### PR TITLE
fix: allow 10.x.x.x home network connections

### DIFF
--- a/Rivulet/Services/Plex/PlexAuthManager.swift
+++ b/Rivulet/Services/Plex/PlexAuthManager.swift
@@ -286,12 +286,12 @@ class PlexAuthManager: ObservableObject {
 
     /// Check if address is a Docker/internal bridge network
     private func isDockerOrInternalAddress(_ address: String) -> Bool {
-        // Docker default bridge networks
+        // Docker default bridge networks (172.17-31.x.x range)
+        // Note: We intentionally do NOT filter 10.x.x.x as these are common home network ranges
         let dockerPrefixes = [
             "172.17.", "172.18.", "172.19.", "172.20.", "172.21.",
             "172.22.", "172.23.", "172.24.", "172.25.", "172.26.",
             "172.27.", "172.28.", "172.29.", "172.30.", "172.31.",
-            "10.0.0.", "10.0.1.",  // Common Docker/container networks
         ]
 
         // Localhost variants (not useful for Apple TV)


### PR DESCRIPTION
## Summary
- Remove 10.0.0.x and 10.0.1.x from the Docker/internal address filter
- These are valid home network ranges that were incorrectly being blocked

## Problem
Users on home networks using 10.0.0.x or 10.0.1.x subnets couldn't connect to their local Plex servers. All local connections were filtered out, leaving only remote/relay connections which may also fail.

Symptoms:
- Auth works, server list appears
- Selecting any server → "Connection Failed. Could not connect to server."

## Fix
Keep the 172.17-31.x.x filter (Docker's default bridge network range) but remove the 10.x.x.x filter since that's a valid home network range.

## Related
- Fixes #3