### PR TITLE
feat: personalized recommendations via TMDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Package.resolved
 
 # Worker deps
 tmdb-proxy/node_modules
+tmdb-proxy/.wrangler
 
 # CocoaPods
 Pods/

--- a/Rivulet/Config/TMDBConfig.swift
+++ b/Rivulet/Config/TMDBConfig.swift
@@ -1,0 +1,16 @@
+//
+//  TMDBConfig.swift
+//  Rivulet
+//
+//  Centralized configuration for TMDB proxy access.
+//
+
+import Foundation
+
+enum TMDBConfig {
+    /// Proxy base URL (Cloudflare Worker) that forwards TMDB requests with caching.
+    static let proxyBaseURL = URL(string: "https://tmdb-proxy.baingurley.workers.dev")!
+
+    /// Cache TTL for TMDB responses when stored locally (in seconds).
+    static let localCacheTTL: TimeInterval = 60 * 60 * 24 * 7  // 7 days
+}

--- a/Rivulet/Services/Recommendations/PersonalizedRecommendationService.swift
+++ b/Rivulet/Services/Recommendations/PersonalizedRecommendationService.swift
@@ -1,0 +1,273 @@
+//
+//  PersonalizedRecommendationService.swift
+//  Rivulet
+//
+//  Generates personalized recommendations using Plex watch signals + TMDB proxy data.
+//  Scope: movies only for now to keep runtime reasonable; can extend to shows later.
+//
+
+import Foundation
+
+enum RecommendationContentType: String, Codable {
+    case movies
+    case shows
+    case moviesAndShows
+}
+
+private struct RecommendationResult: Codable {
+    let generatedAt: Date
+    let items: [PlexMetadata]
+    let contentType: RecommendationContentType
+    let libraryKey: String?
+    let serverURL: String
+}
+
+private struct FeatureProfile {
+    var keywords: [String: Double] = [:]
+    var genres: [String: Double] = [:]
+    var cast: [String: Double] = [:]
+    var directors: [String: Double] = [:]
+
+    var maxKeyword: Double { keywords.values.max() ?? 0 }
+    var maxGenre: Double { genres.values.max() ?? 0 }
+    var maxCast: Double { cast.values.max() ?? 0 }
+    var maxDirector: Double { directors.values.max() ?? 0 }
+
+    mutating func add(features: TMDBItemFeatures, weight: Double) {
+        for tag in features.keywords {
+            keywords[tag, default: 0] += weight
+        }
+        for tag in features.genres {
+            genres[tag, default: 0] += weight
+        }
+        for name in features.cast {
+            cast[name, default: 0] += weight
+        }
+        for name in features.directors {
+            directors[name, default: 0] += weight
+        }
+    }
+}
+
+actor PersonalizedRecommendationService {
+    static let shared = PersonalizedRecommendationService()
+
+    private let tmdbClient = TMDBClient.shared
+    private let networkManager = PlexNetworkManager.shared
+    private let dataStore = PlexDataStore.shared
+    private let authManager = PlexAuthManager.shared
+
+    private struct CacheKey: Hashable {
+        let contentType: RecommendationContentType
+        let libraryKey: String?
+        let serverURL: String
+    }
+
+    private var cachedResults: [CacheKey: RecommendationResult] = [:]
+    private let cacheTTL: TimeInterval = 60 * 60 * 12  // 12 hours
+    private let maxItemsPerLibrary = 200
+    private let maxWatchedForProfile = 120
+    private let maxRecommendations = 40
+    private let minTMDBRating = 5.0
+    private let minTMDBVoteCount = 50
+
+    func recommendations(
+        forceRefresh: Bool = false,
+        contentType: RecommendationContentType = .moviesAndShows,
+        libraryKey: String? = nil
+    ) async throws -> [PlexMetadata] {
+        let auth = await MainActor.run { (authManager.selectedServerURL, authManager.selectedServerToken) }
+        guard let serverURL = auth.0 else {
+            throw NSError(domain: "PlexAuth", code: 1, userInfo: [NSLocalizedDescriptionKey: "Not authenticated with Plex"])
+        }
+
+        let key = CacheKey(contentType: contentType, libraryKey: libraryKey, serverURL: serverURL)
+
+        if !forceRefresh, let cached = cachedResults[key] {
+            if Date().timeIntervalSince(cached.generatedAt) < cacheTTL {
+                return cached.items
+            }
+        }
+
+        let items = try await computeRecommendations(contentType: contentType, libraryKey: libraryKey, serverURL: serverURL)
+        cachedResults[key] = RecommendationResult(
+            generatedAt: Date(),
+            items: items,
+            contentType: contentType,
+            libraryKey: libraryKey,
+            serverURL: serverURL
+        )
+        return items
+    }
+
+    // MARK: - Core logic
+
+    private func computeRecommendations(contentType: RecommendationContentType, libraryKey: String?, serverURL: String) async throws -> [PlexMetadata] {
+        let authToken = await MainActor.run { authManager.selectedServerToken }
+        guard let token = authToken else {
+            throw NSError(domain: "PlexAuth", code: 1, userInfo: [NSLocalizedDescriptionKey: "Not authenticated with Plex"])
+        }
+
+        await dataStore.loadLibrariesIfNeeded()
+        let visibleLibraries = await MainActor.run { dataStore.visibleLibraries }
+
+        // Determine target libraries: specific library when provided, else all visible video libraries
+        let targetLibraries: [PlexLibrary] = {
+            if let libraryKey {
+                return visibleLibraries.filter { $0.key == libraryKey }
+            }
+            return visibleLibraries.filter { $0.isVideoLibrary }
+        }()
+        guard !targetLibraries.isEmpty else { return [] }
+
+        var libraryItems: [PlexMetadata] = []
+        for library in targetLibraries {
+            switch contentType {
+            case .movies where library.type != "movie":
+                continue
+            case .shows where library.type != "show":
+                continue
+            default:
+                break
+            }
+
+            // Limit fetch size to keep runtime in check
+            let result = try await networkManager.getLibraryItemsWithTotal(
+                serverURL: serverURL,
+                authToken: token,
+                sectionId: library.key,
+                start: 0,
+                size: maxItemsPerLibrary
+            )
+            let filtered: [PlexMetadata]
+            switch contentType {
+            case .movies:
+                filtered = result.items.filter { $0.type == "movie" }
+            case .shows:
+                filtered = result.items.filter { $0.type == "show" }
+            case .moviesAndShows:
+                filtered = result.items.filter { $0.type == "movie" || $0.type == "show" }
+            }
+            libraryItems.append(contentsOf: filtered)
+        }
+
+        if libraryItems.isEmpty { return [] }
+
+        // Split watched/unwatched
+        let watchedItems = libraryItems.filter { ($0.viewCount ?? 0) > 0 || $0.lastViewedAt != nil }
+        let unwatchedItems = libraryItems.filter { ($0.viewCount ?? 0) == 0 }
+
+        // Build profile from most recently watched items
+        let recentWatched = watchedItems.sorted { ($0.lastViewedAt ?? 0) > ($1.lastViewedAt ?? 0) }
+        let watchedSample = Array(recentWatched.prefix(maxWatchedForProfile))
+        var profile = FeatureProfile()
+
+        for item in watchedSample {
+            let features = await buildFeatures(for: item)
+            let weight = recencyWeight(lastViewedAt: item.lastViewedAt) * rewatchBoost(viewCount: item.viewCount)
+            profile.add(features: features, weight: weight)
+        }
+
+        var scored: [(PlexMetadata, Double)] = []
+        for item in unwatchedItems {
+            let features = await buildFeatures(for: item)
+            let score = score(features: features, profile: profile, metadata: item)
+            scored.append((item, score))
+        }
+
+        let sorted = scored
+            .filter { !$0.0.isWatched && $0.1 > 0 }
+            .sorted { $0.1 > $1.1 }
+            .prefix(maxRecommendations)
+            .map { $0.0 }
+
+        return Array(sorted)
+    }
+
+    // MARK: - Feature helpers
+
+    private func buildFeatures(for item: PlexMetadata) async -> TMDBItemFeatures {
+        var features = TMDBItemFeatures(
+            keywords: [],
+            cast: item.castNames,
+            directors: item.directorNames,
+            genres: item.genreTags,
+            voteAverage: nil,
+            voteCount: nil
+        )
+
+        if let tmdbId = item.tmdbId {
+            if let tmdbFeatures = await tmdbClient.fetchFeatures(tmdbId: tmdbId, type: item.tmdbMediaType) {
+                features.merge(from: tmdbFeatures)
+            }
+        }
+
+        return features.normalized()
+    }
+
+    private func recencyWeight(lastViewedAt: Int?) -> Double {
+        guard let ts = lastViewedAt else { return 0.6 }
+        let days = (Date().timeIntervalSince1970 - Double(ts)) / (60 * 60 * 24)
+        switch days {
+        case ..<30: return 1.0
+        case ..<90: return 0.8
+        case ..<180: return 0.6
+        default: return 0.4
+        }
+    }
+
+    private func rewatchBoost(viewCount: Int?) -> Double {
+        let count = Double(viewCount ?? 0)
+        if count <= 1 { return 1.0 }
+        return min(1.0 + (count * 0.1), 1.5)
+    }
+
+    private func normalizedScore(tags: [String], counts: [String: Double], maxCount: Double) -> Double {
+        guard !tags.isEmpty, maxCount > 0 else { return 0 }
+        let sum = tags.reduce(0.0) { partial, tag in
+            partial + (counts[tag, default: 0])
+        }
+        return sum / (maxCount * Double(tags.count))
+    }
+
+    private func score(features: TMDBItemFeatures, profile: FeatureProfile, metadata: PlexMetadata) -> Double {
+        // Quality filters
+        if let voteAvg = features.voteAverage, voteAvg < minTMDBRating {
+            return 0
+        }
+        if let voteCount = features.voteCount, voteCount < minTMDBVoteCount {
+            return 0
+        }
+
+        let keywordScore = normalizedScore(tags: features.keywords, counts: profile.keywords, maxCount: profile.maxKeyword)
+        let genreScore = normalizedScore(tags: features.genres, counts: profile.genres, maxCount: profile.maxGenre)
+        let castScore = normalizedScore(tags: features.cast, counts: profile.cast, maxCount: profile.maxCast)
+        let directorScore = normalizedScore(tags: features.directors, counts: profile.directors, maxCount: profile.maxDirector)
+
+        // Redistribute weights if signals are missing (weights similar to upstream)
+        var weights: [Double] = []
+        var signals: [Double] = []
+
+        let components: [(Double, Double)] = [
+            (0.5, keywordScore),
+            (0.25, genreScore),
+            (0.20, castScore),
+            (0.05, directorScore)
+        ]
+
+        var totalWeight: Double = 0
+        for (w, s) in components where s > 0 {
+            weights.append(w)
+            signals.append(s)
+            totalWeight += w
+        }
+
+        let redistributed = zip(weights, signals).reduce(0.0) { partial, pair in
+            let (w, s) = pair
+            return partial + (s * (w / max(totalWeight, 0.0001)))
+        }
+
+        let ratingBoost = ((metadata.audienceRating ?? metadata.rating ?? metadata.userRating ?? 0) / 10.0) * 0.1
+        return redistributed + ratingBoost
+    }
+}

