### PR TITLE
Player: surface timeline overlay on bare touchpad tap

### DIFF
--- a/Rivulet/Views/Player/PlayerContainerViewController.swift
+++ b/Rivulet/Views/Player/PlayerContainerViewController.swift
@@ -20,6 +20,7 @@ class PlayerContainerViewController: UIViewController {
     private var hostingController: UIHostingController<AnyView>?
     private var cancellables = Set<AnyCancellable>()
     private var panGestureRecognizer: UIPanGestureRecognizer?
+    private var touchSurfaceTapGesture: UITapGestureRecognizer?
 
     // Directional gesture recognizers for IR remote support
     private var dPadLeftTapGesture: UITapGestureRecognizer?
@@ -83,6 +84,10 @@ class PlayerContainerViewController: UIViewController {
 
         // Pan gesture for swipe-to-scrub on Siri Remote touchpad
         setupPanGesture()
+
+        // Bare-tap on the Siri Remote touch surface surfaces the timeline
+        // overlay briefly (matches Plex's tvOS client behavior).
+        setupTouchSurfaceTapGesture()
 
         // Directional gestures for IR remote support (learned remotes, universal remotes)
         // These fire UIPress events with leftArrow/rightArrow, NOT GameController events
@@ -294,6 +299,35 @@ class PlayerContainerViewController: UIViewController {
         panRecognizer.allowedTouchTypes = [NSNumber(value: UITouch.TouchType.indirect.rawValue)]
         view.addGestureRecognizer(panRecognizer)
         panGestureRecognizer = panRecognizer
+    }
+
+    // MARK: - Touch-Surface Tap (timeline overlay)
+
+    /// Bare-tap on the Siri Remote touch surface (no force/click). Fires
+    /// only on `.indirect` touches — the touchpad — and not on `.select`
+    /// presses (those are the click and are routed to play/pause via the
+    /// micro-gamepad buttonA handler). Coexists with the pan recognizer:
+    /// if the user starts moving, pan takes over and tap doesn't fire.
+    private func setupTouchSurfaceTapGesture() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(handleTouchSurfaceTap))
+        tap.allowedTouchTypes = [NSNumber(value: UITouch.TouchType.indirect.rawValue)]
+        // On tvOS, UITapGestureRecognizer defaults allowedPressTypes to
+        // [.select], so without this it would silently wait for a click
+        // rather than a bare finger tap.
+        tap.allowedPressTypes = []
+        view.addGestureRecognizer(tap)
+        touchSurfaceTapGesture = tap
+    }
+
+    @objc private func handleTouchSurfaceTap() {
+        guard let vm = viewModel else { return }
+        guard !vm.showInfoPanel,
+              !vm.isScrubbing,
+              vm.postVideoState == .hidden,
+              !vm.playbackState.isFailed
+        else { return }
+
+        vm.showControlsTemporarily()
     }
 
     // MARK: - Directional Gestures (IR Remote Support)


### PR DESCRIPTION
## Summary

A bare finger tap on the Siri Remote touchpad (no force/click) does nothing in the player today — the timeline / playback controls only appear when paused, when the user begins scrubbing, or when other state changes trigger them. Plex's first-party tvOS client surfaces controls briefly on tap, which is the discoverability-friendly default for "where am I in this episode?". This PR matches that behavior.

## What it does

- **`PlayerContainerViewController.swift`** — adds a `UITapGestureRecognizer` filtered to `.indirect` touch types (Siri Remote touchpad). On tap, calls the existing `viewModel.showControlsTemporarily()`, which already handles the show + auto-hide logic. Standard guards before triggering: bail if the info panel is open, the user is mid-scrub, post-video is showing, or playback has failed.
- The recognizer sets `allowedPressTypes = []` explicitly because `UITapGestureRecognizer` on tvOS defaults to waiting for a `.select` press in `allowedPressTypes`. Without overriding that, the recognizer never fires on a bare touch even when `allowedTouchTypes = [.indirect]` is set. Click-based interactions (play/pause via the `GCMicroGamepad` `buttonA` handler, dpad press handling) are unchanged.
- Coexists with the existing `UIPanGestureRecognizer` (swipe-to-scrub, swipe-down for info panel): the tap recognizes only on a quick touch-and-lift; if the user starts moving their finger, the pan recognizer takes over and the tap doesn't fire.

## Test plan

- [x] Bare tap during playback: timeline overlay appears, auto-hides ~3s after playback resumes. Verified on Apple TV 4K (tvOS 26.4).
- [x] Swipe-to-scrub (paused state) still works as before.
- [x] Touchpad click for play/pause still works as before.
- [x] Swipe-down to open the info panel still works.
- [x] Tap during scrubbing does not trigger overlay (gated by `isScrubbing` guard).
- [x] Tap with info panel open does not trigger overlay (gated by `showInfoPanel` guard).
- [x] Built clean against `upstream/main` with `CODE_SIGNING_ALLOWED=NO`.

## Notes

- LLM-assisted authorship per [README.md#contributing](https://github.com/l984-451/Rivulet#readme): code reviewed and tested end-to-end before submission.