### PR TITLE
feat: add sidebar font size option (#34)

### DIFF
--- a/Rivulet.xcodeproj/xcuserdata/bain.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Rivulet.xcodeproj/xcuserdata/bain.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -12,7 +12,7 @@
 		<key>TopShelfExtension.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>2</integer>
 		</dict>
 	</dict>
 	<key>SuppressBuildableAutocreation</key>

--- a/Rivulet/Views/Settings/SettingsView.swift
+++ b/Rivulet/Views/Settings/SettingsView.swift
@@ -34,6 +34,30 @@ enum AutoplayCountdown: Int, CaseIterable, CustomStringConvertible {
     }
 }
 
+// MARK: - Sidebar Font Size
+
+enum SidebarFontSize: String, CaseIterable, CustomStringConvertible {
+    case normal = "normal"
+    case large = "large"
+    case extraLarge = "extraLarge"
+
+    var description: String {
+        switch self {
+        case .normal: return "Normal"
+        case .large: return "Large"
+        case .extraLarge: return "Extra Large"
+        }
+    }
+
+    var scale: CGFloat {
+        switch self {
+        case .normal: return 1.0
+        case .large: return 1.25
+        case .extraLarge: return 1.5
+        }
+    }
+}
+
 // MARK: - Language Option
 
 enum LanguageOption: String, CaseIterable, CustomStringConvertible {
@@ -198,6 +222,7 @@ struct SettingsView: View {
     @AppStorage("showMarkersOnScrubber") private var showMarkersOnScrubber = true
     @AppStorage("useAVPlayerForDolbyVision") private var useAVPlayerForDolbyVision = false
     @AppStorage("useAVPlayerForAllVideos") private var useAVPlayerForAllVideos = false
+    @AppStorage("sidebarFontSize") private var sidebarFontSizeRaw = SidebarFontSize.normal.rawValue
     @Environment(\.focusScopeManager) private var focusScopeManager
     @Environment(\.nestedNavigationState) private var nestedNavState
     #if os(tvOS)
@@ -252,6 +277,13 @@ struct SettingsView: View {
         )
     }
 
+    private var sidebarFontSize: Binding<SidebarFontSize> {
+        Binding(
+            get: { SidebarFontSize(rawValue: sidebarFontSizeRaw) ?? .normal },
+            set: { sidebarFontSizeRaw = $0.rawValue }
+        )
+    }
+
     private var appVersion: String {
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
         let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
@@ -282,6 +314,15 @@ struct SettingsView: View {
                                     navigationPath.append(SettingsDestination.libraries)
                                 },
                                 focusTrigger: focusTrigger  // First row gets focus
+                            )
+
+                            SettingsListPickerRow(
+                                icon: "textformat.size",
+                                iconColor: .orange,
+                                title: "Sidebar Font Size",
+                                subtitle: "Menu text size",
+                                selection: sidebarFontSize,
+                                options: SidebarFontSize.allCases
                             )
 
                             SettingsToggleRow(
@@ -405,8 +446,8 @@ struct SettingsView: View {
                             SettingsToggleRow(
                                 icon: "play.rectangle",
                                 iconColor: .blue,
-                                title: "Use AVPlayer for All Videos",
-                                subtitle: "Falls back to MPV if needed",
+                                title: "Use AVPlayer for All Videos (more experimental than the rest)",
+                                subtitle: "Will probably remux a lot. Falls back to MPV if needed",
                                 isOn: $useAVPlayerForAllVideos
                             )
                         }

--- a/Rivulet/Views/TVNavigation/SidebarComponents.swift
+++ b/Rivulet/Views/TVNavigation/SidebarComponents.swift
@@ -17,6 +17,7 @@ struct FocusableSidebarRow: View {
     let title: String
     let isSelected: Bool
     let onSelect: () -> Void
+    var fontScale: CGFloat = 1.0
 
     @FocusState.Binding var focusedItem: String?
 
@@ -24,13 +25,13 @@ struct FocusableSidebarRow: View {
         Button {
             onSelect()
         } label: {
-            HStack(spacing: 14) {
+            HStack(spacing: 14 * fontScale) {
                 Image(systemName: icon)
-                    .font(.system(size: 22, weight: .medium))
-                    .frame(width: 26)
+                    .font(.system(size: 22 * fontScale, weight: .medium))
+                    .frame(width: 26 * fontScale)
 
                 Text(title)
-                    .font(.system(size: 21, weight: isSelected ? .semibold : .regular))
+                    .font(.system(size: 21 * fontScale, weight: isSelected ? .semibold : .regular))
                     .lineLimit(1)
 
                 Spacer(minLength: 4)
@@ -38,13 +39,13 @@ struct FocusableSidebarRow: View {
                 if isSelected {
                     Circle()
                         .fill(.white)
-                        .frame(width: 6, height: 6)
+                        .frame(width: 6 * fontScale, height: 6 * fontScale)
                 }
             }
             .foregroundStyle(.white.opacity(focusedItem == id || isSelected ? 1.0 : 0.6))
             .padding(.leading, 16)
             .padding(.trailing, 12)
-            .padding(.vertical, 13)
+            .padding(.vertical, 13 * fontScale)
             .background(
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
                     .fill(focusedItem == id ? .white.opacity(0.15) : .clear)

--- a/Rivulet/Views/TVNavigation/TVSidebarView.swift
+++ b/Rivulet/Views/TVNavigation/TVSidebarView.swift
@@ -17,6 +17,7 @@ struct TVSidebarView: View {
     @StateObject private var focusScopeManager = FocusScopeManager()
     @StateObject private var deepLinkHandler = DeepLinkHandler.shared
     @AppStorage("combineLiveTVSources") private var combineLiveTVSources = true
+    @AppStorage("sidebarFontSize") private var sidebarFontSizeRaw = SidebarFontSize.normal.rawValue
     @State private var selectedDestination: TVDestination = .home
     @State private var selectedLibraryKey: String?
     @State private var selectedLiveTVSourceId: String?  // nil = all sources, non-nil = specific source
@@ -31,6 +32,10 @@ struct TVSidebarView: View {
     }
 
     private let sidebarWidth: CGFloat = 340
+
+    private var fontScale: CGFloat {
+        (SidebarFontSize(rawValue: sidebarFontSizeRaw) ?? .normal).scale
+    }
 
     var body: some View {
         ZStack {
@@ -193,11 +198,11 @@ struct TVSidebarView: View {
     private var sidebarContent: some View {
         VStack(alignment: .leading, spacing: 0) {
             // App branding
-            HStack(spacing: 14) {
+            HStack(spacing: 14 * fontScale) {
                 Image(systemName: "play.rectangle.fill")
-                    .font(.system(size: 30, weight: .semibold))
+                    .font(.system(size: 30 * fontScale, weight: .semibold))
                 Text("Rivulet")
-                    .font(.system(size: 34, weight: .bold))
+                    .font(.system(size: 34 * fontScale, weight: .bold))
             }
             .foregroundStyle(.white)
             .padding(.top, 50)
@@ -216,6 +221,7 @@ struct TVSidebarView: View {
                                 title: "Search",
                                 isSelected: selectedDestination == .search,
                                 onSelect: { queueNavigation(destination: .search, libraryKey: nil) },
+                                fontScale: fontScale,
                                 focusedItem: $sidebarFocusedItem
                             )
 
@@ -226,6 +232,7 @@ struct TVSidebarView: View {
                                 title: "Home",
                                 isSelected: selectedDestination == .home && selectedLibraryKey == nil,
                                 onSelect: { queueNavigation(destination: .home, libraryKey: nil) },
+                                fontScale: fontScale,
                                 focusedItem: $sidebarFocusedItem
                             )
 
@@ -240,6 +247,7 @@ struct TVSidebarView: View {
                                         title: library.title,
                                         isSelected: selectedLibraryKey == library.key,
                                         onSelect: { queueNavigation(destination: .home, libraryKey: library.key) },
+                                        fontScale: fontScale,
                                         focusedItem: $sidebarFocusedItem
                                     )
                                 }
@@ -250,7 +258,7 @@ struct TVSidebarView: View {
                                     ProgressView()
                                         .tint(.white.opacity(0.5))
                                     Text("Loading...")
-                                        .font(.system(size: 17))
+                                        .font(.system(size: 17 * fontScale))
                                         .foregroundStyle(.white.opacity(0.5))
                                 }
                                 .padding(.horizontal, 32)
@@ -269,6 +277,7 @@ struct TVSidebarView: View {
                                         title: "Channels",
                                         isSelected: selectedDestination == .liveTV && selectedLiveTVSourceId == nil,
                                         onSelect: { queueLiveTVNavigation(sourceId: nil) },
+                                        fontScale: fontScale,
                                         focusedItem: $sidebarFocusedItem
                                     )
                                 } else {
@@ -280,6 +289,7 @@ struct TVSidebarView: View {
                                             title: source.displayName.replacingOccurrences(of: " Live TV", with: ""),
                                             isSelected: selectedDestination == .liveTV && selectedLiveTVSourceId == source.id,
                                             onSelect: { queueLiveTVNavigation(sourceId: source.id) },
+                                            fontScale: fontScale,
                                             focusedItem: $sidebarFocusedItem
                                         )
                                     }
@@ -300,6 +310,7 @@ struct TVSidebarView: View {
                                 title: "Settings",
                                 isSelected: selectedDestination == .settings,
                                 onSelect: { queueNavigation(destination: .settings, libraryKey: nil) },
+                                fontScale: fontScale,
                                 focusedItem: $sidebarFocusedItem
                             )
                         }
@@ -349,8 +360,8 @@ struct TVSidebarView: View {
 
     private func sectionHeader(_ title: String) -> some View {
         Text(title)
-            .font(.system(size: 13, weight: .bold))
-            .tracking(1.5)
+            .font(.system(size: 13 * fontScale, weight: .bold))
+            .tracking(1.5 * fontScale)
             .foregroundStyle(.white.opacity(0.5))
             .padding(.horizontal, 36)
             .padding(.top, 24)


### PR DESCRIPTION
## Summary
Add option to increase sidebar menu font size for accessibility.

## Options
- **Normal** (1.0x) - Default size
- **Large** (1.25x) - 25% larger
- **Extra Large** (1.5x) - 50% larger

## What Scales
- Menu item icons and text
- Section headers (LIBRARY, LIVE TV)
- App title "Rivulet"
- Selection indicators

## Location
Settings → Appearance → Sidebar Font Size

Closes #34