### PR TITLE
Player: wire mid-playback audio/subtitle track switch through to pipeline

### DIFF
--- a/Rivulet/Views/Player/UniversalPlayerViewModel.swift
+++ b/Rivulet/Views/Player/UniversalPlayerViewModel.swift
@@ -2440,10 +2440,13 @@ final class UniversalPlayerViewModel: ObservableObject {
     // MARK: - Track Selection
 
     func selectAudioTrack(id: Int) {
-        // TODO: AVPlayer audio track selection via AVMediaSelectionGroup
-        currentAudioTrackId = id
+        // Delegate the actual pipeline switch to the auto-selection helper,
+        // then persist the user's explicit choice as the saved preference so
+        // future playback sessions restore it.
+        // TODO: AVPlayer path still needs AVMediaSelectionGroup wiring; this
+        // fix only covers the RivuletPlayer pipeline (custom player).
+        selectAudioTrackWithoutSaving(id: id)
 
-        // Save preference
         if let track = audioTracks.first(where: { $0.id == id }) {
             AudioPreferenceManager.current = AudioPreference(from: track)
         }
@@ -2540,10 +2543,13 @@ final class UniversalPlayerViewModel: ObservableObject {
     }
 
     func selectSubtitleTrack(id: Int?) {
-        // TODO: AVPlayer subtitle selection via AVMediaSelectionGroup
-        currentSubtitleTrackId = id
+        // Delegate the actual pipeline switch to the auto-selection helper,
+        // then persist the user's explicit choice as the saved preference so
+        // future playback sessions restore it.
+        // TODO: AVPlayer path still needs AVMediaSelectionGroup wiring; this
+        // fix only covers the RivuletPlayer pipeline (custom player).
+        selectSubtitleTrackWithoutSaving(id: id)
 
-        // Save preference
         if let id = id, let track = subtitleTracks.first(where: { $0.id == id }) {
             SubtitlePreferenceManager.current = SubtitlePreference(from: track)
         } else {


### PR DESCRIPTION
## Summary

`UniversalPlayerViewModel.selectAudioTrack(id:)` and
`selectSubtitleTrack(id:)` were TODO stubs that only updated UI state and
persisted the user's preference — the pipeline kept playing the previous
track, so the swipe-down settings menu was effectively read-only
mid-playback.

Delegate the real work to the existing `selectAudioTrackWithoutSaving` /
`selectSubtitleTrackWithoutSaving` helpers — already wired through
`RivuletPlayer` and `DirectPlayPipeline` — then still save the preference so
the choice restores on next playback.

## Scope

- Only the `RivuletPlayer` (custom player) pipeline is covered. The
  `AVPlayer` fallback still needs `AVMediaSelectionGroup` wiring; that TODO
  is preserved in place.
- Subtitle packets still don't render on-screen even once selected — that
  failure is in the packet-to-cue path (or pipeline-type predicate) and is a
  separate, not-yet-diagnosed issue. This PR fixes selection *delivery*
  only.

## Test plan

- Built and installed on Apple TV 4K (2nd gen), tvOS 26.4.
- Verified mid-playback audio-track switch takes effect immediately on a
  multi-track DV UHD title (previously row highlight moved but audio didn't
  change).
- Verified subtitle *selection* now flows through (rendering bug above
  remains).
- Verified preference is still saved and restored on next playback.

---

_Prepared with LLM assistance and verified on-device._
