### PR TITLE
fix: prevent watchdog terminations on older Apple TVs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,10 +21,17 @@ body:
     validations:
       required: true
 
-  - type: textarea
-    id: description
+  - type: input
+    id: version
     attributes:
-      label: Describe the bug
-      placeholder: A clear description of what the bug is
+      label: Version
+      description: App version and build number (e.g. 1.0.0 18)
+      placeholder: "1.0.0 18"
     validations:
       required: true
+
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Any additional info
+      placeholder: Any other context about the bug

--- a/Rivulet/Views/LiveTV/ChannelListView.swift
+++ b/Rivulet/Views/LiveTV/ChannelListView.swift
@@ -174,7 +174,7 @@ struct ChannelCard: View {
                     .fill(Color(white: 0.15))
 
                 if let logoURL = channel.logoURL {
-                    AsyncImage(url: logoURL) { phase in
+                    CachedAsyncImage(url: logoURL) { phase in
                         switch phase {
                         case .success(let image):
                             image

--- a/Rivulet/Views/LiveTV/GuideLayoutView.swift
+++ b/Rivulet/Views/LiveTV/GuideLayoutView.swift
@@ -113,7 +113,9 @@ struct GuideLayoutView: View {
                     ScrollViewReader { proxy in
                         ScrollView(.vertical, showsIndicators: false) {
                             ZStack(alignment: .topLeading) {
-                                VStack(spacing: 0) {
+                                // Use LazyVStack to avoid rendering all channels at once
+                                // This prevents memory pressure and focus system overload on older devices
+                                LazyVStack(spacing: 0, pinnedViews: []) {
                                     ForEach(Array(channels.enumerated()), id: \.element.id) { idx, ch in
                                         HStack(spacing: 0) {
                                             ChannelCell(channel: ch, isSelected: idx == focusedRow,
@@ -248,10 +250,10 @@ private struct ChannelCell: View {
 
     var body: some View {
         HStack(spacing: 10) {
-            // Channel logo
+            // Channel logo - use CachedAsyncImage for better memory management
             Group {
                 if let logoURL = channel.logoURL {
-                    AsyncImage(url: logoURL) { phase in
+                    CachedAsyncImage(url: logoURL) { phase in
                         switch phase {
                         case .success(let image):
                             image


### PR DESCRIPTION
## Summary
- Convert `GuideLayoutView` from `VStack` to `LazyVStack` for lazy rendering
- Replace `AsyncImage` with `CachedAsyncImage` in Guide and ChannelList views

## Root Cause
The TV Guide was using a non-lazy `VStack` which rendered **ALL** channels and programs at once. On older devices like AppleTV5,3 (2GB RAM, 2 cores), this caused:

1. **Memory pressure** - hundreds of views created simultaneously
2. **Focus system overload** - deep view traversal blocking main thread (3-5 seconds)
3. **Watchdog termination** - OS kills app after prolonged hangs

Stack trace showed `MultiViewResponder.visit` being called 15+ times in deep recursion during focus updates.

## Fix
- `LazyVStack` only renders visible rows, dramatically reducing memory and CPU usage
- `CachedAsyncImage` provides better memory management for channel logos

## Affected Devices
Primarily impacts older Apple TVs with limited RAM:
- AppleTV5,3 (4th gen, 2015) - 2GB RAM
- AppleTV6,2 (4K 1st gen, 2017) - 3GB RAM

## Related
- Fixes [RIVULET-B](https://g-studios-xc.sentry.io/issues/RIVULET-B) (25 occurrences, 7 users) - Watchdog termination
- Related to [RIVULET-M](https://g-studios-xc.sentry.io/issues/RIVULET-M) (9 occurrences) - App hang 4.1-4.9s
- Related to [RIVULET-11](https://g-studios-xc.sentry.io/issues/RIVULET-11) - App hang 3.8-4.6s