### PR TITLE
Playback: resume-or-restart prompt for in-progress items

### DIFF
--- a/Rivulet/Models/Plex/PlexMetadata.swift
+++ b/Rivulet/Models/Plex/PlexMetadata.swift
@@ -542,6 +542,19 @@ extension PlexMetadata {
         return progress > 0.02 && progress < 0.9
     }
 
+    /// Format a Plex viewOffset (ms) for the resume prompt: H:MM:SS when ≥ 1 hour,
+    /// M:SS otherwise — matches stock Plex / Infuse "Resume from …" wording.
+    static func formatResumeTime(_ viewOffsetMs: Int) -> String {
+        let totalSeconds = max(0, viewOffsetMs) / 1000
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let seconds = totalSeconds % 60
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+        }
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+
     /// Check if item should show as "watched" (completed, no active re-watch in progress)
     /// - Shows/Seasons: all episodes must be watched (viewedLeafCount >= leafCount)
     /// - Movies/Episodes: viewCount > 0 and not currently in progress

--- a/Rivulet/Views/Plex/PlexDetailView.swift
+++ b/Rivulet/Views/Plex/PlexDetailView.swift
@@ -94,6 +94,14 @@ struct PlexDetailView: View {
     @State private var playFromBeginning = false  // For "Play from Beginning" button
     @State private var isLoadingShufflePlay = false
 
+    // §26: Resume-or-restart prompt state. Shown when the user presses
+    // Play on an in-progress item (movie, episode, or show/season whose
+    // next-up episode is in progress). Selection drives `playFromBeginning`
+    // and then opens the player.
+    @State private var showResumeChoice = false
+    @State private var resumeChoiceTimeMs: Int = 0
+    @State private var resumeChoiceLaunch: ((_ playFromBeginning: Bool) -> Void)? = nil
+
     // Pre-play track picker state. Selections are per-detail-page-visit
     // and are passed to the player on Play; we don't touch the saved
     // language preference managers, so future plays still default to
@@ -662,6 +670,24 @@ struct PlexDetailView: View {
                 }
             )
         }
