### PR TITLE
Detail page: pre-play audio/subtitle pickers with server-side persistence

### DIFF
--- a/Rivulet/Services/Plex/Playback/MediaTrack.swift
+++ b/Rivulet/Services/Plex/Playback/MediaTrack.swift
@@ -18,6 +18,12 @@ struct MediaTrack: Identifiable, Equatable, Sendable {
     let isForced: Bool
     let isHearingImpaired: Bool
 
+    /// Plex's long-form descriptive title when present (e.g.,
+    /// "English (AC3 5.1) - Director's Commentary"). Preferred over `name`
+    /// in user-facing pickers so commentary / audio-description / SDH
+    /// tracks are distinguishable from the main mix.
+    let extendedDisplayTitle: String?
+
     // Audio-specific
     let channels: Int?
 
@@ -33,6 +39,7 @@ struct MediaTrack: Identifiable, Equatable, Sendable {
         isDefault: Bool = false,
         isForced: Bool = false,
         isHearingImpaired: Bool = false,
+        extendedDisplayTitle: String? = nil,
         channels: Int? = nil,
         subtitleKey: String? = nil
     ) {
@@ -44,6 +51,7 @@ struct MediaTrack: Identifiable, Equatable, Sendable {
         self.isDefault = isDefault
         self.isForced = isForced
         self.isHearingImpaired = isHearingImpaired
+        self.extendedDisplayTitle = extendedDisplayTitle
         self.channels = channels
         self.subtitleKey = subtitleKey
     }
@@ -58,13 +66,17 @@ struct MediaTrack: Identifiable, Equatable, Sendable {
         self.isDefault = stream.default ?? false
         self.isForced = stream.forced ?? false
         self.isHearingImpaired = stream.hearingImpaired ?? false
+        self.extendedDisplayTitle = stream.extendedDisplayTitle
         self.channels = stream.channels
         self.subtitleKey = stream.key
     }
 
-    /// Display name with additional info
+    /// Display name with additional info. Prefers Plex's long-form
+    /// `extendedDisplayTitle` when present so commentary / SDH / etc.
+    /// are distinguishable; otherwise falls back to the synthesized
+    /// `name`. Forced / SDH suffixes are appended in either case.
     var displayName: String {
-        var components: [String] = [name]
+        var components: [String] = [extendedDisplayTitle ?? name]
 
         if isForced {
             components.append("(Forced)")

--- a/Rivulet/Services/Plex/PlexNetworkManager.swift
+++ b/Rivulet/Services/Plex/PlexNetworkManager.swift
@@ -1532,8 +1532,15 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
         partId: Int,
         audioStreamID: Int
     ) async {
-        let urlString = "\(serverURL)/library/parts/\(partId)?audioStreamID=\(audioStreamID)&X-Plex-Token=\(authToken)"
-        guard let url = URL(string: urlString) else {
+        guard var components = URLComponents(string: "\(serverURL)/library/parts/\(partId)") else {
+            print("[Plex] Failed to build audio stream selection URL")
+            return
+        }
+        components.queryItems = [
+            URLQueryItem(name: "audioStreamID", value: "\(audioStreamID)"),
+            URLQueryItem(name: "X-Plex-Token", value: authToken)
+        ]
+        guard let url = components.url else {
             print("[Plex] Failed to build audio stream selection URL")
             return
         }
@@ -1542,7 +1549,7 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
         request.httpMethod = "PUT"
 
         do {
-            let (_, response) = try await URLSession.shared.data(for: request)
+            let (_, response) = try await session.data(for: request)
             let status = (response as? HTTPURLResponse)?.statusCode ?? 0
             print("[Plex] Set audio stream \(audioStreamID) on part \(partId): HTTP \(status)")
         } catch {
@@ -1559,8 +1566,15 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
         partId: Int,
         subtitleStreamID: Int
     ) async {
-        let urlString = "\(serverURL)/library/parts/\(partId)?subtitleStreamID=\(subtitleStreamID)&X-Plex-Token=\(authToken)"
-        guard let url = URL(string: urlString) else {
+        guard var components = URLComponents(string: "\(serverURL)/library/parts/\(partId)") else {
+            print("[Plex] Failed to build subtitle stream selection URL")
+            return
+        }
+        components.queryItems = [
+            URLQueryItem(name: "subtitleStreamID", value: "\(subtitleStreamID)"),
+            URLQueryItem(name: "X-Plex-Token", value: authToken)
+        ]
+        guard let url = components.url else {
             print("[Plex] Failed to build subtitle stream selection URL")
             return
         }
@@ -1569,7 +1583,7 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
         request.httpMethod = "PUT"
 
         do {
-            let (_, response) = try await URLSession.shared.data(for: request)
+            let (_, response) = try await session.data(for: request)
             let status = (response as? HTTPURLResponse)?.statusCode ?? 0
             print("[Plex] Set subtitle stream \(subtitleStreamID) on part \(partId): HTTP \(status)")
         } catch {

--- a/Rivulet/Services/Plex/PlexNetworkManager.swift
+++ b/Rivulet/Services/Plex/PlexNetworkManager.swift
@@ -1550,6 +1550,33 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
         }
     }
 
+    /// Set the preferred subtitle stream on a media part. Pass `0` for
+    /// `subtitleStreamID` to disable subtitles. Plex persists this
+    /// per-user-per-part, so it survives across plays from any client.
+    func setSelectedSubtitleStream(
+        serverURL: String,
+        authToken: String,
+        partId: Int,
+        subtitleStreamID: Int
+    ) async {
+        let urlString = "\(serverURL)/library/parts/\(partId)?subtitleStreamID=\(subtitleStreamID)&X-Plex-Token=\(authToken)"
+        guard let url = URL(string: urlString) else {
+            print("[Plex] Failed to build subtitle stream selection URL")
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+            print("[Plex] Set subtitle stream \(subtitleStreamID) on part \(partId): HTTP \(status)")
+        } catch {
+            print("[Plex] Failed to set subtitle stream: \(error.localizedDescription)")
+        }
+    }
+
     /// Ping the `/decision` endpoint to tell Plex to actually start the transcode/remux session.
     /// Without this, Plex may return a playlist with segment URLs but never begin muxing,
     /// causing the init segment (`/base/header`) to hang indefinitely.

--- a/Rivulet/Views/Player/UniversalPlayerViewModel.swift
+++ b/Rivulet/Views/Player/UniversalPlayerViewModel.swift
@@ -506,6 +506,15 @@ final class UniversalPlayerViewModel: ObservableObject {
 
     // MARK: - Initialization
 
+    /// Pre-play subtitle choice from the item-detail picker. Distinguishes
+    /// "user hasn't picked yet" from "user explicitly turned subs off"
+    /// from "user picked this specific subtitle track".
+    enum InitialSubtitleSelection {
+        case auto              // No preselection — fall through to SubtitlePreferenceManager.
+        case off               // User explicitly chose Off in the pre-play picker.
+        case track(id: Int)    // User picked a specific subtitle track.
+    }
+
     init(
         metadata: PlexMetadata,
         serverURL: String,
@@ -513,7 +522,9 @@ final class UniversalPlayerViewModel: ObservableObject {
         startOffset: TimeInterval? = nil,
         shuffledQueue: [PlexMetadata] = [],
         loadingArtImage: UIImage? = nil,
-        loadingThumbImage: UIImage? = nil
+        loadingThumbImage: UIImage? = nil,
+        initialAudioTrackId: Int? = nil,
+        initialSubtitleSelection: InitialSubtitleSelection = .auto
     ) {
         self.metadata = metadata
         self.serverURL = serverURL
@@ -522,6 +533,8 @@ final class UniversalPlayerViewModel: ObservableObject {
         self.shuffledQueue = shuffledQueue
         self.loadingArtImage = loadingArtImage
         self.loadingThumbImage = loadingThumbImage
+        self.initialAudioTrackId = initialAudioTrackId
+        self.initialSubtitleSelection = initialSubtitleSelection
 
         let isAirPlayRoute = Self.isAirPlayOutput()
         let hasDolbyVision = metadata.hasDolbyVision
@@ -2669,6 +2682,14 @@ final class UniversalPlayerViewModel: ObservableObject {
     private var hasAppliedSubtitlePreference = false
     private var hasAppliedAudioPreference = false
 
+    /// Pre-play track selections passed in from the item-detail picker.
+    /// Override the saved-preference auto-apply on first track population
+    /// — explicit user choice wins over remembered language preferences.
+    /// Cleared after consumption so subsequent re-applications fall back
+    /// to the preference managers.
+    private var initialAudioTrackId: Int?
+    private var initialSubtitleSelection: InitialSubtitleSelection = .auto
+
     private func updateTrackLists() {
         let previousSubtitleCount = subtitleTracks.count
         let previousAudioCount = audioTracks.count
@@ -2761,27 +2782,98 @@ final class UniversalPlayerViewModel: ObservableObject {
                 isDefault: stream.default ?? track.isDefault,
                 isForced: stream.forced ?? track.isForced,
                 isHearingImpaired: stream.hearingImpaired ?? track.isHearingImpaired,
+                extendedDisplayTitle: stream.extendedDisplayTitle ?? track.extendedDisplayTitle,
                 channels: stream.channels ?? track.channels,
                 subtitleKey: stream.key ?? track.subtitleKey
             )
         }
     }
 
-    /// Apply saved audio preference
+    /// Apply saved audio preference. Selection priority is:
+    ///  1. `initialAudioTrackId` from the pre-play picker (this session).
+    ///  2. Plex's per-item explicit selection (a `selected: true` stream
+    ///     that isn't also the file's `default: true` track — meaning the
+    ///     user picked something deliberately, in Plex Web / mobile / our
+    ///     own picker — that choice persists server-side and should win
+    ///     over a global language default).
+    ///  3. App-level `AudioPreferenceManager` language preference (which
+    ///     defaults to English even when nothing has been stored — drives
+    ///     the typical "auto-pick the highest-quality English stream"
+    ///     behavior for items the user has never deliberately picked for).
+    ///  4. Plex's default-flagged stream as a final fallback.
+    /// In every tier we issue `selectAudioTrackWithoutSaving` explicitly,
+    /// even when `currentAudioTrackId` already matches the desired id.
+    /// Reason: DirectPlay loaded the file's default-flagged audio track
+    /// and won't switch on its own, and Plex's HLS session is built from
+    /// server-state-at-session-start which doesn't always reflect the
+    /// persisted per-part selection — so an explicit switch is the only
+    /// reliable way to honor the user's actual choice. The cost is a
+    /// possibly-redundant HLS session rebuild at startup; correctness wins.
     private func applyAudioPreference() {
-        let preference = AudioPreferenceManager.current
-
-        // Find best matching track
-        if let match = AudioPreferenceManager.findBestMatch(in: audioTracks, preference: preference) {
-            if match.id != currentAudioTrackId {
-                selectAudioTrackWithoutSaving(id: match.id)
-            } else {
+        // 1. Pre-play picker (this session).
+        if let id = initialAudioTrackId {
+            initialAudioTrackId = nil
+            if audioTracks.contains(where: { $0.id == id }) {
+                selectAudioTrackWithoutSaving(id: id)
+                return
             }
+        }
+
+        // 2. Plex per-item explicit selection.
+        if let plexSelectedId = currentAudioTrackId,
+           let plexDefaultId = audioTracks.first(where: { $0.isDefault })?.id,
+           plexSelectedId != plexDefaultId,
+           audioTracks.contains(where: { $0.id == plexSelectedId }) {
+            selectAudioTrackWithoutSaving(id: plexSelectedId)
+            return
+        }
+
+        // 3. App-level language preference.
+        let preference = AudioPreferenceManager.current
+        if let match = AudioPreferenceManager.findBestMatch(in: audioTracks, preference: preference) {
+            selectAudioTrackWithoutSaving(id: match.id)
+            return
+        }
+
+        // 4. Plex default fallback.
+        if let id = currentAudioTrackId,
+           audioTracks.contains(where: { $0.id == id }) {
+            selectAudioTrackWithoutSaving(id: id)
         }
     }
 
     /// Apply saved subtitle preference
     private func applySubtitlePreference() {
+        // 1. Pre-play picker selection (this session). Off and a specific
+        //    track id are both explicit; auto means "no selection was
+        //    made, fall through". Consume and clear in either explicit
+        //    branch.
+        switch initialSubtitleSelection {
+        case .off:
+            initialSubtitleSelection = .auto
+            selectSubtitleTrackWithoutSaving(id: nil)
+            return
+        case .track(let id):
+            initialSubtitleSelection = .auto
+            if subtitleTracks.contains(where: { $0.id == id }) {
+                selectSubtitleTrackWithoutSaving(id: id)
+                return
+            }
+        case .auto:
+            break
+        }
+
+        // 2. Plex's per-item explicit selection. A `selected: true`
+        //    track that's neither the default nor the forced track is
+        //    one the user picked deliberately — honor it over the
+        //    app-level language preference.
+        if let plexSelectedSubId = currentSubtitleTrackId,
+           let track = subtitleTracks.first(where: { $0.id == plexSelectedSubId }),
+           !track.isDefault, !track.isForced {
+            selectSubtitleTrackWithoutSaving(id: plexSelectedSubId)
+            return
+        }
+
         // No explicit user preference yet: honor selected/default stream behavior.
         if !SubtitlePreferenceManager.hasStoredPreference {
             if currentSubtitleTrackId == nil,

--- a/Rivulet/Views/Plex/PlexDetailView.swift
+++ b/Rivulet/Views/Plex/PlexDetailView.swift
@@ -667,6 +667,11 @@ struct PlexDetailView: View {
             // item within this detail view (e.g., via collection / recs).
             preplayAudioTrackId = nil
             preplaySubtitleSelection = .auto
+            // Cancel any in-flight write for the previous item so
+            // presentPlayer() doesn't await a task that refreshes
+            // metadata for the now-defunct item.
+            pendingPreplayWrite?.cancel()
+            pendingPreplayWrite = nil
         }
         .onChange(of: showPlayer) { _, isShowing in
             // Clear selected episode/track and playFromBeginning when player closes
@@ -1416,14 +1421,6 @@ struct PlexDetailView: View {
 
     private var preplaySubtitleTracks: [MediaTrack] {
         preplayStreams.filter { $0.isSubtitle }.map { MediaTrack(from: $0) }
-    }
-
-    /// The id passed to TrackSelectionSheet for the subtitle picker.
-    /// `.auto` and `.off` both surface as nil (the picker shows "Off"
-    /// highlighted for nil); `.track(id)` surfaces the picked id.
-    private var preplaySubtitleSelectedId: Int? {
-        if case .track(let id) = preplaySubtitleSelection { return id }
-        return nil
     }
 
     /// Audio stream Plex has marked `selected` for the current user.

--- a/Rivulet/Views/Plex/PlexDetailView.swift
+++ b/Rivulet/Views/Plex/PlexDetailView.swift
@@ -93,6 +93,21 @@ struct PlexDetailView: View {
     @State private var trailerMetadata: PlexMetadata?  // Full metadata for trailer playback
     @State private var playFromBeginning = false  // For "Play from Beginning" button
     @State private var isLoadingShufflePlay = false
+
+    // Pre-play track picker state. Selections are per-detail-page-visit
+    // and are passed to the player on Play; we don't touch the saved
+    // language preference managers, so future plays still default to
+    // remembered language defaults until the user explicitly picks again.
+    @State private var preplayAudioTrackId: Int? = nil
+    @State private var preplaySubtitleSelection: UniversalPlayerViewModel.InitialSubtitleSelection = .auto
+    @State private var showAudioTrackPicker = false
+    @State private var showSubtitleTrackPicker = false
+
+    /// In-flight serialised chain of pre-play picker writes (Plex stream
+    /// selection PUT + fullMetadata refresh). presentPlayer awaits this
+    /// before building the player VM so the HLS URL is constructed
+    /// against Plex's updated server-side state.
+    @State private var pendingPreplayWrite: Task<Void, Never>? = nil
     @State private var shuffledEpisodeQueue: [PlexMetadata] = []
     @StateObject private var heroBackdrop = HeroBackdropCoordinator()
     @State private var belowFoldLoaded = false  // Flipped true after the full cascade finishes
@@ -624,6 +639,34 @@ struct PlexDetailView: View {
                 bio: fullMetadata?.summary ?? currentItem.summary ?? "",
                 thumbURL: artistThumbURL
             )
+        }
+        .sheet(isPresented: $showAudioTrackPicker) {
+            TrackSelectionSheet(
+                trackType: .audio,
+                tracks: preplayAudioTracks,
+                selectedTrackId: preplayAudioTrackId ?? currentSelectedAudioStreamId,
+                onSelect: { id in
+                    preplayAudioTrackId = id
+                    if let id { persistAudioStreamSelection(id) }
+                }
+            )
+        }
+        .sheet(isPresented: $showSubtitleTrackPicker) {
+            TrackSelectionSheet(
+                trackType: .subtitles,
+                tracks: preplaySubtitleTracks,
+                selectedTrackId: effectiveSubtitlePickerSelection,
+                onSelect: { id in
+                    preplaySubtitleSelection = id.map { .track(id: $0) } ?? .off
+                    persistSubtitleStreamSelection(id)
+                }
+            )
+        }
+        .onChange(of: currentItem.ratingKey) { _, _ in
+            // Reset pre-play picker state when navigating to a different
+            // item within this detail view (e.g., via collection / recs).
+            preplayAudioTrackId = nil
+            preplaySubtitleSelection = .auto
         }
         .onChange(of: showPlayer) { _, isShowing in
             // Clear selected episode/track and playFromBeginning when player closes
@@ -1318,8 +1361,139 @@ struct PlexDetailView: View {
                 .buttonStyle(AppStoreActionButtonStyle(isFocused: focusedActionButton == "trailer", cornerRadius: circleButtonSize / 2, isPrimary: false))
                 .focused($focusedActionButton, equals: "trailer")
             }
+
+            // Pre-play audio track picker — only for movies and episodes
+            // (single-video items where we know the streams ahead of play).
+            if showsPreplayTrackPickers, !preplayAudioTracks.isEmpty {
+                Button {
+                    showAudioTrackPicker = true
+                } label: {
+                    Image(systemName: "speaker.wave.3")
+                        .font(.system(size: 24, weight: .semibold))
+                        .frame(width: circleButtonSize, height: circleButtonSize)
+                }
+                .buttonStyle(AppStoreActionButtonStyle(isFocused: focusedActionButton == "audioTrack", cornerRadius: circleButtonSize / 2, isPrimary: false))
+                .focused($focusedActionButton, equals: "audioTrack")
+            }
+
+            // Pre-play subtitle track picker — hidden when there are no subtitle streams.
+            if showsPreplayTrackPickers, !preplaySubtitleTracks.isEmpty {
+                Button {
+                    showSubtitleTrackPicker = true
+                } label: {
+                    Image(systemName: "captions.bubble")
+                        .font(.system(size: 24, weight: .semibold))
+                        .frame(width: circleButtonSize, height: circleButtonSize)
+                }
+                .buttonStyle(AppStoreActionButtonStyle(isFocused: focusedActionButton == "subtitleTrack", cornerRadius: circleButtonSize / 2, isPrimary: false))
+                .focused($focusedActionButton, equals: "subtitleTrack")
+            }
         }
         .disabled(!allowActionRowInteraction)
+    }
+
+    // MARK: - Pre-play Track Picker Helpers
+
+    /// Whether the pre-play picker buttons make sense for the current
+    /// item type. Show / season / artist / album / track detail pages
+    /// don't have a single, known track list at this level.
+    private var showsPreplayTrackPickers: Bool {
+        switch currentItem.type {
+        case "movie", "episode": return true
+        default: return false
+        }
+    }
+
+    /// Streams come from `fullMetadata` once it's loaded; before that,
+    /// the pickers stay hidden because their counts are zero.
+    private var preplayStreams: [PlexStream] {
+        (fullMetadata ?? currentItem).Media?.first?.Part?.first?.Stream ?? []
+    }
+
+    private var preplayAudioTracks: [MediaTrack] {
+        preplayStreams.filter { $0.isAudio }.map { MediaTrack(from: $0) }
+    }
+
+    private var preplaySubtitleTracks: [MediaTrack] {
+        preplayStreams.filter { $0.isSubtitle }.map { MediaTrack(from: $0) }
+    }
+
+    /// The id passed to TrackSelectionSheet for the subtitle picker.
+    /// `.auto` and `.off` both surface as nil (the picker shows "Off"
+    /// highlighted for nil); `.track(id)` surfaces the picked id.
+    private var preplaySubtitleSelectedId: Int? {
+        if case .track(let id) = preplaySubtitleSelection { return id }
+        return nil
+    }
+
+    /// Audio stream Plex has marked `selected` for the current user.
+    /// Reflects whatever the user previously chose (in any client) or
+    /// Plex's server-side default; what the player would pick today.
+    private var currentSelectedAudioStreamId: Int? {
+        preplayStreams.first(where: { $0.isAudio && $0.selected == true })?.id
+    }
+
+    /// Subtitle stream Plex has marked `selected` for the current user.
+    /// `nil` means subtitles are off server-side.
+    private var currentSelectedSubtitleStreamId: Int? {
+        preplayStreams.first(where: { $0.isSubtitle && $0.selected == true })?.id
+    }
+
+    /// What to highlight in the subtitle picker on open. Honors the
+    /// user's local preplay choice first, then falls back to the
+    /// server-side selection so reopening the picker mid-visit shows
+    /// the current state rather than always defaulting to "Off".
+    private var effectiveSubtitlePickerSelection: Int? {
+        switch preplaySubtitleSelection {
+        case .track(let id): return id
+        case .off: return nil
+        case .auto: return currentSelectedSubtitleStreamId
+        }
+    }
+
+    /// PUT the chosen audio stream to Plex so it persists per-user-per-item
+    /// across plays from any client. Refresh `fullMetadata` afterward so
+    /// the local view of `selected: true` matches the new server state.
+    /// Chained off any prior in-flight write so concurrent audio + subtitle
+    /// picks serialise rather than racing each other (or the Play tap).
+    private func persistAudioStreamSelection(_ streamId: Int) {
+        guard let serverURL = authManager.selectedServerURL,
+              let authToken = authManager.selectedServerToken,
+              let partId = (fullMetadata ?? currentItem).Media?.first?.Part?.first?.id else {
+            return
+        }
+        let previous = pendingPreplayWrite
+        pendingPreplayWrite = Task {
+            if let previous { _ = await previous.value }
+            await networkManager.setSelectedAudioStream(
+                serverURL: serverURL,
+                authToken: authToken,
+                partId: partId,
+                audioStreamID: streamId
+            )
+            await loadFullMetadata()
+        }
+    }
+
+    /// PUT the chosen subtitle stream to Plex (id `0` disables subs).
+    /// Refresh `fullMetadata` afterward. Same chained-Task pattern as audio.
+    private func persistSubtitleStreamSelection(_ streamId: Int?) {
+        guard let serverURL = authManager.selectedServerURL,
+              let authToken = authManager.selectedServerToken,
+              let partId = (fullMetadata ?? currentItem).Media?.first?.Part?.first?.id else {
+            return
+        }
+        let previous = pendingPreplayWrite
+        pendingPreplayWrite = Task {
+            if let previous { _ = await previous.value }
+            await networkManager.setSelectedSubtitleStream(
+                serverURL: serverURL,
+                authToken: authToken,
+                partId: partId,
+                subtitleStreamID: streamId ?? 0
+            )
+            await loadFullMetadata()
+        }
     }
 
     /// Play button label with inline progress bar + time remaining (Apple TV+ style)
@@ -1580,6 +1754,16 @@ struct PlexDetailView: View {
     private func presentPlayer() {
         // Get images and metadata, then present player
         Task {
+            // Wait for any in-flight pre-play picker writes to land first,
+            // so the player is built against Plex's updated server-side
+            // stream selection (avoids a race where the HLS URL is built
+            // with stale audio / subtitle ids). Awaiting an already-finished
+            // Task returns immediately, so leaving pendingPreplayWrite set
+            // after it completes is harmless.
+            if let pending = pendingPreplayWrite {
+                _ = await pending.value
+            }
+
             // Determine which item to play and fetch full metadata if needed (for DV/HDR detection)
             let playItem: PlexMetadata
             if let episode = selectedEpisode {
@@ -1645,6 +1829,11 @@ struct PlexDetailView: View {
                 let queue = shuffledEpisodeQueue
                 shuffledEpisodeQueue = []
 
+                // Forward pre-play picker selections only when the picker
+                // applies to the actual item being played. Show/season Play
+                // resolves to a child episode whose stream ids may differ;
+                // playFromBeginning paths reuse the same metadata so are fine.
+                let useTrackOverrides = (selectedEpisode == nil && selectedTrack == nil)
                 let viewModel = UniversalPlayerViewModel(
                     metadata: playItem,
                     serverURL: authManager.selectedServerURL ?? "",
@@ -1652,7 +1841,9 @@ struct PlexDetailView: View {
                     startOffset: resumeOffset != nil && resumeOffset! > 0 ? resumeOffset : nil,
                     shuffledQueue: queue,
                     loadingArtImage: artImage,
-                    loadingThumbImage: thumbImage
+                    loadingThumbImage: thumbImage,
+                    initialAudioTrackId: useTrackOverrides ? preplayAudioTrackId : nil,
+                    initialSubtitleSelection: useTrackOverrides ? preplaySubtitleSelection : .auto
                 )
 
                 let useApplePlayer = UserDefaults.standard.bool(forKey: "useApplePlayer")


### PR DESCRIPTION
## Summary

Two changes bundled because they only become end-to-end useful
together:

1. **Pre-play track pickers on the detail page** — circular sibling
   buttons (audio + subtitles) on the movie/episode action HStack.
   Selecting a track persists server-side via Plex's
   per-user-per-part stream selection, so the choice applies to
   subsequent plays from any client (Plex Web, mobile, our app),
   mirroring first-party behavior.
2. **Selection-priority fix** — Plex's per-item explicit selection
   now wins over the language-preference managers in
   `applyAudioPreference` / `applySubtitlePreference`. Previously the
   managers returned `eng` even when nothing was stored, which let
   `findBestMatch` override deliberate per-item picks (a user who
   selected "Director's Commentary" in any client would still get
   the highest-channel English track played because TrueHD 7.1 beats
   commentary AC-3).

The two are bundled because the picker UI is mostly cosmetic without
the priority-tier fix — picks survive, but the language manager
overrides them at startup.

## Persistence model

- `PUT /library/parts/<partId>?audioStreamID=X` for audio.
- `PUT /library/parts/<partId>?subtitleStreamID=X` (with `0` for
  subtitles-off) for subs.
- Selection also stored in `@State` on the detail view as a
  same-session fast path. `presentPlayer()` awaits any in-flight
  PUT + `loadFullMetadata` refresh before constructing the player
  VM, so the HLS URL is built against fresh server-side state and
  not stale metadata.
- Plumbed via two new optional `UniversalPlayerViewModel` init
  parameters: `initialAudioTrackId: Int?` and
  `initialSubtitleSelection: InitialSubtitleSelection` — a small enum
  distinguishing "no preselection" / "explicitly off" / specific id.

## New selection priority

In `applyAudioPreference` / `applySubtitlePreference`:

1. Pre-play picker selection from this session.
2. Plex's per-item explicit selection — `selected: true` track that
   is **not** also `default: true` (and for subtitles, also not
   `forced: true`). Distinguishes deliberate user picks from
   default behavior.
3. App-level language preference (existing behavior).
4. Plex's default fallback.

## Implementation notes

- Pickers shown only on `movie` and `episode` detail pages —
  show / season / artist / album / track pages don't expose a single
  playable track list.
- Picker state resets when navigating to a different item within the
  same detail view (via collection / recommendation in-page nav).
- `TrackSelectionSheet.swift` previously existed in the repo with no
  callers; this PR is its first wiring.
- The audio path always issues `selectAudioTrackWithoutSaving` even
  when the resolved id matches `currentAudioTrackId`. Required because
  DirectPlay loads the file's default-flagged audio track on its own
  and Plex's HLS session-build doesn't always reflect the persisted
  per-part selection — an explicit switch is the only reliable way
  to honor the user's actual choice. Cost: a possibly-redundant HLS
  session rebuild at startup; correctness wins.
- Also fills `MediaTrack.extendedDisplayTitle` from `PlexStream` and
  prefers it in `MediaTrack.displayName`, so picker rows show
  "English (AC3 5.1) - Director's Commentary" instead of
  "English (AC3 5.1)" when available.

## Caveats / cross-PR notes

- **Textually overlaps #112.** Both PRs add `extendedDisplayTitle` to
  `MediaTrack` (same field, same init/`PlexStream`-init plumbing).
  Whichever merges first, the other will need a trivial rebase on
  `MediaTrack.swift` — both halves are identical so the resolution
  is just deduplication. #112 is the in-playback menu's use of the
  field; this PR additionally tweaks `displayName` to use it.
- **Subtitle persistence is end-to-end useful only with subtitle
  rendering on `main`.** Currently the `RivuletPlayer` path doesn't
  render text or bitmap subtitles on `main`; the player gets told
  the right subtitle id, but nothing appears on screen. A separate
  PR for subtitle rendering follows. Audio persistence is fully
  end-to-end on this PR alone.

## Test plan

- [x] Apple TV 4K (2nd gen), tvOS 26.4, with Doctor Strange in the
      Multiverse of Madness (UHD HEVC HDR DV + TrueHD/AC-3 commentary
      + multi-track subs)
- [x] Pick commentary audio + commentary subs on detail page → exit
      app → return to detail page → both shown as selected, `Play`
      starts in the correct tracks without re-picking
- [x] Pick a track in Plex Web → open Rivulet detail page → shows
      Plex Web's choice as selected
- [x] Subtitles-off picked → server-side persistence stores `0`
- [x] Show / season / artist pages — no picker buttons rendered

🤖 Authored with assistance from Claude (Anthropic).