### PR TITLE
Validate HTTP status before parsing HDHomeRun lineup JSON

### DIFF
--- a/Rivulet/Services/Plex/PlexNetworkManager.swift
+++ b/Rivulet/Services/Plex/PlexNetworkManager.swift
@@ -1919,7 +1919,14 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
         }
 
         do {
-            let (data, _) = try await session.data(from: lineupURL)
+            let (data, response) = try await session.data(from: lineupURL)
+
+            // Validate HTTP response before attempting JSON decode
+            if let httpResponse = response as? HTTPURLResponse, !(200...299).contains(httpResponse.statusCode) {
+                print("🌐 PlexNetwork: HDHomeRun lineup returned HTTP \(httpResponse.statusCode)")
+                return [:]
+            }
+
             let channels = try JSONDecoder().decode([HDHomeRunChannel].self, from: data)
 
             var urlMap: [String: String] = [:]


### PR DESCRIPTION
## Summary
- `fetchHDHomeRunLineup` discarded the HTTP response and passed data directly to `JSONDecoder`
- When HDHomeRun devices return HTML error pages (404, 500, device offline), the decoder failed with "Unexpected character '<' around line 1"
- Now checks HTTP status code first — non-2xx responses return empty gracefully without hitting Sentry
- 46 events across 7 users were caused by this

## Test plan
- [ ] Verify HDHomeRun lineup still loads correctly for working devices
- [ ] Simulate device offline/unreachable — should return empty without crash or Sentry noise
- [ ] Check Plex Live TV channel list still populates with HDHomeRun stream URLs

Fixes RIVULET-18