### PR TITLE
ci: fix Claude auto-review on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,22 +1,17 @@
 name: Claude Code Review
 
+# Runs on the base repo (not the fork) so OIDC token minting works for
+# fork PRs. Workflow source comes from the base branch — never from the
+# PR head — and an author allowlist limits who can trigger the run.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    if: |
+      github.event.pull_request.user.login == 'l984-451' ||
+      github.event.pull_request.user.login == 'rrgomes'
 
     runs-on: ubuntu-latest
     permissions:
@@ -26,9 +21,10 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout repository
+      - name: Checkout PR head
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 
       - name: Run Claude Code Review
@@ -39,6 +35,3 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-


### PR DESCRIPTION
## Summary

The Claude Code Review workflow was failing on PRs from forks (e.g. PR #112 from rrgomes/Rivulet) with:

> Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?

GitHub Actions disables OIDC token minting for workflows running in a fork's context (the security default for `pull_request`). The action needs OIDC, so fork PRs always failed.

## Fix

Switch the trigger from `pull_request` to `pull_request_target`, which runs the workflow from the base repo (not the fork) with full token privileges. Mitigate the security trade-off with:

1. An **author allowlist** so only trusted contributors (`l984-451`, `rrgomes`) trigger runs
2. Explicit **checkout of the PR head SHA** so the action still reviews the fork's code (not just `main`)
3. Workflow source always comes from the base branch — never the PR head

## Test plan

- [ ] Merge this PR
- [ ] Re-trigger auto-review on PR #112 (push or close/reopen) and confirm it succeeds