### PR TITLE
Audio decoder: synthesize default channel layout for UNSPEC PCM-in-MKV

### DIFF
--- a/Rivulet/Services/Plex/Playback/FFmpeg/FFmpegAudioDecoder.swift
+++ b/Rivulet/Services/Plex/Playback/FFmpeg/FFmpegAudioDecoder.swift
@@ -845,6 +845,18 @@ final class FFmpegAudioDecoder: @unchecked Sendable {
         }
 
         var inLayout = frame.pointee.ch_layout
+        // Raw PCM streams arrive without channel-layout metadata
+        // (order=AV_CHANNEL_ORDER_UNSPEC, mask=0). swresample needs a concrete
+        // layout to know the channel ordering — synthesize a default from the
+        // channel count, which gives us the standard MPEG layouts (mono/stereo/
+        // 5.1/7.1) that match channelLayoutTag(for:) on the output side.
+        if inLayout.order == AV_CHANNEL_ORDER_UNSPEC {
+            playerDebugLog(
+                "[AudioDecoder] Input ch_layout was UNSPEC; defaulting to standard " +
+                "\(inputChannels)ch layout for swresample"
+            )
+            av_channel_layout_default(&inLayout, inputChannels)
+        }
         var outLayout: AVChannelLayout
         if needsDownmix {
             outLayout = AVChannelLayout()


### PR DESCRIPTION
## Summary

Raw PCM tracks (`pcm_s16le`, `pcm_s24le`, etc.) demuxed from MKV containers
arrive at `FFmpegAudioDecoder` with `ch_layout.order = AV_CHANNEL_ORDER_UNSPEC`
and `ch_layout.mask = 0`. Matroska's audio track header doesn't carry
channel-position metadata and MakeMKV doesn't synthesize one, so FFmpeg can
only tell us the channel COUNT from the codec, not channel POSITIONS.

We were passing this UNSPEC layout straight into `swr_alloc_set_opts2` for
both input and output sides. `swr_init()` accepts UNSPEC+UNSPEC without
error but then has no defined channel-position semantics, producing audibly
distorted output for every PCM-in-MKV track.

## Fix

In `setupSwresample`, when the input `ch_layout.order` is
`AV_CHANNEL_ORDER_UNSPEC`, call `av_channel_layout_default()` to synthesize
a standard layout (mono / stereo / 5.1 / 7.1) from the channel count. This
matches what `channelLayoutTag(for:)` returns on the output side, so swr
has consistent positions to map between.

## Scope

- Affects every PCM-from-MKV track (Blu-ray rips with raw PCM tracks).
- Other PCM containers (WAV-EXTENSIBLE, MOV) carry channel-mask metadata
  and aren't hit.
- Codecs whose channel mask is part of the bitstream (AC-3, E-AC-3, AAC,
  FLAC) report a real `ch_layout.mask` and aren't affected.

## Test plan

- [ ] Play an MKV with a raw PCM audio track.
- [ ] Confirm clean audio (previously distorted).
- [ ] Confirm a regular MKV/MP4 with AC-3, E-AC-3, AAC, or FLAC still
      plays cleanly (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)