### PR TITLE
Audio decoder: gapless PTS for all decoded buffers, not just resampled

### DIFF
--- a/Rivulet/Services/Plex/Playback/FFmpeg/FFmpegAudioDecoder.swift
+++ b/Rivulet/Services/Plex/Playback/FFmpeg/FFmpegAudioDecoder.swift
@@ -649,24 +649,29 @@ final class FFmpegAudioDecoder: @unchecked Sendable {
         let actualSize = Int(convertedSamples) * Int(outChannels) * bytesPerSample
         let pcmData = Data(bytes: outBuf, count: actualSize)
 
-        // When resampling, use continuous PTS tracking to eliminate micro-gaps.
-        // The resampler output sample count doesn't exactly match source PTS spacing,
-        // creating ~0.37ms gaps per batch that cause audible crackling. By tracking
-        // a running PTS based on actual output samples, each buffer starts exactly
-        // where the previous one ended.
+        // Use continuous PTS tracking to eliminate micro-gaps between buffers.
+        // Two sources of per-buffer drift fall into this:
+        //   1. Resampling: swr_convert's output sample count doesn't exactly match
+        //      source PTS spacing.
+        //   2. Container-tick rounding: FFmpeg's per-frame PTS is rounded to the
+        //      container timebase (e.g., Matroska's 1ms ticks). Frames whose true
+        //      duration doesn't divide evenly into that tick (AAC 1024/48000 ≈
+        //      21.333ms, FLAC 4096/48000 ≈ 85.333ms, PCM 1600/48000 ≈ 33.333ms)
+        //      drift ~0.333ms per frame, which the renderer hears as flutter.
+        //      AC-3 (1536/48000 = 32ms exactly) doesn't drift and so was clean
+        //      while every other codec was distorted.
+        // Tracking a running PTS based on the first frame's anchor + actual output
+        // sample counts makes each buffer start exactly where the previous ended.
         var overridePTS: CMTime?
-        if needsResample {
-            let timescale = Int32(effectiveOutputRate)
-            if continuousOutputPTS.isValid {
-                overridePTS = continuousOutputPTS
-            }
-            // Advance continuous PTS by actual output sample count
-            let outputDuration = CMTime(value: CMTimeValue(convertedSamples), timescale: timescale)
-            if continuousOutputPTS.isValid {
-                continuousOutputPTS = CMTimeAdd(continuousOutputPTS, outputDuration)
-            }
-            // Will be anchored on first valid PTS from buildDecodedFrame
+        let timescale = Int32(effectiveOutputRate)
+        if continuousOutputPTS.isValid {
+            overridePTS = continuousOutputPTS
         }
+        let outputDuration = CMTime(value: CMTimeValue(convertedSamples), timescale: timescale)
+        if continuousOutputPTS.isValid {
+            continuousOutputPTS = CMTimeAdd(continuousOutputPTS, outputDuration)
+        }
+        // Anchored on first valid PTS from buildDecodedFrame.
 
         return buildDecodedFrame(
             data: pcmData, sampleCount: Int(convertedSamples),


### PR DESCRIPTION
## Summary

Per-buffer flutter audible on AAC, FLAC, and PCM tracks but **not** on AC-3
or DTS-HD MA. Mechanism: FFmpeg returns per-frame PTSes rounded to the
container's timebase. For Matroska's 1ms ticks, frames whose true duration
doesn't divide evenly drift ~0.333ms per frame:

| Codec | Frame duration              | Tick rounding | Drift/frame |
|-------|-----------------------------|---------------|-------------|
| AC-3  | 1536/48000 = 32ms exactly   | 32 ticks      | **0**       |
| AAC   | 1024/48000 ≈ 21.333ms       | 21 ticks      | -0.333ms    |
| FLAC  | 4096/48000 ≈ 85.333ms       | 85 ticks      | -0.333ms    |
| PCM   | 1600/48000 ≈ 33.333ms (MKV) | 33 ticks      | -0.333ms    |

Each `CMSampleBuffer` reaching `AVSampleBufferAudioRenderer` therefore
has a tiny PTS/duration mismatch with the next one, which the renderer
hears as a fluttery, noisy artifact at every buffer boundary. AC-3's
frame duration aligns exactly with Matroska ticks, so AC-3 is clean.

Aggregating frames into larger batches attenuates the artifact (fewer
buffer boundaries per second = fewer trigger events) but doesn't
eliminate it.

## Fix

The `continuousOutputPTS` mechanism already in this file solves exactly
this problem -- the comment literally says "creating ~0.37ms gaps per
batch that cause audible crackling". It was gated to `needsResample`
only. Container-tick rounding is the same micro-gap class, so the gate
comes off and the docstring is updated to cover both sources.

`continuousOutputPTS` is anchored on the first valid frame's PTS, then
advances by exact output sample counts. Each subsequent buffer's PTS is
overridden to be precisely where the previous buffer ended.

## Scope

- Affects every codec with non-tick-aligned frame durations in
  containers with coarse PTS timebases. Practically: AAC, FLAC, PCM in
  MKV (1ms ticks).
- Benign for codecs where FFmpeg's per-frame PTS already aligns (AC-3,
  E-AC-3, DTS-HD MA, anything with frame durations divisible by the
  container tick). The override produces the same PTS the renderer
  would have gotten from FFmpeg.
- The resample path is unchanged in behavior — that branch already
  used the override before this change.
- Stacks with #125 (PCM-in-MKV channel layout); both are needed for
  fully-clean PCM-from-MKV playback.

## Test plan

- [ ] Play AAC, FLAC, and PCM tracks from MKVs. All should be clean
      (previously AAC/FLAC/PCM had audible flutter).
- [ ] Quick regression check on AC-3 and DTS-HD MA tracks (no audible
      change expected; was already clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)