### PR TITLE
fix: allow connection when Plex 'Require Secure Connections' is enabled

### DIFF
--- a/Rivulet/Services/Plex/PlexAuthManager.swift
+++ b/Rivulet/Services/Plex/PlexAuthManager.swift
@@ -208,9 +208,10 @@ class PlexAuthManager: ObservableObject {
             } else {
                 print("🔐 PlexAuthManager: ❌ Connection failed: \(connection.uri)")
 
-                // If HTTP failed on a non-local connection, try HTTPS and plex.direct
-                if !connection.local && connection.protocolType == "http" {
-                    // First try direct HTTPS - this will fail with cert error but we can extract the correct hash
+                // If HTTP failed, try HTTPS fallback
+                // This handles "Require Secure Connections" setting on Plex servers
+                // For both local and remote connections
+                if connection.protocolType == "http" {
                     let httpsURI = connection.uri.replacingOccurrences(of: "http://", with: "https://")
                     print("🔐 PlexAuthManager: Trying HTTPS fallback: \(httpsURI)...")
                     let (success, certHash) = await testConnectionWithCertExtraction(httpsURI, serverToken: tokenToUse)
@@ -221,6 +222,7 @@ class PlexAuthManager: ObservableObject {
                         print("🔐 PlexAuthManager: ❌ HTTPS fallback failed: \(httpsURI)")
 
                         // If we extracted a plex.direct hash from the certificate, try that
+                        // This provides a valid SSL cert for the connection
                         if let hash = certHash {
                             let plexDirectURI = buildPlexDirectURL(
                                 address: connection.address,


### PR DESCRIPTION
## Summary
- Try HTTPS fallback for **local** connections when HTTP fails
- Previously, HTTPS fallback only applied to remote connections
- This allows users to keep "Require Secure Connections" enabled in Plex settings

## Problem
When Plex server has "Require Secure Connections" enabled, it rejects HTTP connections. The app was trying HTTP first for local connections (to avoid self-signed cert issues), but when HTTP failed, it wasn't trying HTTPS as a fallback - it just moved on to the next connection or relay.

This forced users to disable "Require Secure Connections" in their Plex settings to use the app.

## Solution
Now the connection flow for all connections (local and remote) is:
1. Try primary connection (HTTP for local, HTTPS for remote)
2. If HTTP fails → try HTTPS to same address (handles "Require Secure Connections")
3. If HTTPS fails with cert error → extract plex.direct hash from cert and try that
4. If all fail → try relay as last resort

The self-signed certificate handling was already in place via `PlexCertificateDelegate`, so HTTPS connections to local servers work fine.

## Related
- Fixes #23