### PR TITLE
Fix SwiftUI layout hang from unstable ForEach identity

### DIFF
--- a/Rivulet/Models/Plex/PlexMetadata.swift
+++ b/Rivulet/Models/Plex/PlexMetadata.swift
@@ -13,7 +13,7 @@ import Foundation
 
 /// Actor/cast member with role information
 struct PlexRole: Codable, Identifiable, Sendable {
-    var id: String { "\(tag ?? "")-\(role ?? "")" }
+    var id: String { "\(tag ?? "unknown")-\(role ?? "unknown")-\(thumb ?? "")" }
     var tag: String?        // Actor name
     var role: String?       // Character name
     var thumb: String?      // Photo URL
@@ -21,7 +21,7 @@ struct PlexRole: Codable, Identifiable, Sendable {
 
 /// Director/Writer/Producer
 struct PlexCrewMember: Codable, Identifiable, Sendable {
-    var id: String { tag ?? UUID().uuidString }
+    var id: String { "\(tag ?? "unknown")-\(thumb ?? "")" }
     var tag: String?
     var thumb: String?
 }

--- a/Rivulet/Views/Plex/CastMemberCard.swift
+++ b/Rivulet/Views/Plex/CastMemberCard.swift
@@ -147,7 +147,7 @@ struct CastCrewRow: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 LazyHStack(spacing: ScaledDimensions.rowItemSpacing * scale) {
                     // Directors first
-                    ForEach(directors) { director in
+                    ForEach(directors, id: \.id) { director in
                         Button { } label: {
                             PersonCard(
                                 name: director.tag ?? "Unknown",
@@ -165,7 +165,7 @@ struct CastCrewRow: View {
                     }
 
                     // Cast members
-                    ForEach(cast) { actor in
+                    ForEach(cast, id: \.id) { actor in
                         Button { } label: {
                             PersonCard(
                                 name: actor.tag ?? "Unknown",


### PR DESCRIPTION
## Summary
- `PlexCrewMember.id` generated a new `UUID()` on every access when `tag` was nil, causing infinite SwiftUI re-layout in `LazyHStack` — the OS watchdog killed the app after 2000ms
- `PlexRole.id` could produce duplicate IDs (`"-"`) when both `tag` and `role` were nil
- Both now use stable computed IDs combining available fields (`tag`, `role`, `thumb`)
- Added explicit `id: \.id` to `ForEach` calls in `CastCrewRow` as defense-in-depth

## Test plan
- [ ] Open detail view for media with cast/crew — verify no hang or watchdog kill
- [ ] Test with media where some cast members lack `tag` (name) field
- [ ] Verify cast/crew row scrolls smoothly on Apple TV HD (3GB RAM model)

Fixes RIVULET-G