### PR TITLE
fix: prevent crash from duplicate dictionary keys

### DIFF
--- a/Rivulet/Services/LiveTV/IPTVProvider.swift
+++ b/Rivulet/Services/LiveTV/IPTVProvider.swift
@@ -180,10 +180,12 @@ actor IPTVProvider: LiveTVProvider {
         print("📺 IPTVProvider [\(displayName)]: ✅ Parsed EPG with \(parseResult.programs.count) channel schedules")
 
         // Build unified channel ID -> tvgId mapping
+        // Use uniquingKeysWith to handle duplicate tvgIds (keep first occurrence)
         let tvgIdToUnifiedId = Dictionary(
-            uniqueKeysWithValues: channels.compactMap { channel in
+            channels.compactMap { channel in
                 channel.tvgId.map { ($0, channel.id) }
-            }
+            },
+            uniquingKeysWith: { first, _ in first }
         )
 
         // Convert to UnifiedProgram, mapping by tvgId

--- a/Rivulet/Services/LiveTV/PlexLiveTVProvider.swift
+++ b/Rivulet/Services/LiveTV/PlexLiveTVProvider.swift
@@ -183,12 +183,14 @@ actor PlexLiveTVProvider: LiveTVProvider {
         print("📺 PlexLiveTVProvider: ✅ Fetched EPG for \(guideChannels.count) channels")
 
         // Build unified channel ID lookup
+        // Use uniquingKeysWith to handle duplicate ratingKeys (keep first occurrence)
         let ratingKeyToUnifiedId = Dictionary(
-            uniqueKeysWithValues: channels.map { channel -> (String, String) in
+            channels.map { channel -> (String, String) in
                 let components = channel.id.split(separator: ":")
                 let ratingKey = components.count >= 3 ? String(components.last!) : channel.id
                 return (ratingKey, channel.id)
-            }
+            },
+            uniquingKeysWith: { first, _ in first }
         )
 
         print("📺 PlexLiveTVProvider: Channel lookup keys: \(Array(ratingKeyToUnifiedId.keys))")

--- a/Rivulet/Services/Plex/LibrarySettingsManager.swift
+++ b/Rivulet/Services/Plex/LibrarySettingsManager.swift
@@ -101,7 +101,11 @@ class LibrarySettingsManager: ObservableObject {
     /// - Returns: Libraries sorted by user preference, with unordered ones at the end
     func sortLibraries(_ libraries: [PlexLibrary]) -> [PlexLibrary] {
         // Create a lookup for quick access
-        let libraryByKey = Dictionary(uniqueKeysWithValues: libraries.map { ($0.key, $0) })
+        // Use uniquingKeysWith to handle potential duplicate keys (keep first occurrence)
+        let libraryByKey = Dictionary(
+            libraries.map { ($0.key, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
 
         var result: [PlexLibrary] = []
 


### PR DESCRIPTION
## Summary
- Replace `Dictionary(uniqueKeysWithValues:)` with `Dictionary(_:uniquingKeysWith:)` to handle duplicate keys gracefully
- Fixes fatal crashes when IPTV channels have duplicate `tvgId` values or Plex channels have duplicate `ratingKey` values

## Root Cause
Swift's `Dictionary(uniqueKeysWithValues:)` crashes with a fatal error when given duplicate keys. This was happening in three locations:

1. **IPTVProvider.swift** - Two IPTV channels with the same `tvgId` (e.g., `'#####beosports#####.uk'`)
2. **PlexLiveTVProvider.swift** - Two Plex channels with the same `ratingKey` (e.g., `'1'`)  
3. **LibrarySettingsManager.swift** - Potential duplicate library keys

## Fix
Use `Dictionary(_:uniquingKeysWith:)` which allows specifying how to handle duplicates. We keep the first occurrence:
```swift
Dictionary(items, uniquingKeysWith: { first, _ in first })
```

## Related
- Fixes [RIVULET-Q](https://g-studios-xc.sentry.io/issues/RIVULET-Q) (10 occurrences, 2 users)
- Fixes [RIVULET-N](https://g-studios-xc.sentry.io/issues/RIVULET-N) (9 occurrences, 1 user)
- Related to #8 (TV guide crashes app)