### PR TITLE
fix RIVULET-16: prevent URL path duplication for Dispatcharr sources

### DIFF
--- a/Rivulet/Services/IPTV/DispatcharrService.swift
+++ b/Rivulet/Services/IPTV/DispatcharrService.swift
@@ -43,6 +43,15 @@ actor DispatcharrService {
             cleanedURL = "http://\(cleanedURL)"
         }
 
+        // Strip /output/m3u or /output/epg paths if user pasted a full endpoint URL
+        // This prevents URL duplication when we append these paths later
+        // Handles: /output/m3u, /output/m3u/, /output/m3u/ProfileName, etc.
+        if let range = cleanedURL.range(of: "/output/m3u", options: .caseInsensitive) {
+            cleanedURL = String(cleanedURL[..<range.lowerBound])
+        } else if let range = cleanedURL.range(of: "/output/epg", options: .caseInsensitive) {
+            cleanedURL = String(cleanedURL[..<range.lowerBound])
+        }
+
         guard let url = URL(string: cleanedURL) else {
             return nil
         }

--- a/Rivulet/Services/LiveTV/IPTVProvider.swift
+++ b/Rivulet/Services/LiveTV/IPTVProvider.swift
@@ -45,10 +45,29 @@ actor IPTVProvider: LiveTVProvider {
         self.sourceType = .dispatcharr
         self.sourceId = sourceId
         self.displayName = displayName
-        self.baseURL = dispatcharrURL
-        self.dispatcharrService = DispatcharrService(baseURL: dispatcharrURL)
-        self.m3uURL = dispatcharrURL.appendingPathComponent("output/m3u")
-        self.epgURL = dispatcharrURL.appendingPathComponent("output/epg")
+
+        // Clean the URL in case it already contains /output/m3u or /output/epg
+        // This handles URLs that were saved before the cleanup was added
+        let cleanedURL = Self.cleanDispatcharrURL(dispatcharrURL)
+
+        self.baseURL = cleanedURL
+        self.dispatcharrService = DispatcharrService(baseURL: cleanedURL)
+        self.m3uURL = cleanedURL.appendingPathComponent("output/m3u")
+        self.epgURL = cleanedURL.appendingPathComponent("output/epg")
+    }
+
+    /// Clean a Dispatcharr URL by removing /output/m3u or /output/epg paths
+    private static func cleanDispatcharrURL(_ url: URL) -> URL {
+        var urlString = url.absoluteString
+
+        // Strip /output/m3u or /output/epg paths if present
+        if let range = urlString.range(of: "/output/m3u", options: .caseInsensitive) {
+            urlString = String(urlString[..<range.lowerBound])
+        } else if let range = urlString.range(of: "/output/epg", options: .caseInsensitive) {
+            urlString = String(urlString[..<range.lowerBound])
+        }
+
+        return URL(string: urlString) ?? url
     }
 
     /// Initialize for generic M3U source


### PR DESCRIPTION
## Summary
- Fix URL path duplication when building stream URLs for Dispatcharr IPTV sources

## Problem
Dispatcharr channel URLs were being double-prefixed, causing 404 errors when attempting to play IPTV streams.

Fixes RIVULET-16