### PR TITLE
feat: add AVPlayer for all videos option with direct play support

### DIFF
--- a/Rivulet/Views/Settings/SettingsView.swift
+++ b/Rivulet/Views/Settings/SettingsView.swift
@@ -149,6 +149,7 @@ struct SettingsView: View {
     @AppStorage("autoplayCountdown") private var autoplayCountdownRaw = AutoplayCountdown.fiveSeconds.rawValue
     @AppStorage("showMarkersOnScrubber") private var showMarkersOnScrubber = true
     @AppStorage("useAVPlayerForDolbyVision") private var useAVPlayerForDolbyVision = false
+    @AppStorage("useAVPlayerForAllVideos") private var useAVPlayerForAllVideos = false
     @Environment(\.focusScopeManager) private var focusScopeManager
     @Environment(\.nestedNavigationState) private var nestedNavState
     #if os(tvOS)
@@ -351,6 +352,14 @@ struct SettingsView: View {
                                 title: "Use AVPlayer for Dolby Vision",
                                 subtitle: "DV Profile 5/8 only. Profile 7 (MKV remux) requires MPV",
                                 isOn: $useAVPlayerForDolbyVision
+                            )
+
+                            SettingsToggleRow(
+                                icon: "play.rectangle",
+                                iconColor: .blue,
+                                title: "Use AVPlayer for All Videos",
+                                subtitle: "Falls back to MPV if needed",
+                                isOn: $useAVPlayerForAllVideos
                             )
                         }
 


### PR DESCRIPTION
## Summary
- Add "Use AVPlayer for All Videos" setting in Playback section
- Enable true direct play for compatible files (zero server processing)
- Fall back to HLS remux for incompatible sources

## How It Works
```
AVPlayer selected?
├── Yes → Direct-play compatible?
│   ├── Yes → Raw file stream (zero server work)
│   └── No → HLS remux (handles MKV, DTS, codec tags)
│       └── AVPlayer fails? → Fallback to MPV
└── No → Use MPV
```

## Direct Play Compatibility
Files are direct-play compatible when:
- Container: mp4, mov, m4v
- Video: h264 or hevc (without dvhe/hev1 codec tags)
- Audio: aac, ac3, or eac3

Everything else (MKV, DTS, TrueHD, bad codec tags) uses HLS remux.

## Benefits
- Better AirPlay, HomePod, and iPhone remote integration
- Zero server load for compatible MP4 files
- Automatic fallback ensures playback always works

Closes #45