### PR TITLE
Player: prefer Plex extendedDisplayTitle in in-playback track menu

### DIFF
--- a/Rivulet/Services/Plex/Playback/MediaTrack.swift
+++ b/Rivulet/Services/Plex/Playback/MediaTrack.swift
@@ -18,6 +18,12 @@ struct MediaTrack: Identifiable, Equatable, Sendable {
     let isForced: Bool
     let isHearingImpaired: Bool
 
+    /// Plex's long-form descriptive title when present (e.g.,
+    /// "English (AC3 5.1) - Director's Commentary"). Preferred over `name`
+    /// in user-facing pickers so commentary / audio-description / SDH
+    /// tracks are distinguishable from the main mix.
+    let extendedDisplayTitle: String?
+
     // Audio-specific
     let channels: Int?
 
@@ -33,6 +39,7 @@ struct MediaTrack: Identifiable, Equatable, Sendable {
         isDefault: Bool = false,
         isForced: Bool = false,
         isHearingImpaired: Bool = false,
+        extendedDisplayTitle: String? = nil,
         channels: Int? = nil,
         subtitleKey: String? = nil
     ) {
@@ -44,6 +51,7 @@ struct MediaTrack: Identifiable, Equatable, Sendable {
         self.isDefault = isDefault
         self.isForced = isForced
         self.isHearingImpaired = isHearingImpaired
+        self.extendedDisplayTitle = extendedDisplayTitle
         self.channels = channels
         self.subtitleKey = subtitleKey
     }
@@ -58,6 +66,7 @@ struct MediaTrack: Identifiable, Equatable, Sendable {
         self.isDefault = stream.default ?? false
         self.isForced = stream.forced ?? false
         self.isHearingImpaired = stream.hearingImpaired ?? false
+        self.extendedDisplayTitle = stream.extendedDisplayTitle
         self.channels = stream.channels
         self.subtitleKey = stream.key
     }

--- a/Rivulet/Views/Player/PlayerControlsOverlay.swift
+++ b/Rivulet/Views/Player/PlayerControlsOverlay.swift
@@ -437,9 +437,11 @@ struct PlayerControlsOverlay: View {
 
     // MARK: - Track Display Formatting
 
-    /// Audio track title: format string (e.g., "AAC Stereo", "TrueHD 5.1")
+    /// Audio track title: Plex's long-form descriptive title when present
+    /// (e.g., "English (AC3 5.1) - Director's Commentary"); otherwise the
+    /// synthesized format string ("AAC Stereo", "TrueHD 5.1").
     private func formatAudioTrackTitle(_ track: MediaTrack) -> String {
-        track.audioFormatString
+        track.extendedDisplayTitle ?? track.audioFormatString
     }
 
     /// Audio track subtitle: language in uppercase (e.g., "ENGLISH")
@@ -447,9 +449,11 @@ struct PlayerControlsOverlay: View {
         track.languageDisplay
     }
 
-    /// Subtitle track title: language in uppercase (e.g., "ENGLISH")
+    /// Subtitle track title: Plex's long-form descriptive title when
+    /// present; otherwise the language in uppercase ("ENGLISH").
+    /// Forced / SDH suffixes are appended in either case.
     private func formatSubtitleTrackTitle(_ track: MediaTrack) -> String {
-        var title = track.languageDisplay
+        var title = track.extendedDisplayTitle ?? track.languageDisplay
         if track.isForced {
             title += " (Forced)"
         }

--- a/Rivulet/Views/Player/PlayerControlsOverlay.swift
+++ b/Rivulet/Views/Player/PlayerControlsOverlay.swift
@@ -450,10 +450,14 @@ struct PlayerControlsOverlay: View {
     }
 
     /// Subtitle track title: Plex's long-form descriptive title when
-    /// present; otherwise the language in uppercase ("ENGLISH").
-    /// Forced / SDH suffixes are appended in either case.
+    /// present (already includes "Forced" / "SDH" where applicable);
+    /// otherwise the language in uppercase ("ENGLISH") with suffixes
+    /// appended.
     private func formatSubtitleTrackTitle(_ track: MediaTrack) -> String {
-        var title = track.extendedDisplayTitle ?? track.languageDisplay
+        if let extended = track.extendedDisplayTitle {
+            return extended
+        }
+        var title = track.languageDisplay
         if track.isForced {
             title += " (Forced)"
         }

--- a/Rivulet/Views/Player/UniversalPlayerViewModel.swift
+++ b/Rivulet/Views/Player/UniversalPlayerViewModel.swift
@@ -2761,6 +2761,7 @@ final class UniversalPlayerViewModel: ObservableObject {
                 isDefault: stream.default ?? track.isDefault,
                 isForced: stream.forced ?? track.isForced,
                 isHearingImpaired: stream.hearingImpaired ?? track.isHearingImpaired,
+                extendedDisplayTitle: stream.extendedDisplayTitle ?? track.extendedDisplayTitle,
                 channels: stream.channels ?? track.channels,
                 subtitleKey: stream.key ?? track.subtitleKey
             )


### PR DESCRIPTION
## Summary

Plex tags audio and subtitle streams with both a short `displayTitle`
("English (AC3 5.1)") and a long-form `extendedDisplayTitle`
("English (AC3 5.1) - Director's Commentary"). The extended form is
what distinguishes a commentary or audio-description track from the
main mix; without it, multi-track items show two rows whose
label-side text is identical, and the user has to guess.

The in-playback (swipe-down) menu rendered tracks fully synthesized
from language + codec — never even displaying `displayTitle`, let
alone the extended form. `PlexStream` already parses
`extendedDisplayTitle` and the `VideoInfoOverlay` already prints it,
so the data is end-to-end available — it just wasn't propagated
through `MediaTrack`.

## Changes

- Add `extendedDisplayTitle: String?` to `MediaTrack`; populate from
  `PlexStream` and at the FFmpeg-track enrichment site in
  `UniversalPlayerViewModel`.
- In `PlayerControlsOverlay`, prefer `extendedDisplayTitle` for the
  title row of audio + subtitle entries; fall back to the existing
  synthesized `audioFormatString` / `languageDisplay` form when Plex
  doesn't supply one (typical for embedded streams without titles, or
  FFmpeg-only tracks before enrichment).
- Subtitle row (synthesized language / codec form) preserved beneath
  the descriptive title — Plex Web shows both.

## Test plan

- [x] Multi-track UHD HEVC HDR DV item with TrueHD + AC-3 commentary
      and multi-track subs (Doctor Strange in the Multiverse of Madness)
      — commentary row now distinguishable from main mix
- [x] Item with no `extendedDisplayTitle` — falls back to prior
      synthesized form
- [x] FFmpeg-only tracks (pre-enrichment) — still use synthesized form
- [x] Build + run on Apple TV 4K (2nd gen), tvOS 26.4

🤖 Authored with assistance from Claude (Anthropic).