### PR TITLE
PlexAPI: derive clientIdentifier per install, not global constant

### DIFF
--- a/Rivulet/Models/Plex/PlexModels.swift
+++ b/Rivulet/Models/Plex/PlexModels.swift
@@ -13,10 +13,31 @@ import Foundation
 /// Plex API constants
 enum PlexAPI: Sendable {
     static let baseUrl = "https://plex.tv"
-    static let clientIdentifier = "com.gstudios.rivulet"
     static let productName = "Rivulet"
     static let deviceName = "Apple TV"
     static let platform = "tvOS"
+
+    /// Stable per-install client identifier. Plex uses this to distinguish
+    /// devices in its Dashboard, attribute transcode sessions, and track
+    /// "Continue Watching" state. Generated as a UUID on first launch and
+    /// persisted in UserDefaults so subsequent launches reuse it.
+    ///
+    /// Earlier Rivulet hardcoded "com.gstudios.rivulet" globally — every
+    /// install on every device identified as the same Plex client, which
+    /// merged multi-device deployments in the Plex Dashboard and let one
+    /// device's traffic redirect another device's transcode session.
+    /// Matches Plezy's `lib/services/storage_service.dart`
+    /// `getOrCreateClientIdentifier` pattern.
+    static let clientIdentifier: String = {
+        let key = "plexClientIdentifier"
+        let defaults = UserDefaults.standard
+        if let stored = defaults.string(forKey: key), !stored.isEmpty {
+            return stored
+        }
+        let generated = UUID().uuidString
+        defaults.set(generated, forKey: key)
+        return generated
+    }()
 }
 
 // MARK: - Server/Device Models

--- a/Rivulet/Models/Plex/PlexModels.swift
+++ b/Rivulet/Models/Plex/PlexModels.swift
@@ -17,17 +17,10 @@ enum PlexAPI: Sendable {
     static let deviceName = "Apple TV"
     static let platform = "tvOS"
 
-    /// Stable per-install client identifier. Plex uses this to distinguish
-    /// devices in its Dashboard, attribute transcode sessions, and track
-    /// "Continue Watching" state. Generated as a UUID on first launch and
-    /// persisted in UserDefaults so subsequent launches reuse it.
-    ///
-    /// Earlier Rivulet hardcoded "com.gstudios.rivulet" globally — every
-    /// install on every device identified as the same Plex client, which
-    /// merged multi-device deployments in the Plex Dashboard and let one
-    /// device's traffic redirect another device's transcode session.
-    /// Matches Plezy's `lib/services/storage_service.dart`
-    /// `getOrCreateClientIdentifier` pattern.
+    /// Per-install UUID generated on first launch and persisted in UserDefaults.
+    /// Plex uses this to distinguish devices in its Dashboard, attribute transcode
+    /// sessions, and route /player control messages — sharing one identifier across
+    /// devices causes Dashboard merges and cross-device transcode session collisions.
     static let clientIdentifier: String = {
         let key = "plexClientIdentifier"
         let defaults = UserDefaults.standard


### PR DESCRIPTION
## Summary

`PlexAPI.clientIdentifier` was hardcoded as `"com.gstudios.rivulet"`
globally — every Rivulet install on every device identifies as the
same Plex client. Replace the constant with a UUID generated at
first launch and persisted in `UserDefaults`; subsequent launches
reuse the stored value.

## Why this matters

Plex routes control messages, attributes transcode sessions, and
deduplicates Dashboard entries by `clientIdentifier`. With every
install sharing a single id, multi-device deployments collide:

- Plex Dashboard shows only one player even when two devices are
  actively streaming.
- One device's playback state can clobber another's, because Plex
  routes `/player` control endpoints by `clientIdentifier`.
- A transcode session originated by one device can be repurposed
  by another device's traffic mid-playback, with downstream
  player-side crashes (different track layout / segment cadence).

The fix matches Plezy's `lib/services/storage_service.dart`
`getOrCreateClientIdentifier` pattern, which has the same
constraints and reaches the same conclusion. Plex's own apps each
generate a per-install id; this brings Rivulet in line.

## Migration

Existing installs migrate transparently — on next launch they get
a fresh UUID and Plex sees them as a brand-new client. Per-item
`viewOffset` (Continue Watching position) is keyed on metadata, not
client identity, so resume points are preserved. The old Plex.tv
"Authorized devices" entry tied to the global identifier becomes
inactive after migration and can be pruned manually.

## Test plan

- [x] Two Apple TVs running the new build show up as two separate
      players in Plex Dashboard
- [x] First-launch generates a fresh UUID and persists it in
      UserDefaults under key `plexClientIdentifier`
- [x] Second launch reads the stored value (UUID stays stable
      across app restarts)
- [x] Continue Watching resume points carry forward from
      pre-migration state on first launch after upgrade
- [x] Multi-device WT session — host transcode session is no
      longer affected by guest's separate Plex traffic

🤖 Authored with assistance from Claude (Anthropic).