### PR TITLE
Player: route touch-surface swipes through the swipe-down menu

### DIFF
--- a/Rivulet/Views/Player/PlayerContainerViewController.swift
+++ b/Rivulet/Views/Player/PlayerContainerViewController.swift
@@ -389,11 +389,26 @@ class PlayerContainerViewController: UIViewController {
     @objc private func handlePanGesture(_ gesture: UIPanGestureRecognizer) {
         guard let vm = viewModel else { return }
 
-        // Only allow swipe scrubbing when paused
-        guard vm.playbackState == .paused else { return }
+        // Bail in error / post-video states regardless of mode.
+        if vm.playbackState.isFailed || vm.postVideoState != .hidden {
+            return
+        }
 
-        // Don't handle pan when info panel or post-video is showing
-        if vm.showInfoPanel || vm.postVideoState != .hidden {
+        // The same touch-surface pan drives two distinct interactions
+        // depending on player state:
+        //   • paused, panel closed → continuous swipe-to-scrub (existing).
+        //   • panel open OR active playback → discrete swipe gesture
+        //     that opens the panel (downward, when closed) or navigates
+        //     the menu (any direction, when open).
+        // For the discrete-swipe case we wait for the gesture to end
+        // and decide direction from total translation + final velocity,
+        // which reads the user's intent more reliably than sampling the
+        // first directional crossing during motion.
+        let isSwipeMode = vm.showInfoPanel || vm.playbackState != .paused
+        if isSwipeMode {
+            if gesture.state == .ended {
+                handleEndOfSwipe(gesture, vm: vm)
+            }
             return
         }
 
@@ -422,6 +437,52 @@ class PlayerContainerViewController: UIViewController {
 
         default:
             break
+        }
+    }
+
+    /// Translate an end-of-pan gesture into a discrete swipe and dispatch
+    /// the corresponding action. Called only in the swipe-mode branch of
+    /// handlePanGesture (panel open, or active non-paused playback) — the
+    /// scrubbing path still owns paused-state pans.
+    private func handleEndOfSwipe(_ gesture: UIPanGestureRecognizer, vm: UniversalPlayerViewModel) {
+        let translation = gesture.translation(in: view)
+        let velocity = gesture.velocity(in: view)
+
+        let absX = abs(translation.x)
+        let absY = abs(translation.y)
+        let dominantHorizontal = absX > absY
+        let displacement = dominantHorizontal ? absX : absY
+        let speed = dominantHorizontal ? abs(velocity.x) : abs(velocity.y)
+
+        // Recognize a swipe if there's either meaningful displacement
+        // or a strong final velocity. Either alone is sufficient — a
+        // short fast flick reads as a swipe even if the displacement
+        // is small, and a slow long drag reads as a swipe even at
+        // low velocity.
+        let minDistance: CGFloat = 30
+        let minVelocity: CGFloat = 150
+        guard displacement >= minDistance || speed >= minVelocity else { return }
+
+        let direction: MoveCommandDirection
+        if dominantHorizontal {
+            direction = translation.x > 0 ? .right : .left
+        } else {
+            direction = translation.y > 0 ? .down : .up
+        }
+
+        if vm.showInfoPanel {
+            // Mirror UniversalPlayerView's onMoveCommand: swipe-up at
+            // the topmost row closes the panel.
+            if direction == .up && vm.focusedRowIndex == 0 {
+                withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) {
+                    vm.showInfoPanel = false
+                }
+            } else {
+                vm.navigateSettings(direction: direction)
+            }
+        } else if direction == .down {
+            // Active, non-paused playback: downward swipe opens the panel.
+            inputCoordinator.handle(action: .showInfo, source: .siriMicroGamepad)
         }
     }
 


### PR DESCRIPTION
## Summary

The 2nd-gen Siri Remote's touch surface does not deliver
`MoveCommandDirection` events to SwiftUI's focus engine for raw
swipes — only perimeter clickpad presses do. That left two
gestures broken on the playback path:

- Once the swipe-down menu was open, focus would only move on
  perimeter clicks; touch-surface gestures were ignored and the
  user had to fall back to the arrow buttons mid-flow.
- Opening the menu via a downward swipe worked inconsistently —
  the focus engine sometimes synthesised a `.down` move command
  and sometimes didn't.

## Approach

Three iterations led to the shipped design:

1. `GCMicroGamepad.dpad` polling — sluggish at touch-up; first-
   directional-crossing didn't help.
2. Four `UISwipeGestureRecognizer`s with delegate gating — even
   worse, likely because the existing pan recognizer claimed
   touches first.
3. **Winner**: extend the existing `UIPanGestureRecognizer` (which
   already drives swipe-to-scrub when paused) to recognize
   discrete swipes at end-of-pan from total translation + final
   velocity, when the panel is open or during active non-paused
   playback. Single recognizer, no inter-recognizer conflicts,
   feels native.

## Behavior

- Panel-open swipes route to `navigateSettings` (with the
  swipe-up-at-top-closes-panel exception the perimeter path
  already implements).
- Panel-closed downward swipes during active playback route to
  `.showInfo` to open the menu.
- Other directions on a closed panel are ignored.
- Paused-state continuous scrub path is unchanged.

## Test plan

- [x] Verified on Apple TV 4K (2nd gen), tvOS 26.4, with the
      2nd-gen Siri Remote touch surface
- [x] Open menu via downward swipe; navigate options via
      touch-surface swipes in all four directions
- [x] Swipe-up at top of panel closes the menu (existing
      perimeter behavior preserved)
- [x] Paused-state scrub still works unchanged

🤖 Authored with assistance from Claude (Anthropic).