--- a/Rivulet/Services/TMDB/TMDBClient.swift
+++ b/Rivulet/Services/TMDB/TMDBClient.swift
@@ -1,0 +1,187 @@
+//
+//  TMDBClient.swift
+//  Rivulet
+//
+//  Lightweight TMDB client that talks to the Cloudflare Worker proxy.
+//  Includes simple on-disk caching to reduce requests and work offline.
+//
+
+import Foundation
+
+enum TMDBMediaType: String {
+    case movie
+    case tv
+}
+
+struct TMDBKeyword: Codable {
+    let id: Int?
+    let name: String?
+}
+
+struct TMDBGenre: Codable {
+    let id: Int?
+    let name: String?
+}
+
+struct TMDBDetails: Codable {
+    let genres: [TMDBGenre]?
+    let voteAverage: Double?
+    let voteCount: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case genres
+        case voteAverage = "vote_average"
+        case voteCount = "vote_count"
+    }
+}
+
+struct TMDBCredit: Codable {
+    let id: Int?
+    let name: String?
+    let job: String?
+    let department: String?
+    let character: String?
+}
+
+private struct TMDBKeywordsResponse: Codable {
+    let keywords: [TMDBKeyword]?
+    let results: [TMDBKeyword]?
+
+    var allKeywords: [TMDBKeyword] {
+        if let keywords { return keywords }
+        if let results { return results }
+        return []
+    }
+}
+
+private struct TMDBCreditsResponse: Codable {
+    let cast: [TMDBCredit]?
+    let crew: [TMDBCredit]?
+}
+
+struct TMDBItemFeatures: Codable {
+    var keywords: [String]
+    var cast: [String]
+    var directors: [String]
+    var genres: [String]
+    var voteAverage: Double?
+    var voteCount: Int?
+
+    mutating func merge(from other: TMDBItemFeatures) {
+        keywords.append(contentsOf: other.keywords)
+        cast.append(contentsOf: other.cast)
+        directors.append(contentsOf: other.directors)
+        genres.append(contentsOf: other.genres)
+    }
+
+    func normalized() -> TMDBItemFeatures {
+        TMDBItemFeatures(
+            keywords: Array(Set(keywords)),
+            cast: Array(Set(cast)),
+            directors: Array(Set(directors)),
+            genres: Array(Set(genres)),
+            voteAverage: voteAverage,
+            voteCount: voteCount
+        )
+    }
+}
+
+private struct CachedFeatures: Codable {
+    let generatedAt: Date
+    let features: TMDBItemFeatures
+}
+
+final class TMDBClient: @unchecked Sendable {
+    static let shared = TMDBClient()
+
+    private let session: URLSession
+    private let cacheDirectory: URL
+    private let cacheTTL = TMDBConfig.localCacheTTL
+
+    private init() {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 15
+        config.timeoutIntervalForResource = 30
+        session = URLSession(configuration: config)
+
+        let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first ?? URL(fileURLWithPath: NSTemporaryDirectory())
+        cacheDirectory = caches.appendingPathComponent("TMDBCache", isDirectory: true)
+        try? FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
+    }
+
+    func fetchFeatures(tmdbId: Int, type: TMDBMediaType) async -> TMDBItemFeatures? {
+        if let cached = loadCachedFeatures(tmdbId: tmdbId, type: type) {
+            return cached
+        }
+
+        do {
+            async let keywordsResponse: TMDBKeywordsResponse = request(endpoint: "tmdb/keywords/\(tmdbId)", type: type)
+            async let creditsResponse: TMDBCreditsResponse = request(endpoint: "tmdb/credits/\(tmdbId)", type: type)
+            async let detailsResponse: TMDBDetails = request(endpoint: "tmdb/details/\(tmdbId)", type: type)
+
+            let (keywords, credits, details) = try await (keywordsResponse, creditsResponse, detailsResponse)
+
+            let features = TMDBItemFeatures(
+                keywords: keywords.allKeywords.compactMap { $0.name?.lowercased() },
+                cast: (credits.cast ?? []).prefix(8).compactMap { $0.name?.lowercased() },
+                directors: (credits.crew ?? []).filter { $0.job?.lowercased() == "director" }.prefix(4).compactMap { $0.name?.lowercased() },
+                genres: (details.genres ?? []).compactMap { $0.name?.lowercased() },
+                voteAverage: details.voteAverage,
+                voteCount: details.voteCount
+            ).normalized()
+
+            saveCachedFeatures(features, tmdbId: tmdbId, type: type)
+            return features
+        } catch {
+            return nil
+        }
+    }
+
+    // MARK: - Networking
+
+    private func request<T: Decodable>(endpoint: String, type: TMDBMediaType) async throws -> T {
+        guard var url = URL(string: endpoint, relativeTo: TMDBConfig.proxyBaseURL) else {
+            throw URLError(.badURL)
+        }
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
+        components?.queryItems = [
+            URLQueryItem(name: "type", value: type.rawValue)
+        ]
+        guard let finalURL = components?.url else {
+            throw URLError(.badURL)
+        }
+
+        var request = URLRequest(url: finalURL)
+        request.httpMethod = "GET"
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    // MARK: - Local Cache
+
+    private func cacheURL(tmdbId: Int, type: TMDBMediaType) -> URL {
+        cacheDirectory.appendingPathComponent("\(type.rawValue)_\(tmdbId).json")
+    }
+
+    private func loadCachedFeatures(tmdbId: Int, type: TMDBMediaType) -> TMDBItemFeatures? {
+        let url = cacheURL(tmdbId: tmdbId, type: type)
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        guard let cached = try? JSONDecoder().decode(CachedFeatures.self, from: data) else { return nil }
+        let age = Date().timeIntervalSince(cached.generatedAt)
+        guard age < cacheTTL else { return nil }
+        return cached.features
+    }
+
+    private func saveCachedFeatures(_ features: TMDBItemFeatures, tmdbId: Int, type: TMDBMediaType) {
+        let cached = CachedFeatures(generatedAt: Date(), features: features)
+        guard let data = try? JSONEncoder().encode(cached) else { return }
+        let url = cacheURL(tmdbId: tmdbId, type: type)
+        try? data.write(to: url, options: [.atomic])
+    }
+}

--- a/Rivulet/Views/Settings/SettingsView.swift
+++ b/Rivulet/Views/Settings/SettingsView.swift
@@ -41,6 +41,7 @@ struct SettingsView: View {
     @AppStorage("showHomeHero") private var showHomeHero = false
     @AppStorage("showLibraryHero") private var showLibraryHero = false
     @AppStorage("showLibraryRecommendations") private var showLibraryRecommendations = true
+    @AppStorage("enablePersonalizedRecommendations") private var enablePersonalizedRecommendations = false
     @AppStorage("liveTVLayout") private var liveTVLayoutRaw = LiveTVLayout.guide.rawValue
     @AppStorage("confirmExitMultiview") private var confirmExitMultiview = true
     @AppStorage("allowFourStreams") private var allowFourStreams = false
@@ -130,6 +131,14 @@ struct SettingsView: View {
                                 title: "Discovery Rows",
                                 subtitle: "Top Rated, Rediscover, and similar",
                                 isOn: $showLibraryRecommendations
+                            )
+
+                            SettingsToggleRow(
+                                icon: "person.3",
+                                iconColor: .mint,
+                                title: "Personalized Recommendations",
+                                subtitle: "Use TMDB + watch history to surface unwatched picks",
+                                isOn: $enablePersonalizedRecommendations
                             )
                         }
 


### PR DESCRIPTION
## Summary
- Add in-app personalized recommendations based on viewing history
- Uses TMDB API for recommendation data
- Integrates with PlexHomeView and PlexLibraryView
- Based on work from https://github.com/OrchestratedChaos/plex-recommender

## Changes
- Add `TMDBConfig` and `TMDBClient` for API integration
- Add `PersonalizedRecommendationService` for recommendation logic
- Add recommendations row to home and library views
- Add settings toggle for recommendations