### PR TITLE
DirectPlay: refresh demuxer keyframe on Play after paused-seek

### DIFF
--- a/Rivulet/Services/Plex/Playback/Pipeline/DirectPlayPipeline.swift
+++ b/Rivulet/Services/Plex/Playback/Pipeline/DirectPlayPipeline.swift
@@ -576,6 +576,19 @@ final class DirectPlayPipeline {
         }
 
         let isResume = (state == .paused && readTask != nil)
+        // Distinguish a fresh start that follows a paused-seek (state was
+        // .paused, readTask was nil because the paused-seek inline path
+        // exited the loop after enqueueing one preview keyframe) from a
+        // fresh start at initial load (state was .ready). In the
+        // paused-seek case the demuxer has been advanced past that
+        // keyframe, so the next reads return non-keyframe P/B packets.
+        // Without intervention those feed into a display layer whose
+        // decoder reference can be stale across a long paused gap, and
+        // the visible result is a frozen image while the synchronizer
+        // clock advances and audio plays normally. Re-seeking the demuxer
+        // before startReadLoop() guarantees a keyframe heads the new read
+        // sequence.
+        let isFreshStartFromPaused = (state == .paused && readTask == nil)
         isPlaying = true
         playbackRate = rate
         state = .running
@@ -605,6 +618,21 @@ final class DirectPlayPipeline {
             deferRunningStateChange = true
             playerDebugLog("[DirectPlay] start(rate=\(rate))")
             playerDebugLog("[StartupTrace] start(): deferring .running emission until preroll completes")
+
+            // Refresh the demuxer position so the next read loop's first
+            // packet is a keyframe — see comment above. Skipped for the
+            // state==.ready initial-load case where the demuxer is already
+            // keyframe-aligned at the open position.
+            if isFreshStartFromPaused {
+                let resumeTime = renderer.currentTime
+                do {
+                    try demuxer.seek(to: resumeTime)
+                    playerDebugLog("[DirectPlay] start(): re-seeking demuxer to \(String(format: "%.3f", resumeTime))s after paused-seek")
+                } catch {
+                    playerDebugLog("[DirectPlay] start(): demuxer re-seek failed at \(String(format: "%.3f", resumeTime))s: \(error)")
+                }
+            }
+
             startReadLoop()
         }
     }


### PR DESCRIPTION
## Summary

- When the user pauses, scrubs to a new position while paused, then presses Play, the playback pipeline can hit an indeterminate visible freeze — synchronizer clock advances, audio plays normally, but no decoded video appears until a real IDR keyframe arrives in the stream (often 10+ seconds later).
- Root cause: in the "fresh start from paused-seek" path of `DirectPlayPipeline.start()`, the demuxer is positioned past the keyframe that was enqueued for the seek-preview frame, so the new read loop's first packet is a non-keyframe P/B sample. Feeding it into a display layer whose decoder reference has aged out during the paused gap → no decoded output.
- Fix: in `start()`'s fresh-start branch, when we know the prior state was paused-after-seek (state was `.paused`, readTask was `nil`), re-seek the demuxer to the synchronizer's current time before `startReadLoop()`. The new read sequence now begins on a fresh keyframe.

## Reproduction

DV+HEVC+FLAC mkv, paused-seek backward ~30 s, press Play. The post-Play read loop's first packets are all `keyframe=false`. Preroll completes, `rate=1.0`, audio flows, `PlaybackHealth verdict=GOOD` — but the user sees a frozen image until the next IDR in the stream (often 10+ seconds later).

## Verification

Verified on a 4K DV mkv with FLAC stereo: 5 deliberate paused-seek-then-Play attempts plus 2 ancillary. Every attempt now logs \`[DirectPlay] start(): re-seeking demuxer to X.XXXs after paused-seek\` and the next packet read is a keyframe. No extended freezes observed.

## Tradeoff

The \`demuxer.seek(to:)\` invalidates FFmpeg's read-buffer state, forcing the read loop to re-warm against the network. Visible result is a brief "audio leads, video catches up" cold-start lasting ~5–10 s (\`audioAhead=2.0–2.6s\`, \`wall=0.5x\`, \`PlaybackHealth verdict=WARN\`) before recovering to \`GOOD\`. Pre-fix, the freeze masked this latency; post-fix it's exposed but bounded.

We considered avoiding this by saving the seek-preview keyframe sample buffer and re-enqueueing it at \`start()\` time without going back to the demuxer, or by reducing \`requiredPrerollLeadSeconds\` for the warm-resume case — both would reduce the cold-start window but add complexity. Happy to pursue either as a follow-up if you'd prefer the slow-start be tighter.

## Test plan

- [x] Pause-scrub-Play on DV+HEVC mkv (deliberate trigger × 5 attempts) → no freeze.
- [x] Initial-load playback (\`state == .ready\`) untouched — fix gates on \`state == .paused\` only.
- [x] Pause-Resume without scrub untouched — fix gates on \`readTask == nil\` (paused-Resume keeps readTask alive in the pause gate).
- [x] Build succeeds against \`upstream/main\`.
- [ ] No regression on AVPlayer-pipeline path (the fix lives entirely in the rivuletPlayer DirectPlay path, so by construction unaffected).

---

Drafted with assistance from Claude (Anthropic). Every line was reviewed and tested locally on Apple TV before filing.