### PR TITLE
Add API token support for Dispatcharr authentication

### DIFF
--- a/Rivulet/Services/IPTV/DispatcharrService.swift
+++ b/Rivulet/Services/IPTV/DispatcharrService.swift
@@ -14,12 +14,14 @@ actor DispatcharrService {
     // MARK: - Properties
 
     let baseURL: URL
+    let apiToken: String?
     private let session: URLSession
 
     // MARK: - Initialization
 
-    init(baseURL: URL) {
+    init(baseURL: URL, apiToken: String? = nil) {
         self.baseURL = baseURL
+        self.apiToken = apiToken
 
         // Configure session with reasonable timeouts for potentially large M3U/EPG files
         let config = URLSessionConfiguration.default
@@ -29,7 +31,7 @@ actor DispatcharrService {
     }
 
     /// Create a DispatcharrService from a URL string, cleaning up the URL if needed
-    static func create(from urlString: String) -> DispatcharrService? {
+    static func create(from urlString: String, apiToken: String? = nil) -> DispatcharrService? {
         // Clean up the URL string
         var cleanedURL = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -56,7 +58,7 @@ actor DispatcharrService {
             return nil
         }
 
-        return DispatcharrService(baseURL: url)
+        return DispatcharrService(baseURL: url, apiToken: apiToken)
     }
 
     // MARK: - Public Methods
@@ -65,8 +67,9 @@ actor DispatcharrService {
     /// - Returns: Raw M3U data
     func fetchM3U() async throws -> Data {
         let url = baseURL.appendingPathComponent("output/m3u")
+        let request = authenticatedRequest(for: url)
 
-        let (data, response) = try await session.data(from: url)
+        let (data, response) = try await session.data(for: request)
 
         try validateResponse(response)
 
@@ -77,8 +80,9 @@ actor DispatcharrService {
     /// - Returns: Raw XMLTV data
     func fetchEPG() async throws -> Data {
         let url = baseURL.appendingPathComponent("output/epg")
+        let request = authenticatedRequest(for: url)
 
-        let (data, response) = try await session.data(from: url)
+        let (data, response) = try await session.data(for: request)
 
         try validateResponse(response)
 
@@ -89,8 +93,7 @@ actor DispatcharrService {
     /// - Returns: Status information about the server
     func getStatus() async throws -> DispatcharrStatus {
         // Try to fetch a small portion of the M3U to verify connectivity
-        var request = URLRequest(url: baseURL.appendingPathComponent("output/m3u"))
-        request.httpMethod = "HEAD"
+        let request = authenticatedRequest(for: baseURL.appendingPathComponent("output/m3u"), method: "HEAD")
 
         let (_, response) = try await session.data(for: request)
 
@@ -125,6 +128,15 @@ actor DispatcharrService {
     }
 
     // MARK: - Private Methods
+
+    private func authenticatedRequest(for url: URL, method: String = "GET") -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        if let token = apiToken, !token.isEmpty {
+            request.setValue("Token \(token)", forHTTPHeaderField: "Authorization")
+        }
+        return request
+    }
 
     private func validateResponse(_ response: URLResponse) throws {
         guard let httpResponse = response as? HTTPURLResponse else {

--- a/Rivulet/Services/LiveTV/IPTVProvider.swift
+++ b/Rivulet/Services/LiveTV/IPTVProvider.swift
@@ -26,6 +26,9 @@ actor IPTVProvider: LiveTVProvider {
     /// EPG/XMLTV URL (optional)
     nonisolated let epgURL: URL?
 
+    /// API token for Dispatcharr authentication (nil if not required)
+    nonisolated let apiToken: String?
+
     private let dispatcharrService: DispatcharrService?
 
     // Cached data
@@ -41,17 +44,18 @@ actor IPTVProvider: LiveTVProvider {
     // MARK: - Initialization
 
     /// Initialize for Dispatcharr source
-    init(dispatcharrURL: URL, sourceId: String, displayName: String) {
+    init(dispatcharrURL: URL, sourceId: String, displayName: String, apiToken: String? = nil) {
         self.sourceType = .dispatcharr
         self.sourceId = sourceId
         self.displayName = displayName
+        self.apiToken = apiToken
 
         // Clean the URL in case it already contains /output/m3u or /output/epg
         // This handles URLs that were saved before the cleanup was added
         let cleanedURL = Self.cleanDispatcharrURL(dispatcharrURL)
 
         self.baseURL = cleanedURL
-        self.dispatcharrService = DispatcharrService(baseURL: cleanedURL)
+        self.dispatcharrService = DispatcharrService(baseURL: cleanedURL, apiToken: apiToken)
         self.m3uURL = cleanedURL.appendingPathComponent("output/m3u")
         self.epgURL = cleanedURL.appendingPathComponent("output/epg")
     }
@@ -75,6 +79,7 @@ actor IPTVProvider: LiveTVProvider {
         self.sourceType = .genericM3U
         self.sourceId = sourceId
         self.displayName = displayName
+        self.apiToken = nil
         self.baseURL = nil
         self.dispatcharrService = nil
         self.m3uURL = m3uURL

--- a/Rivulet/Services/LiveTV/LiveTVDataStore.swift
+++ b/Rivulet/Services/LiveTV/LiveTVDataStore.swift
@@ -62,6 +62,7 @@ class LiveTVDataStore: ObservableObject {
         let baseURL: String?
         let m3uURL: String?
         let epgURL: String?
+        let apiToken: String?
     }
 
     // MARK: - Source Info
@@ -115,12 +116,13 @@ class LiveTVDataStore: ObservableObject {
     // MARK: - Source Management
 
     /// Add a Dispatcharr source
-    func addDispatcharrSource(baseURL: URL, name: String) async {
+    func addDispatcharrSource(baseURL: URL, name: String, apiToken: String? = nil) async {
         let sourceId = "dispatcharr:\(baseURL.absoluteString)"
         let provider = IPTVProvider(
             dispatcharrURL: baseURL,
             sourceId: sourceId,
-            displayName: name
+            displayName: name,
+            apiToken: apiToken
         )
         providers[sourceId] = provider
         saveSources()
@@ -182,7 +184,8 @@ class LiveTVDataStore: ObservableObject {
                     let provider = IPTVProvider(
                         dispatcharrURL: url,
                         sourceId: config.id,
-                        displayName: config.name
+                        displayName: config.name,
+                        apiToken: config.apiToken
                     )
                     providers[config.id] = provider
                 }
@@ -240,7 +243,8 @@ class LiveTVDataStore: ObservableObject {
                         name: provider.displayName,
                         baseURL: iptvProvider.baseURL?.absoluteString,
                         m3uURL: nil,
-                        epgURL: nil
+                        epgURL: nil,
+                        apiToken: iptvProvider.apiToken
                     ))
                 }
 
@@ -252,7 +256,8 @@ class LiveTVDataStore: ObservableObject {
                         name: provider.displayName,
                         baseURL: nil,
                         m3uURL: iptvProvider.m3uURL?.absoluteString,
-                        epgURL: iptvProvider.epgURL?.absoluteString
+                        epgURL: iptvProvider.epgURL?.absoluteString,
+                        apiToken: nil
                     ))
                 }
 
@@ -264,7 +269,8 @@ class LiveTVDataStore: ObservableObject {
                         name: provider.displayName,
                         baseURL: plexProvider.serverURL,
                         m3uURL: nil,
-                        epgURL: nil
+                        epgURL: nil,
+                        apiToken: nil
                     ))
                 }
             }

--- a/Rivulet/Views/Settings/AddLiveTVSourceSheet.swift
+++ b/Rivulet/Views/Settings/AddLiveTVSourceSheet.swift
@@ -401,6 +401,7 @@ private struct DispatcharrConfigForm: View {
     @StateObject private var authManager = PlexAuthManager.shared
     @State private var serverURL = ""
     @State private var displayName = "Live TV"
+    @State private var apiToken = ""
     @State private var isAdding = false
     @State private var isValidating = false
     @State private var errorMessage: String?
@@ -487,6 +488,15 @@ private struct DispatcharrConfigForm: View {
                         title: "Display Name",
                         value: $displayName,
                         placeholder: "Live TV"
+                    )
+
+                    // API Token field (optional)
+                    SettingsTextEntryRow(
+                        icon: "key",
+                        iconColor: .orange,
+                        title: "API Token",
+                        value: $apiToken,
+                        placeholder: "Optional — leave blank if not required"
                     )
                 }
 
@@ -616,7 +626,7 @@ private struct DispatcharrConfigForm: View {
     private func validateServer() {
         // Sanitize URL before validation (fixes common typos like "hhttp://")
         let cleanedURL = sanitizeURL(serverURL)
-        guard let service = DispatcharrService.create(from: cleanedURL) else {
+        guard let service = DispatcharrService.create(from: cleanedURL, apiToken: apiToken.isEmpty ? nil : apiToken) else {
             validationStatus = .invalid("Invalid URL format")
             return
         }
@@ -655,7 +665,8 @@ private struct DispatcharrConfigForm: View {
         Task {
             await dataStore.addDispatcharrSource(
                 baseURL: url,
-                name: displayName.isEmpty ? "Live TV" : displayName
+                name: displayName.isEmpty ? "Live TV" : displayName,
+                apiToken: apiToken.isEmpty ? nil : apiToken
             )
 
             await dataStore.loadChannels()


### PR DESCRIPTION
## Summary
- Dispatcharr servers can require authentication, but the app had no way to provide credentials — requests were sent with no auth headers
- Added optional `apiToken` to `DispatcharrService` that sends `Authorization: Token <value>` header when present
- Token is persisted in `SourceConfiguration` (UserDefaults) and restored on app launch
- New "API Token" field in Add Source UI (optional, with key icon)
- Changes span 4 files: `DispatcharrService`, `IPTVProvider`, `LiveTVDataStore`, `AddLiveTVSourceSheet`

## Test plan
- [ ] Add a Dispatcharr source without token — verify it still works for public servers
- [ ] Add a Dispatcharr source with API token — verify auth header is sent and channels load
- [ ] Remove and re-add a source — verify token persists correctly
- [ ] Validate button should show auth error clearly when token is wrong/missing

Fixes RIVULET-31