### PR TITLE
PlexAPI: preserve selectedServerToken when per-server lookup falls through

### DIFF
--- a/Rivulet/Services/Plex/PlexNetworkManager.swift
+++ b/Rivulet/Services/Plex/PlexNetworkManager.swift
@@ -2498,12 +2498,22 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
                 }
             }
 
-            // Fallback: return the authToken itself (works for server owners)
-            print("🌐 PlexNetwork: ⚠️ No server-specific token found, using plex.tv auth token")
-            return authToken
+            // No per-server token found. Returning the input plex.tv-level
+            // authToken here was the previous behavior, but for accounts
+            // that have multiple servers in their resources list (server
+            // owner of one + friend-share on another, or two friend-shares),
+            // the matching above can fall through. The plex.tv-level token
+            // doesn't authenticate against the target PMS the same way a
+            // per-server access token does — the server logs the request
+            // as "Signed-in Token ()" with no user attribution and treats
+            // the user as guest, returning 401 on per-section/streaming
+            // endpoints. Returning nil instead lets the caller (selectUser)
+            // keep the per-server token that selectServer set up at sign-in.
+            print("🌐 PlexNetwork: ⚠️ No per-server token found for serverURL=\(serverURL); returning nil to preserve existing selectedServerToken")
+            return nil
         } catch {
-            print("🌐 PlexNetwork: ❌ Failed to get server access token: \(error)")
-            return authToken
+            print("🌐 PlexNetwork: ❌ Failed to get server access token: \(error) — returning nil")
+            return nil
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes a 401 cascade for accounts whose plex.tv resources list contains multiple servers (server owner of one + friend on another, or two friend-shares).

## Symptoms
- 401 on `GET /library/sections/<id>/all` (browse)
- 401 on `GET /library/metadata/<id>/thumb/...` (artwork)
- 401 on `GET /hubs/sections/<id>` (hubs)
- FFmpeg `avformat_open_input` failure on streaming (manifests in Rivulet's player as "Couldn't Load Video")

The target server logs each failing request as `Signed-in Token ()` with empty user attribution, and `Auth: authenticating user as guest`.

## Cause
`getServerAccessToken` iterates the resources list looking for a server matching `selectedServerURL` by machineIdentifier or connection URI. When account has only one server, the final `if servers.count == 1` shortcut catches the match. For multi-server accounts that shortcut doesn't apply and the per-server matching can fall through.

The pre-existing fallback returned the input plex.tv-level authToken, which `selectUser` then stored as `selectedServerToken` via `updateServerToken`. That plex.tv-level token is recognized by the target PMS as a valid Signed-in Token format but doesn't resolve to any user account on that server — hence the empty parens in the log attribution and the guest treatment that returns 401.

## Fix
Return \`nil\` from \`getServerAccessToken\` in both fallback paths instead. \`selectUser\` already handles a nil return by returning false, and the caller (\`restoreOrSelectDefaultUser\`) handles a false return by setting the user locally without calling \`updateServerToken\` — preserving the correct per-server token that \`selectServer\` set up at sign-in.

The matching logic in \`getServerAccessToken\` could probably be improved further (handle non-plex.direct URL shapes, more URI variants), but those are separate concerns; this is the minimal change that stops the silent token corruption.

## Test plan
- [x] Built and tested on Apple TV 4K (2nd gen), tvOS 26.4, both Debug and Release configurations.
- [x] Verified pre-fix repro on a real shared-user Plex account with two servers in resources (browse + artwork + streaming all 401).
- [x] Verified post-fix the same account browses, loads artwork, and streams without 401s.
- [x] Verified single-server accounts (where the existing \`servers.count == 1\` shortcut catches the match) continue to work unchanged.