### PR TITLE
fix: make PlexDevice.device optional to handle null API responses

### DIFF
--- a/Rivulet/Models/Plex/PlexModels.swift
+++ b/Rivulet/Models/Plex/PlexModels.swift
@@ -27,7 +27,7 @@ struct PlexDevice: Codable, Sendable {
     let productVersion: String
     let platform: String?
     let platformVersion: String?
-    let device: String
+    let device: String?
     let clientIdentifier: String
     let createdAt: String
     let lastSeenAt: String
@@ -66,7 +66,7 @@ struct PlexDevice: Codable, Sendable {
         productVersion = try container.decode(String.self, forKey: .productVersion)
         platform = try container.decodeIfPresent(String.self, forKey: .platform)
         platformVersion = try container.decodeIfPresent(String.self, forKey: .platformVersion)
-        device = try container.decode(String.self, forKey: .device)
+        device = try container.decodeIfPresent(String.self, forKey: .device)
         clientIdentifier = try container.decode(String.self, forKey: .clientIdentifier)
         createdAt = try container.decode(String.self, forKey: .createdAt)
         lastSeenAt = try container.decode(String.self, forKey: .lastSeenAt)

--- a/RivuletTests/PlexDeviceDecodingTests.swift
+++ b/RivuletTests/PlexDeviceDecodingTests.swift
@@ -1,0 +1,110 @@
+//
+//  PlexDeviceDecodingTests.swift
+//  RivuletTests
+//
+//  Tests for PlexDevice JSON decoding edge cases
+//
+
+import XCTest
+@testable import Rivulet
+
+final class PlexDeviceDecodingTests: XCTestCase {
+
+    /// Test that PlexDevice can be decoded when `device` field is null
+    /// Regression test for RIVULET-6 / GitHub Issue #4
+    func testDecodesWithNullDeviceField() throws {
+        let json = """
+        {
+            "name": "Test Server",
+            "product": "Plex Media Server",
+            "productVersion": "1.40.0",
+            "platform": "Linux",
+            "platformVersion": "22.04",
+            "device": null,
+            "clientIdentifier": "abc123",
+            "createdAt": "2024-01-01T00:00:00Z",
+            "lastSeenAt": "2024-01-01T00:00:00Z",
+            "provides": "server",
+            "connections": []
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+
+        // This should not throw - the fix makes `device` optional
+        let device = try decoder.decode(PlexDevice.self, from: json)
+
+        XCTAssertEqual(device.name, "Test Server")
+        XCTAssertEqual(device.provides, "server")
+        XCTAssertNil(device.device)
+    }
+
+    /// Test that PlexDevice still decodes correctly when `device` field is present
+    func testDecodesWithDeviceFieldPresent() throws {
+        let json = """
+        {
+            "name": "Test Server",
+            "product": "Plex Media Server",
+            "productVersion": "1.40.0",
+            "platform": "Linux",
+            "platformVersion": "22.04",
+            "device": "PC",
+            "clientIdentifier": "abc123",
+            "createdAt": "2024-01-01T00:00:00Z",
+            "lastSeenAt": "2024-01-01T00:00:00Z",
+            "provides": "server",
+            "connections": []
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        let device = try decoder.decode(PlexDevice.self, from: json)
+
+        XCTAssertEqual(device.name, "Test Server")
+        XCTAssertEqual(device.device, "PC")
+    }
+
+    /// Test that an array of PlexDevices decodes when one has null device
+    /// This matches the actual failure scenario from Sentry
+    func testDecodesArrayWithMixedDeviceFields() throws {
+        let json = """
+        [
+            {
+                "name": "Server 1",
+                "product": "Plex Media Server",
+                "productVersion": "1.40.0",
+                "platform": "Linux",
+                "platformVersion": "22.04",
+                "device": "NAS",
+                "clientIdentifier": "server1",
+                "createdAt": "2024-01-01T00:00:00Z",
+                "lastSeenAt": "2024-01-01T00:00:00Z",
+                "provides": "server",
+                "connections": []
+            },
+            {
+                "name": "Orphaned Device",
+                "product": "Plex Web",
+                "productVersion": "4.0.0",
+                "platform": null,
+                "platformVersion": null,
+                "device": null,
+                "clientIdentifier": "orphan",
+                "createdAt": "2024-01-01T00:00:00Z",
+                "lastSeenAt": "2024-01-01T00:00:00Z",
+                "provides": "player",
+                "connections": []
+            }
+        ]
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+
+        // Before the fix, this would fail on Index 1 -> device
+        let devices = try decoder.decode([PlexDevice].self, from: json)
+
+        XCTAssertEqual(devices.count, 2)
+        XCTAssertEqual(devices[0].device, "NAS")
+        XCTAssertNil(devices[1].device)
+    }
+}


### PR DESCRIPTION
## Summary
- Make `PlexDevice.device` optional to handle null values from Plex API
- Add regression tests for JSON decoding edge cases

## Problem
The Plex API (`/api/v2/resources`) can return devices where the `device` field is null. This was causing JSON decoding to fail during server discovery, preventing users from connecting to their Plex servers.

**Error**: `Cannot get value of type String -- found null value instead` at coding path `Index 1 → device`

## Related
- Related to #4
- Fixes [RIVULET-6](https://g-studios-xc.sentry.io/issues/RIVULET-6) (41 occurrences, 9 users affected)