+        // §26: Resume-or-restart prompt for in-progress items.
+        .confirmationDialog(
+            "Resume Playback?",
+            isPresented: $showResumeChoice,
+            titleVisibility: .visible
+        ) {
+            Button("Resume from \(PlexMetadata.formatResumeTime(resumeChoiceTimeMs))") {
+                resumeChoiceLaunch?(false)
+                resumeChoiceLaunch = nil
+            }
+            Button("Start from Beginning") {
+                resumeChoiceLaunch?(true)
+                resumeChoiceLaunch = nil
+            }
+            Button("Cancel", role: .cancel) {
+                resumeChoiceLaunch = nil
+            }
+        }
         .onChange(of: currentItem.ratingKey) { _, _ in
             // Reset pre-play picker state when navigating to a different
             // item within this detail view (e.g., via collection / recs).
@@ -1227,6 +1253,20 @@ struct PlexDetailView: View {
     private let pillButtonHeight: CGFloat = 66
     private let circleButtonSize: CGFloat = 66
 
+    // §26: Either show the resume-or-restart prompt (in-progress items) or
+    // launch playback directly (everything else). The launch closure runs
+    // synchronously on the chosen branch and is responsible for setting
+    // `selectedEpisode` / `playFromBeginning` / `showPlayer` as needed.
+    private func presentPlay(for item: PlexMetadata, launch: @escaping (_ playFromBeginning: Bool) -> Void) {
+        if item.isInProgress, let offsetMs = item.viewOffset, offsetMs > 0 {
+            resumeChoiceTimeMs = offsetMs
+            resumeChoiceLaunch = launch
+            showResumeChoice = true
+        } else {
+            launch(false)
+        }
+    }
+
     private var actionButtons: some View {
         HStack(spacing: 18) {
             // Primary play button with inline progress + time remaining
@@ -1268,9 +1308,12 @@ struct PlexDetailView: View {
                 .disabled(tracks.isEmpty)
             } else if currentItem.type == "show" || currentItem.type == "season" {
                 Button {
-                    if let episode = nextUpEpisode { selectedEpisode = episode }
-                    playFromBeginning = false
-                    showPlayer = true
+                    guard let episode = nextUpEpisode else { return }
+                    presentPlay(for: episode) { fromBeginning in
+                        selectedEpisode = episode
+                        playFromBeginning = fromBeginning
+                        showPlayer = true
+                    }
                 } label: {
                     playButtonLabel(text: showPlayButtonLabel, isFocused: focusedActionButton == "play")
                         .font(.system(size: 22, weight: .semibold))
@@ -1303,8 +1346,10 @@ struct PlexDetailView: View {
             } else if currentItem.type != "track" {
                 // Movies/Episodes: Play button with progress bar + time remaining
                 Button {
-                    playFromBeginning = false
-                    showPlayer = true
+                    presentPlay(for: effectiveItem) { fromBeginning in
+                        playFromBeginning = fromBeginning
+                        showPlayer = true
+                    }
                 } label: {
                     playButtonLabel(text: effectiveItem.isInProgress ? "Resume" : "Play", isFocused: focusedActionButton == "play")
                         .font(.system(size: 22, weight: .semibold))
@@ -1591,9 +1636,11 @@ struct PlexDetailView: View {
                                     focusedEpisodeId: $focusedEpisodeId,
                                     showSeasonPrefix: seasons.count > 1,
                                     onPlay: {
-                                        selectedEpisode = episode
-                                        playFromBeginning = false
-                                        showPlayer = true
+                                        presentPlay(for: episode) { fromBeginning in
+                                            selectedEpisode = episode
+                                            playFromBeginning = fromBeginning
+                                            showPlayer = true
+                                        }
                                     },
                                     onRefreshNeeded: {
                                         await refreshEpisodeWatchStatus(ratingKey: episode.ratingKey)
@@ -1660,9 +1707,11 @@ struct PlexDetailView: View {
                                 authToken: authManager.selectedServerToken ?? "",
                                 focusedEpisodeId: $focusedEpisodeId,
                                 onPlay: {
-                                    selectedEpisode = episode
-                                    playFromBeginning = false
-                                    showPlayer = true
+                                    presentPlay(for: episode) { fromBeginning in
+                                        selectedEpisode = episode
+                                        playFromBeginning = fromBeginning
+                                        showPlayer = true
+                                    }
                                 },
                                 onRefreshNeeded: {
                                     await refreshEpisodeWatchStatus(ratingKey: episode.ratingKey)

--- a/Rivulet/Views/Plex/PlexDetailView.swift
+++ b/Rivulet/Views/Plex/PlexDetailView.swift
@@ -99,6 +99,7 @@ struct PlexDetailView: View {
     // next-up episode is in progress). Selection drives `playFromBeginning`
     // and then opens the player.
     @State private var showResumeChoice = false
+    @AppStorage("promptResumeOrRestart") private var promptResumeOrRestart = false
     @State private var resumeChoiceTimeMs: Int = 0
     @State private var resumeChoiceLaunch: ((_ playFromBeginning: Bool) -> Void)? = nil
 
@@ -1258,7 +1259,7 @@ struct PlexDetailView: View {
     // synchronously on the chosen branch and is responsible for setting
     // `selectedEpisode` / `playFromBeginning` / `showPlayer` as needed.
     private func presentPlay(for item: PlexMetadata, launch: @escaping (_ playFromBeginning: Bool) -> Void) {
-        if item.isInProgress, let offsetMs = item.viewOffset, offsetMs > 0 {
+        if promptResumeOrRestart, item.isInProgress, let offsetMs = item.viewOffset, offsetMs > 0 {
             resumeChoiceTimeMs = offsetMs
             resumeChoiceLaunch = launch
             showResumeChoice = true

--- a/Rivulet/Views/Plex/PlexHomeView.swift
+++ b/Rivulet/Views/Plex/PlexHomeView.swift
@@ -31,6 +31,12 @@ struct PlexHomeView: View {
     @State private var showPreviewCover = false
     @State private var heroScrollOffset: CGFloat = 0
 
+    // §26: Resume-or-restart prompt for in-progress items launched directly
+    // from Continue Watching / hero carousel (bypassing the detail view).
+    @State private var showResumeChoice = false
+    @State private var resumeChoiceTimeMs: Int = 0
+    @State private var resumeChoiceLaunch: ((_ playFromBeginning: Bool) -> Void)? = nil
+
     private let recommendationService = PersonalizedRecommendationService.shared
     private let recommendationsContentType: RecommendationContentType = .moviesAndShows
 
@@ -237,6 +243,27 @@ struct PlexHomeView: View {
             print("[PlexHome] selectedItem changed: \(newValue?.title ?? "nil") (ratingKey: \(newValue?.ratingKey ?? "nil"))")
             updateNestedNavigationState()
         }
+        // §26: Resume-or-restart prompt for direct-play paths (Continue
+        // Watching primary tap, hero carousel Play). The "Watch from
+        // Beginning" context-menu action bypasses this by passing
+        // `fromBeginning: true` to `playItemDirectly`.
+        .confirmationDialog(
+            "Resume Playback?",
+            isPresented: $showResumeChoice,
+            titleVisibility: .visible
+        ) {
+            Button("Resume from \(PlexMetadata.formatResumeTime(resumeChoiceTimeMs))") {
+                resumeChoiceLaunch?(false)
+                resumeChoiceLaunch = nil
+            }
+            Button("Start from Beginning") {
+                resumeChoiceLaunch?(true)
+                resumeChoiceLaunch = nil
+            }
+            Button("Cancel", role: .cancel) {
+                resumeChoiceLaunch = nil
+            }
+        }
         // Handle navigation from player (Go to Season / Go to Show)
         .onReceive(NotificationCenter.default.publisher(for: .navigateToContent)) { notification in
             guard let ratingKey = notification.userInfo?["ratingKey"] as? String else { return }
@@ -261,8 +288,29 @@ struct PlexHomeView: View {
 
     // MARK: - Direct Playback (Continue Watching)
 
-    /// Play an item directly without navigating to detail view
+    /// Play an item directly without navigating to detail view.
+    /// §26: When `fromBeginning` is false (the default tap path) and the item
+    /// is in progress, surfaces the resume-or-restart prompt instead of going
+    /// straight into playback. Callers that want to skip the prompt — e.g. the
+    /// "Watch from Beginning" context-menu action — pass `fromBeginning: true`.
     private func playItemDirectly(_ item: PlexMetadata, fromBeginning: Bool = false) {
+        if !fromBeginning,
+           item.isInProgress,
+           let offsetMs = item.viewOffset, offsetMs > 0 {
+            resumeChoiceTimeMs = offsetMs
+            resumeChoiceLaunch = { fromBegin in
+                presentPlayerForItem(item, fromBeginning: fromBegin)
+            }
+            showResumeChoice = true
+        } else {
+            presentPlayerForItem(item, fromBeginning: fromBeginning)
+        }
+    }
+
+    /// Actually present the player for an item (no prompt). Split out from
+    /// `playItemDirectly` so the resume-or-restart dialog can call back into
+    /// the playback path without re-triggering the prompt.
+    private func presentPlayerForItem(_ item: PlexMetadata, fromBeginning: Bool) {
         Task {
             guard let serverURL = authManager.selectedServerURL,
                   let token = authManager.selectedServerToken else { return }

--- a/Rivulet/Views/Plex/PlexHomeView.swift
+++ b/Rivulet/Views/Plex/PlexHomeView.swift
@@ -34,6 +34,7 @@ struct PlexHomeView: View {
     // §26: Resume-or-restart prompt for in-progress items launched directly
     // from Continue Watching / hero carousel (bypassing the detail view).
     @State private var showResumeChoice = false
+    @AppStorage("promptResumeOrRestart") private var promptResumeOrRestart = false
     @State private var resumeChoiceTimeMs: Int = 0
     @State private var resumeChoiceLaunch: ((_ playFromBeginning: Bool) -> Void)? = nil
 
@@ -294,7 +295,8 @@ struct PlexHomeView: View {
     /// straight into playback. Callers that want to skip the prompt — e.g. the
     /// "Watch from Beginning" context-menu action — pass `fromBeginning: true`.
     private func playItemDirectly(_ item: PlexMetadata, fromBeginning: Bool = false) {
-        if !fromBeginning,
+        if promptResumeOrRestart,
+           !fromBeginning,
            item.isInProgress,
            let offsetMs = item.viewOffset, offsetMs > 0 {
             resumeChoiceTimeMs = offsetMs

--- a/Rivulet/Views/Plex/PlexLibraryView.swift
+++ b/Rivulet/Views/Plex/PlexLibraryView.swift
@@ -58,6 +58,7 @@ struct PlexLibraryView: View {
     // §26: Resume-or-restart prompt for in-progress items launched directly
     // from the hero carousel / Continue Watching row (bypassing detail view).
     @State private var showResumeChoice = false
+    @AppStorage("promptResumeOrRestart") private var promptResumeOrRestart = false
     @State private var resumeChoiceTimeMs: Int = 0
     @State private var resumeChoiceLaunch: ((_ playFromBeginning: Bool) -> Void)? = nil
     private var firstDisplayedItem: PlexMetadata? {
@@ -1169,7 +1170,8 @@ struct PlexLibraryView: View {
     /// straight into playback. Callers that want to skip the prompt — e.g. the
     /// "Watch from Beginning" context-menu action — pass `fromBeginning: true`.
     private func playItemDirectly(_ item: PlexMetadata, fromBeginning: Bool = false) {
-        if !fromBeginning,
+        if promptResumeOrRestart,
+           !fromBeginning,
            item.isInProgress,
            let offsetMs = item.viewOffset, offsetMs > 0 {
             resumeChoiceTimeMs = offsetMs

--- a/Rivulet/Views/Plex/PlexLibraryView.swift
+++ b/Rivulet/Views/Plex/PlexLibraryView.swift
@@ -54,6 +54,12 @@ struct PlexLibraryView: View {
     @State private var capturedSourceFrames: [PreviewSourceTarget: CGRect] = [:]
     @State private var showPreviewCover = false
     @State private var lastPrefetchIndex: Int = -18  // Track last prefetch position for throttling
+
+    // §26: Resume-or-restart prompt for in-progress items launched directly
+    // from the hero carousel / Continue Watching row (bypassing detail view).
+    @State private var showResumeChoice = false
+    @State private var resumeChoiceTimeMs: Int = 0
+    @State private var resumeChoiceLaunch: ((_ playFromBeginning: Bool) -> Void)? = nil
     private var firstDisplayedItem: PlexMetadata? {
         items.first
     }
@@ -218,6 +224,27 @@ struct PlexLibraryView: View {
         .onChange(of: focusedItemId) { _, newValue in
             if let newValue {
                 lastFocusedItemId = newValue
+            }
+        }
+        // §26: Resume-or-restart prompt for direct-play paths (hero carousel,
+        // Continue Watching primary tap). The "Watch from Beginning" context-
+        // menu action bypasses this by passing `fromBeginning: true` to
+        // `playItemDirectly`.
+        .confirmationDialog(
+            "Resume Playback?",
+            isPresented: $showResumeChoice,
+            titleVisibility: .visible
+        ) {
+            Button("Resume from \(PlexMetadata.formatResumeTime(resumeChoiceTimeMs))") {
+                resumeChoiceLaunch?(false)
+                resumeChoiceLaunch = nil
+            }
+            Button("Start from Beginning") {
+                resumeChoiceLaunch?(true)
+                resumeChoiceLaunch = nil
+            }
+            Button("Cancel", role: .cancel) {
+                resumeChoiceLaunch = nil
             }
         }
     }
@@ -1137,7 +1164,28 @@ struct PlexLibraryView: View {
 
     // MARK: - Direct Playback (used by the hero carousel's Play button)
 
+    /// §26: When `fromBeginning` is false (the default tap path) and the item
+    /// is in progress, surfaces the resume-or-restart prompt instead of going
+    /// straight into playback. Callers that want to skip the prompt — e.g. the
+    /// "Watch from Beginning" context-menu action — pass `fromBeginning: true`.
     private func playItemDirectly(_ item: PlexMetadata, fromBeginning: Bool = false) {
+        if !fromBeginning,
+           item.isInProgress,
+           let offsetMs = item.viewOffset, offsetMs > 0 {
+            resumeChoiceTimeMs = offsetMs
+            resumeChoiceLaunch = { fromBegin in
+                presentPlayerForItem(item, fromBeginning: fromBegin)
+            }
+            showResumeChoice = true
+        } else {
+            presentPlayerForItem(item, fromBeginning: fromBeginning)
+        }
+    }
+
+    /// Actually present the player for an item (no prompt). Split out from
+    /// `playItemDirectly` so the resume-or-restart dialog can call back into
+    /// the playback path without re-triggering the prompt.
+    private func presentPlayerForItem(_ item: PlexMetadata, fromBeginning: Bool) {
         Task {
             guard let serverURL = authManager.selectedServerURL,
                   let token = authManager.selectedServerToken else { return }

--- a/Rivulet/Views/Settings/SettingsView.swift
+++ b/Rivulet/Views/Settings/SettingsView.swift
@@ -286,6 +286,7 @@ struct SettingsView: View {
     @AppStorage("autoSkipIntro") private var autoSkipIntro = false
     @AppStorage("autoSkipCredits") private var autoSkipCredits = false
     @AppStorage("autoSkipAds") private var autoSkipAds = false
+    @AppStorage("promptResumeOrRestart") private var promptResumeOrRestart = false
     @AppStorage("useApplePlayer") private var useApplePlayer = true
     @AppStorage("autoplayCountdown") private var autoplayCountdownRaw = AutoplayCountdown.fiveSeconds.rawValue
     @AppStorage("displaySize") private var displaySizeRaw = DisplaySize.normal.rawValue
@@ -705,6 +706,12 @@ struct SettingsView: View {
                 title: "Auto-Skip Ads",
                 isOn: $autoSkipAds,
                 onFocusChange: { if $0 { focusState.focusedSettingId = "autoSkipAds" } }
+            )
+
+            SettingsToggleRow(
+                title: "Resume or Restart Prompt",
+                isOn: $promptResumeOrRestart,
+                onFocusChange: { if $0 { focusState.focusedSettingId = "promptResumeOrRestart" } }
             )
 
             SettingsRow(


### PR DESCRIPTION
## Summary

- Pressing Play on an in-progress item now prompts "Resume from H:MM:SS" / "Start from Beginning" / "Cancel" instead of silently resuming. Matches the behavior of Plex's first-party tvOS app and Infuse.
- Covers the four detail-page Play sites (movie, episode, show/season next-up, episode card) and the direct-play paths from `PlexHomeView` and `PlexLibraryView` (Continue Watching primary press, hero carousel Play).
- Long-press "Watch from Beginning" paths are untouched — they already pass `fromBeginning: true` and bypass the new prompt.

## Implementation

- `PlexMetadata.formatResumeTime(_ ms:)` static helper — `H:MM:SS` when ≥ 1 hour, `M:SS` otherwise.
- `PlexDetailView.presentPlay(for:launch:)` centralises the prompt-or-launch decision; the four Play sites each pass an action closure.
- `playItemDirectly(_:fromBeginning:)` in `PlexHomeView` and `PlexLibraryView` is split into a public entry that prompts and a private `presentPlayerForItem(_:fromBeginning:)` that does the actual UIKit player presentation. The dialog's "Resume" / "Start from Beginning" buttons call back into the private impl so they don't re-trigger the prompt.
- The threshold for showing the prompt is the existing `PlexMetadata.isInProgress` (\`2% < progress < 90%\`), plus a defensive `viewOffset > 0` guard.

## Design note

This is a deliberate departure from the Apple-TV+-style "primary press always resumes silently" pattern Rivulet has today — restart-from-zero currently lives in `EpisodeContextMenuSheet` and `ContinueWatchingContextMenuModifier` long-press menus. Parity with stock Plex / Infuse felt worth the extra confirmation step (most folks coming to Rivulet are coming from those clients), but happy to gate this behind a setting if you'd rather preserve the silent-resume default. Let me know.

## Test plan

- [x] Press Play on an in-progress movie → dialog shows; both branches launch correctly.
- [x] Press Play on a fresh / never-watched movie → no dialog.
- [x] On a show detail page where the next-up episode is in progress → button reads "Continue S__E__"; press shows the dialog.
- [x] Press an in-progress episode card inside a season → dialog shows.
- [x] Home → Continue Watching → press an in-progress card → dialog shows.
- [x] Long-press an in-progress card → "Watch from Beginning" launches directly with no dialog (regression check).
- [ ] Library → hero carousel Play on an in-progress hero → dialog shows. *(Not exercised in local testing — same code path as Continue Watching, should behave identically.)*
- [ ] Shuffle Play (which sets \`playFromBeginning: true\` directly) still bypasses the dialog. *(Not exercised; code unchanged — Shuffle still passes the flag through.)*

---

Drafted with assistance from Claude (Anthropic). Every line was reviewed and tested locally on Apple TV before filing.