### PR TITLE
Detail page: full description sheet + spoiler blur + dual-button card

### DIFF
--- a/Rivulet/Views/Media/MediaDetailView.swift
+++ b/Rivulet/Views/Media/MediaDetailView.swift
@@ -103,6 +103,7 @@ struct MediaDetailView: View {
     // Long-press "Watch from Beginning" paths bypass the prompt because
     // they pass `fromBeginning: true` to the launch closure directly.
     @AppStorage("promptResumeOrRestart") private var promptResumeOrRestart = false
+    @AppStorage("hideSpoilersForUnwatched") private var hideSpoilersForUnwatched = false
     @State private var showResumeChoice = false
     @State private var resumeChoiceTimeMs: Int = 0
     @State private var resumeChoiceLaunch: ((_ playFromBeginning: Bool) -> Void)? = nil
@@ -744,10 +745,27 @@ struct MediaDetailView: View {
                                 let title = currentItem.title
                                 let header = epString + (title.isEmpty ? "" : " · \(title)")
                                 let desc = detail?.item.overview ?? currentItem.overview ?? ""
-                                (Text(header).bold() + Text(desc.isEmpty ? "" : ":  \(desc)"))
-                                    .font(.caption)
-                                    .foregroundStyle(.white)
-                                    .lineLimit(3)
+                                if shouldBlurHeroSummary {
+                                    // When blurring, split header (sharp) from description
+                                    // (blurred) so the title stays visible. Matches Infuse.
+                                    Text(header)
+                                        .font(.caption)
+                                        .bold()
+                                        .foregroundStyle(.white)
+                                        .lineLimit(2)
+                                    if !desc.isEmpty {
+                                        Text(desc)
+                                            .font(.caption)
+                                            .foregroundStyle(.white)
+                                            .lineLimit(3)
+                                            .blur(radius: 8)
+                                    }
+                                } else {
+                                    (Text(header).bold() + Text(desc.isEmpty ? "" : ":  \(desc)"))
+                                        .font(.caption)
+                                        .foregroundStyle(.white)
+                                        .lineLimit(3)
+                                }
                             }
                         } else if currentItem.kind == .show || currentItem.kind == .season {
                             if let tagline = detail?.tagline {
@@ -773,6 +791,7 @@ struct MediaDetailView: View {
                                     .font(.caption)
                                     .foregroundStyle(.white.opacity(0.85))
                                     .lineLimit(3)
+                                    .blur(radius: shouldBlurHeroSummary ? 8 : 0)
                             }
                         }
                     }
@@ -1022,6 +1041,18 @@ struct MediaDetailView: View {
     }
 
     // MARK: - Summary Section (Full, below fold)
+
+    /// Whether the hero overview should be blurred for the spoiler-hiding
+    /// feature. Movies and episodes are spoiler-prone; show/season summaries
+    /// are marketing-level and stay un-blurred. Matches Infuse: blur stays
+    /// until the item is fully watched (in-progress is still blurred).
+    private var shouldBlurHeroSummary: Bool {
+        guard hideSpoilersForUnwatched, !currentItem.isWatched else { return false }
+        switch currentItem.kind {
+        case .movie, .episode: return true
+        default: return false
+        }
+    }
 
     /// Whether the info-circle button should appear: only for kinds that
     /// have meaningful long descriptions, and only when one is present.
@@ -3064,6 +3095,7 @@ struct EpisodeCard: View {
     @FocusState private var thumbnailFocused: Bool
     @FocusState private var descriptionFocused: Bool
     @Namespace private var cardFocus
+    @AppStorage("hideSpoilersForUnwatched") private var hideSpoilersForUnwatched = false
 
     private let cardWidth: CGFloat = 340
     private let thumbHeight: CGFloat = 192
@@ -3072,6 +3104,13 @@ struct EpisodeCard: View {
     /// so the card grows as a unit when it gains focus, regardless of which
     /// sub-button the user lands on.
     private var isFocused: Bool { thumbnailFocused || descriptionFocused }
+
+    /// True when this episode should be blurred to avoid spoilers: setting
+    /// is on and the episode hasn't been watched to completion. Matches
+    /// Infuse — in-progress episodes stay blurred until fully watched.
+    private var blurForSpoilers: Bool {
+        hideSpoilersForUnwatched && !episode.isWatched
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -3093,6 +3132,7 @@ struct EpisodeCard: View {
                 }
                 .frame(width: cardWidth, height: thumbHeight)
                 .clipped()
+                .blur(radius: blurForSpoilers ? 18 : 0)
                 .overlay(alignment: .bottomLeading) {
                     if let duration = episode.durationFormatted {
                         HStack(spacing: 4) {
@@ -3157,6 +3197,7 @@ struct EpisodeCard: View {
                             .foregroundStyle(descriptionFocused ? .black.opacity(0.7) : .white.opacity(0.7))
                             .lineLimit(3)
                             .padding(.top, 1)
+                            .blur(radius: blurForSpoilers ? 6 : 0)
                     }
                 }
                 .padding(.horizontal, 10)
@@ -3212,6 +3253,14 @@ struct EpisodeRow: View {
     var onShowInfo: MediaItemNavigationCallback? = nil
 
     @FocusState private var isFocused: Bool
+    @AppStorage("hideSpoilersForUnwatched") private var hideSpoilersForUnwatched = false
+
+    /// True when this episode should be blurred to avoid spoilers: setting
+    /// is on and the episode hasn't been watched to completion. Matches
+    /// Infuse — in-progress episodes stay blurred until fully watched.
+    private var blurForSpoilers: Bool {
+        hideSpoilersForUnwatched && !episode.isWatched
+    }
 
     var body: some View {
         Button(action: onPlay) {
@@ -3227,6 +3276,7 @@ struct EpisodeRow: View {
                 }
                 .frame(width: 240, height: 135)
                 .clipShape(RoundedRectangle(cornerRadius: 8))
+                .blur(radius: blurForSpoilers ? 18 : 0)
                 .overlay(alignment: .bottom) {
                     if let progress = episode.watchProgress, progress > 0 && progress < 1 {
                         ZStack(alignment: .leading) {
@@ -3248,6 +3298,7 @@ struct EpisodeRow: View {
                     }
                     if let summary = episode.overview, !summary.isEmpty {
                         Text(summary).font(.system(size: 26)).foregroundStyle(.secondary).lineLimit(2)
+                            .blur(radius: blurForSpoilers ? 6 : 0)
                     }
                 }
 

--- a/Rivulet/Views/Media/MediaDetailView.swift
+++ b/Rivulet/Views/Media/MediaDetailView.swift
@@ -94,6 +94,7 @@ struct MediaDetailView: View {
     @State private var preplaySubtitleSelection: UniversalPlayerViewModel.InitialSubtitleSelection = .auto
     @State private var showAudioTrackPicker = false
     @State private var showSubtitleTrackPicker = false
+    @State private var showSummarySheet = false  // Full description for movies/shows/episodes
     @State private var pendingPreplayWrite: Task<Void, Never>? = nil
 
     // Resume-or-restart prompt for in-progress items. Off by default;
@@ -497,6 +498,12 @@ struct MediaDetailView: View {
                         persistSubtitleTrackSelection(trackID: nil)
                     }
                 }
+            )
+        }
+        .sheet(isPresented: $showSummarySheet) {
+            SummarySheet(
+                title: summarySheetTitle,
+                summary: detail?.item.overview ?? currentItem.overview ?? ""
             )
         }
         .onChange(of: currentItem.ref.itemID) { _, _ in
@@ -1016,6 +1023,27 @@ struct MediaDetailView: View {
 
     // MARK: - Summary Section (Full, below fold)
 
+    /// Whether the info-circle button should appear: only for kinds that
+    /// have meaningful long descriptions, and only when one is present.
+    private var hasReadableSummary: Bool {
+        switch currentItem.kind {
+        case .movie, .show, .season, .episode: break
+        default: return false
+        }
+        let summary = detail?.item.overview ?? currentItem.overview ?? ""
+        return !summary.isEmpty
+    }
+
+    /// Title for the SummarySheet: episode header (e.g., "S02E05 · Title")
+    /// for episodes; the item's title for everything else.
+    private var summarySheetTitle: String {
+        if currentItem.kind == .episode, let epString = currentItem.episodeString {
+            let title = currentItem.title
+            return title.isEmpty ? epString : "\(epString) · \(title)"
+        }
+        return detail?.item.title ?? currentItem.title
+    }
+
     @ViewBuilder
     private func fullSummarySection(summary: String) -> some View {
         Button {
@@ -1142,6 +1170,22 @@ struct MediaDetailView: View {
         }
         .buttonStyle(AppStoreActionButtonStyle(isFocused: focusedActionButton == "watched", cornerRadius: circleButtonSize / 2, isPrimary: false))
         .focused($focusedActionButton, equals: "watched")
+
+        // Info button — surfaces the full description for items with a
+        // non-empty summary (movies, shows, seasons, episodes). Hero
+        // text is `lineLimit(3)`-truncated; this is the path to read the
+        // rest. Matches Plex / Infuse "show full description".
+        if hasReadableSummary {
+            Button {
+                showSummarySheet = true
+            } label: {
+                Image(systemName: "info.circle")
+                    .font(.system(size: 24, weight: .semibold))
+                    .frame(width: circleButtonSize, height: circleButtonSize)
+            }
+            .buttonStyle(AppStoreActionButtonStyle(isFocused: focusedActionButton == "summary", cornerRadius: circleButtonSize / 2, isPrimary: false))
+            .focused($focusedActionButton, equals: "summary")
+        }
 
         // Trailer button — perfect circle
         if detail?.trailerURL != nil {

--- a/Rivulet/Views/Media/MediaDetailView.swift
+++ b/Rivulet/Views/Media/MediaDetailView.swift
@@ -3061,14 +3061,24 @@ struct EpisodeCard: View {
     var onRefreshNeeded: MediaItemRefreshCallback? = nil
     var onShowInfo: MediaItemNavigationCallback? = nil
 
-    @FocusState private var isFocused: Bool
+    @FocusState private var thumbnailFocused: Bool
+    @FocusState private var descriptionFocused: Bool
+    @Namespace private var cardFocus
 
     private let cardWidth: CGFloat = 340
     private let thumbHeight: CGFloat = 192
 
+    /// True when either sub-button has focus. Drives the whole-card scale-up
+    /// so the card grows as a unit when it gains focus, regardless of which
+    /// sub-button the user lands on.
+    private var isFocused: Bool { thumbnailFocused || descriptionFocused }
+
     var body: some View {
-        Button(action: onPlay) {
-            VStack(alignment: .leading, spacing: 0) {
+        VStack(alignment: .leading, spacing: 4) {
+            // Thumbnail — clicking plays. Default focus when entering the
+            // card, so left/right between cards always lands here even if
+            // the previous card had focus on its description.
+            Button(action: onPlay) {
                 CachedAsyncImage(url: episode.artwork.thumbnail ?? episode.artwork.poster) { phase in
                     switch phase {
                     case .success(let image):
@@ -3114,41 +3124,61 @@ struct EpisodeCard: View {
                         WatchedCornerTag().accessibilityLabel("Watched")
                     }
                 }
+                .overlay(
+                    Rectangle()
+                        .strokeBorder(.white, lineWidth: thumbnailFocused ? 4 : 0)
+                )
+            }
+            .buttonStyle(.plain)
+            .focused($thumbnailFocused)
+            .prefersDefaultFocus(in: cardFocus)
+            .focusEffectDisabled()
+            .hoverEffectDisabled()
 
+            // Description — clicking opens the episode detail page so the
+            // user can read the full synopsis and pre-play track pickers.
+            // Disabled (and unfocusable) when no info callback is wired.
+            Button(action: { onShowInfo?() }) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(episodeLabel)
                         .font(.system(size: 15, weight: .medium))
-                        .foregroundStyle(isFocused ? .black.opacity(0.6) : .white.opacity(0.6))
+                        .foregroundStyle(descriptionFocused ? .black.opacity(0.6) : .white.opacity(0.6))
                         .textCase(.uppercase)
                         .padding(.top, 10)
 
                     Text(episode.title.isEmpty ? "Episode" : episode.title)
                         .font(.system(size: 20, weight: .bold))
-                        .foregroundStyle(isFocused ? .black : .white)
+                        .foregroundStyle(descriptionFocused ? .black : .white)
                         .lineLimit(1)
 
                     if let summary = episode.overview, !summary.isEmpty {
                         Text(summary)
                             .font(.system(size: 16))
-                            .foregroundStyle(isFocused ? .black.opacity(0.7) : .white.opacity(0.7))
+                            .foregroundStyle(descriptionFocused ? .black.opacity(0.7) : .white.opacity(0.7))
                             .lineLimit(3)
                             .padding(.top, 1)
                     }
                 }
                 .padding(.horizontal, 10)
                 .padding(.bottom, 12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(descriptionFocused ? Color.white.opacity(0.85) : Color.clear)
             }
-            .frame(width: cardWidth)
-            .background(
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .fill(isFocused ? .white.opacity(0.18) : .white.opacity(0.08))
-            )
-            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .buttonStyle(.plain)
+            .focused($descriptionFocused)
+            .disabled(onShowInfo == nil)
+            .focusEffectDisabled()
+            .hoverEffectDisabled()
         }
-        .buttonStyle(.plain)
-        .focused($isFocused)
+        .frame(width: cardWidth)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(.white.opacity(0.08))
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .focusSection()
+        .focusScope(cardFocus)
         .modifier(EpisodeFocusModifier(focusedEpisodeId: focusedEpisodeId, episodeItemID: episode.ref.itemID))
-        .hoverEffect(.highlight)
         .scaleEffect(isFocused ? 1.05 : 1.0)
         .animation(.easeOut(duration: 0.2), value: isFocused)
         .mediaItemContextMenu(

--- a/Rivulet/Views/Media/MediaDetailView.swift
+++ b/Rivulet/Views/Media/MediaDetailView.swift
@@ -1057,7 +1057,14 @@ struct MediaDetailView: View {
     /// are marketing-level and stay un-blurred. Matches Infuse: blur stays
     /// until the item is fully watched (in-progress is still blurred).
     private var shouldBlurHeroSummary: Bool {
-        guard hideSpoilersForUnwatched, !currentItem.isWatched else { return false }
+        // `currentItem` is a navigation-time snapshot and never re-fetches its
+        // watched flag; `isWatched` is the live @State that loadDetailData /
+        // onPlayerDismissed / toggleWatched keep current. Consult both so the
+        // blur clears once an episode is watched to completion (the @State
+        // path) without a one-frame blur flash when arriving on an
+        // already-watched item before loadDetailData runs (the snapshot path).
+        let watched = isWatched || currentItem.isWatched
+        guard hideSpoilersForUnwatched, !watched else { return false }
         switch currentItem.kind {
         case .movie, .episode: return true
         default: return false

--- a/Rivulet/Views/Media/MediaDetailView.swift
+++ b/Rivulet/Views/Media/MediaDetailView.swift
@@ -123,6 +123,8 @@ struct MediaDetailView: View {
     @State private var retainedLogoURL: URL?
     @State private var hasDisplayedHeroLogoImage = false
     @State private var parentShowLogoPath: String?
+    @State private var parentShowSummary: String?
+    @State private var parentShowTagline: String?
 
     // Navigation state for episode parent navigation
     @State private var navigateToSeason: MediaItem?
@@ -387,6 +389,8 @@ struct MediaDetailView: View {
             retainedLogoURL = nil
             hasDisplayedHeroLogoImage = false
             parentShowLogoPath = nil
+            parentShowSummary = nil
+            parentShowTagline = nil
         }
         .onChange(of: showExpandedChrome) { _, isVisible in
             let ref = currentItem.ref.itemID
@@ -504,7 +508,7 @@ struct MediaDetailView: View {
         .sheet(isPresented: $showSummarySheet) {
             SummarySheet(
                 title: summarySheetTitle,
-                summary: detail?.item.overview ?? currentItem.overview ?? ""
+                summary: effectiveOverview
             )
         }
         .onChange(of: currentItem.ref.itemID) { _, _ in
@@ -768,14 +772,20 @@ struct MediaDetailView: View {
                                 }
                             }
                         } else if currentItem.kind == .show || currentItem.kind == .season {
-                            if let tagline = detail?.tagline {
+                            // For seasons, Plex often returns an empty
+                            // summary (notably for single-season recently-
+                            // added shows). Fall back to the parent show's
+                            // tagline/summary so the hero isn't blank.
+                            let effectiveTagline = detail?.tagline
+                                ?? (currentItem.kind == .season ? parentShowTagline : nil)
+                            if let tagline = effectiveTagline, !tagline.isEmpty {
                                 Text(tagline)
                                     .font(.caption)
                                     .italic()
                                     .foregroundStyle(.white.opacity(0.9))
                             }
-                            if let summary = detail?.item.overview ?? currentItem.overview, !summary.isEmpty {
-                                Text(summary)
+                            if !effectiveOverview.isEmpty {
+                                Text(effectiveOverview)
                                     .font(.caption)
                                     .foregroundStyle(.white.opacity(0.85))
                                     .lineLimit(3)
@@ -1054,6 +1064,17 @@ struct MediaDetailView: View {
         }
     }
 
+    /// Resolved summary for hero / info-circle / SummarySheet, with parent-
+    /// show fallback for seasons whose own summary Plex returns empty.
+    private var effectiveOverview: String {
+        let baseSummary = detail?.item.overview ?? currentItem.overview ?? ""
+        if !baseSummary.isEmpty { return baseSummary }
+        if currentItem.kind == .season, let parent = parentShowSummary, !parent.isEmpty {
+            return parent
+        }
+        return ""
+    }
+
     /// Whether the info-circle button should appear: only for kinds that
     /// have meaningful long descriptions, and only when one is present.
     private var hasReadableSummary: Bool {
@@ -1061,8 +1082,7 @@ struct MediaDetailView: View {
         case .movie, .show, .season, .episode: break
         default: return false
         }
-        let summary = detail?.item.overview ?? currentItem.overview ?? ""
-        return !summary.isEmpty
+        return !effectiveOverview.isEmpty
     }
 
     /// Title for the SummarySheet: episode header (e.g., "S02E05 · Title")
@@ -1469,6 +1489,8 @@ struct MediaDetailView: View {
                 }
                 detail = nil
                 parentShowLogoPath = nil
+                parentShowSummary = nil
+                parentShowTagline = nil
                 syncHeroBackdrop()
                 await loadDetail()
                 await refreshHeroBackdropAssets()
@@ -2188,6 +2210,7 @@ struct MediaDetailView: View {
         }
 
         isLoadingExtras = false
+        _ = ratingKey
     }
 
     private func syncHeroBackdrop() {
@@ -2273,7 +2296,11 @@ struct MediaDetailView: View {
     }
 
     /// Fetches the parent show's full metadata (using the cached copy when
-    /// fresh) and extracts its clearLogo path for use on episode/season views.
+    /// fresh) and extracts its clearLogo path, summary, and tagline for use
+    /// on episode/season views. The summary is needed as a fallback for
+    /// season detail pages because Plex's season metadata often returns an
+    /// empty summary (notably for single-season shows surfaced via the
+    /// "Recently Added" hub, which collapses show → season).
     private func loadParentShowLogoPath() async {
         guard let serverURL = authManager.selectedServerURL,
               let token = authManager.selectedServerToken,
@@ -2284,6 +2311,8 @@ struct MediaDetailView: View {
         if let cached = PlexDataStore.shared.getCachedFullMetadata(for: showRatingKey),
            PlexDataStore.shared.isFullMetadataFresh(for: showRatingKey) {
             parentShowLogoPath = cached.clearLogoPath
+            parentShowSummary = cached.summary
+            parentShowTagline = cached.tagline
             return
         }
 
@@ -2295,6 +2324,8 @@ struct MediaDetailView: View {
             )
             PlexDataStore.shared.cacheFullMetadata(showMetadata, for: showRatingKey)
             parentShowLogoPath = showMetadata.clearLogoPath
+            parentShowSummary = showMetadata.summary
+            parentShowTagline = showMetadata.tagline
         } catch {
             print("🎨 [Logo] Failed to fetch parent show metadata: \(error)")
         }
@@ -2425,9 +2456,20 @@ struct MediaDetailView: View {
     }
 
     /// Determine the "next up" episode for seasons.
-    /// episodes is [MediaItem] — no Plex calls needed.
+    ///
+    /// Prefers `detail.nextEpisode` (Plex's OnDeck-derived hint, populated
+    /// by `loadDetail` before this runs) over scanning the `episodes` list.
+    /// `loadDetailData()` schedules `loadEpisodesForSeason()` and
+    /// `loadNextUpEpisode()` as parallel `async let`s, so `episodes` is
+    /// often still empty when this runs — without the detail.nextEpisode
+    /// fallback `nextUpEpisode` would stay nil and the Play button would
+    /// remain `.disabled`. This mirrors the show-case logic in
+    /// `loadNextUpEpisode()`.
     private func loadNextUpEpisodeForSeason() async {
-        // episodes is already [MediaItem] with full watch state
+        if let nextItem = detail?.nextEpisode {
+            nextUpEpisode = nextItem
+            return
+        }
         nextUpEpisode = episodes.first(where: { $0.isInProgress })
             ?? episodes.first(where: { !$0.isWatched })
             ?? episodes.first

--- a/Rivulet/Views/Media/SummarySheet.swift
+++ b/Rivulet/Views/Media/SummarySheet.swift
@@ -1,0 +1,137 @@
+//
+//  SummarySheet.swift
+//  Rivulet
+//
+//  Full-screen sheet that surfaces a long item description in a focusable,
+//  scrollable form. The hero text on the detail page is `lineLimit(3)`-
+//  truncated; this sheet is the path to read the rest. Matches the
+//  affordance Plex's first-party tvOS client and Infuse both provide.
+//
+
+import SwiftUI
+
+struct SummarySheet: View {
+    let title: String
+    let summary: String
+
+    @Environment(\.dismiss) private var dismiss
+    @FocusState private var focusedParagraph: Int?
+
+    /// Split the summary on sentence boundaries and pack into ~300-char
+    /// chunks. Each chunk becomes a focusable row so the touchpad can
+    /// scroll long descriptions smoothly.
+    private var summaryChunks: [String] {
+        let sentences = summary.components(separatedBy: ". ")
+        var chunks: [String] = []
+        var currentChunk = ""
+
+        for sentence in sentences {
+            let trimmed = sentence.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            let sentenceWithPeriod = trimmed.hasSuffix(".") ? trimmed : trimmed + "."
+
+            if currentChunk.isEmpty {
+                currentChunk = sentenceWithPeriod
+            } else if currentChunk.count + sentenceWithPeriod.count < 300 {
+                currentChunk += " " + sentenceWithPeriod
+            } else {
+                chunks.append(currentChunk)
+                currentChunk = sentenceWithPeriod
+            }
+        }
+        if !currentChunk.isEmpty { chunks.append(currentChunk) }
+
+        return chunks.isEmpty ? [summary] : chunks
+    }
+
+    var body: some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack(spacing: 40) {
+                Text(title)
+                    .font(.system(size: 48, weight: .bold))
+                    .foregroundStyle(.white)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 1200)
+                    .padding(.horizontal, 80)
+                    .padding(.top, 60)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(Array(summaryChunks.enumerated()), id: \.offset) { index, chunk in
+                        SummaryParagraphRow(
+                            text: chunk,
+                            isFocused: focusedParagraph == index
+                        )
+                        .focusable()
+                        .focused($focusedParagraph, equals: index)
+                    }
+                }
+                .frame(maxWidth: 1200)
+                .padding(.horizontal, 80)
+
+                SummaryDoneButton(isFocused: focusedParagraph == -1) {
+                    dismiss()
+                }
+                .focused($focusedParagraph, equals: -1)
+                .padding(.top, 20)
+                .padding(.bottom, 80)
+            }
+            .padding(8)
+        }
+        .onExitCommand {
+            dismiss()
+        }
+    }
+}
+
+/// Focusable text chunk — minimal styling for continuous reading.
+private struct SummaryParagraphRow: View {
+    let text: String
+    let isFocused: Bool
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 16) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(isFocused ? .white.opacity(0.6) : .clear)
+                .frame(width: 3)
+
+            Text(text)
+                .font(.system(size: 26))
+                .foregroundStyle(isFocused ? .white : .white.opacity(0.8))
+                .multilineTextAlignment(.leading)
+                .lineSpacing(8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.vertical, 8)
+        .animation(.easeOut(duration: 0.15), value: isFocused)
+    }
+}
+
+/// Done button — glass styling consistent with other sheet dismiss controls.
+private struct SummaryDoneButton: View {
+    let isFocused: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text("Done")
+                .font(.system(size: 28, weight: .medium))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 60)
+                .padding(.vertical, 18)
+                .background(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .fill(isFocused ? .white.opacity(0.18) : .white.opacity(0.08))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                                .strokeBorder(
+                                    isFocused ? .white.opacity(0.25) : .white.opacity(0.08),
+                                    lineWidth: 1
+                                )
+                        )
+                )
+        }
+        .buttonStyle(SettingsButtonStyle())
+        .scaleEffect(isFocused ? 1.02 : 1.0)
+        .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isFocused)
+    }
+}

--- a/Rivulet/Views/Settings/SettingsDescriptors.swift
+++ b/Rivulet/Views/Settings/SettingsDescriptors.swift
@@ -107,6 +107,11 @@ enum SettingsDescriptorStore {
             iconColor: .cyan,
             description: "Moves the Discover tab above your Media libraries in the sidebar for quicker access."
         ),
+        "hideSpoilersForUnwatched": SettingDescriptor(
+            icon: "eye.slash",
+            iconColor: .indigo,
+            description: "Blurs descriptions and thumbnails for unwatched movies and episodes. Press the info button on a detail page to read the full description."
+        ),
 
         // MARK: Playback
         "audioLanguage": SettingDescriptor(

--- a/Rivulet/Views/Settings/SettingsView.swift
+++ b/Rivulet/Views/Settings/SettingsView.swift
@@ -274,6 +274,7 @@ struct SettingsView: View {
     // AppStorage
     @AppStorage("showHomeHero") private var showHomeHero = false
     @AppStorage("showLibraryHero") private var showLibraryHero = false
+    @AppStorage("hideSpoilersForUnwatched") private var hideSpoilersForUnwatched = false
     @AppStorage("showLibraryRecommendations") private var showLibraryRecommendations = true
     @AppStorage("showLibraryRecentRows") private var showLibraryRecentRows = true
     @AppStorage("enablePersonalizedRecommendations") private var enablePersonalizedRecommendations = false
@@ -678,6 +679,12 @@ struct SettingsView: View {
                     onFocusChange: { if $0 { focusState.focusedSettingId = "discoverAboveLibraries" } }
                 )
             }
+
+            SettingsToggleRow(
+                title: "Hide Spoilers",
+                isOn: $hideSpoilersForUnwatched,
+                onFocusChange: { if $0 { focusState.focusedSettingId = "hideSpoilersForUnwatched" } }
+            )
         }
     }
 


### PR DESCRIPTION
## Summary

Three related additions to the Media detail page, layered:

1. **Full-description sheet.** When an item has a non-empty overview
   (movies, shows, seasons, episodes), the action row gets an
   `info.circle` button between Watched and Trailer. Pressing it
   opens a new `SummarySheet` — title at top, description chunked
   into focusable paragraphs (so the touchpad scrolls long text
   smoothly), Done button at bottom. Menu/back also dismisses.
   Matches the "show full description" affordance Plex's first-party
   tvOS client and Infuse both provide.

2. **Dual-button episode card.** Reworked from a prior single-Button
   "press anywhere → detail page" attempt at the maintainer's
   request: split into a thumbnail Button (click → plays, original
   Rivulet behavior preserved) and a description Button (click →
   opens episode detail page). `prefersDefaultFocus(in:)` ensures
   left/right between cards always lands on the next thumbnail, even
   if the previous card had focus on its description — matches Apple
   TV+'s episode-card focus model.

3. **Hide-Spoilers toggle.** Adds a Settings → Appearance toggle
   (default off) that, when on, blurs the description and episode-
   still thumbnail on unwatched movies and episodes — titles and
   show/season summaries stay sharp. Matches Infuse's no-spoiler
   mode. The two earlier features serve as un-blur paths: the info
   button on the detail page shows the SummarySheet with full text,
   and the description-button click on an episode card jumps
   straight to the detail page. (1) and (2) reinforce (3) — that's
   why all three are landing together.

4. **Single-season detail-page fixes (Recently Added).** When a
   single-season show is surfaced in the "Recently Added in TV
   Shows" hub, Plex returns it as `type=season`, so the hub poster
   opens MediaDetailView with `kind=season` directly. Two pre-
   existing bugs surfaced on that path:
   - **Play button stuck `.disabled`**: `loadNextUpEpisodeForSeason`
     scanned `episodes` only, but `loadDetailData()` schedules
     `loadEpisodesForSeason` and `loadNextUpEpisode` as parallel
     `async let`s — so `episodes` was typically still empty when
     the resolver ran, leaving `nextUpEpisode = nil`. Prefer
     `detail.nextEpisode` (Plex's OnDeck-derived hint, populated
     by `loadDetail`), mirroring the show-case logic.
   - **Empty hero summary**: Plex returns `summary=""` on season
     metadata for some shows. `loadParentShowLogoPath` was already
     fetching the parent show's metadata for clearLogo; extended
     to also capture `summary` and `tagline`. New
     `effectiveOverview` helper falls back to the parent show's
     summary on season pages, feeding both the hero and the info-
     button SummarySheet from feature (1) above.

## Design notes

- **`fullSummarySection` left untouched.** Noticed there's a dead
  private `fullSummarySection(summary:)` func in MediaDetailView
  (defined but never called) that uses tap-to-expand
  (`Button { isSummaryExpanded.toggle() }` + conditional `lineLimit`).
  Went with a separate sheet for Plex / Infuse parity, but happy to
  refactor to in-place expansion if that's the direction you'd prefer.
- **Default off on Hide Spoilers.** Off-by-default lets users opt in
  when they want it; easy to flip if you'd rather ship it on.
- **Gate semantics: `!item.isWatched`.** No carve-out for in-progress
  items — matches Infuse. Once watched (Plex's `isPlayed`), blur lifts.
- **Episode hero header stays sharp.** When blurring is active and
  we're on an episode detail page, the original combined
  `Text(header) + Text(desc)` is split into two stacked Texts so the
  `S04E03 · Title` header stays readable; only the description below
  gets blurred.
- **Dual-button focus visuals.** 4pt `strokeBorder` on the focused
  thumbnail; white-bg + black-text flip on the focused description.
  `focusEffectDisabled` / `hoverEffectDisabled` on inner Buttons to
  suppress the default tvOS focus halo (we provide our own).
  Description Button is `.disabled` when `onShowInfo` is nil so it
  isn't focusable in contexts that don't wire it up.
- **Deferred** (potential follow-ups): in-player swipe-down "Up Next"
  panels (would touch PlayerControlsOverlay), track-list labels with
  episode titles, and tap-on-blurred-text → SummarySheet as an
  alternate un-blur path beyond the info-circle button and dual-
  button card paths this PR ships.

## Test plan

### Full-description sheet
- [ ] Visit a movie / show / season / episode detail page → info-
      circle button appears in the action row between Watched and
      Trailer.
- [ ] Press it → SummarySheet opens with focusable paragraphs;
      touchpad up/down scrolls between paragraphs; Menu/back and
      Done both dismiss.
- [ ] Verify info button does not appear on collection or person
      detail pages, or on items with no overview.

### Dual-button episode card
- [ ] Open a season detail page → focus lands on the thumbnail of
      the first episode.
- [ ] Press up/down within a card → focus moves between thumbnail
      and description; visual indicators flip accordingly.
- [ ] Press left/right between cards → focus always lands on the
      next thumbnail, even if it was previously on the description.
- [ ] Same rule when navigating from a season pill or trailer thumb
      back into the episode carousel.
- [ ] Click thumbnail → episode plays (resume-or-restart prompt
      fires if enabled).
- [ ] Click description → episode detail page opens; pressing Play
      from there starts playback as before.
- [ ] Long-press anywhere on the card → context menu (Mark Watched
      / More Info / Refresh) still works.

### Hide Spoilers
- [ ] Settings → Appearance → toggle on Hide Spoilers (off by
      default).
- [ ] Browse a TV show with unwatched episodes → episode cards blur
      thumbnail + summary; titles stay sharp.
- [ ] Open an unwatched episode detail page → header
      (`S04E03 · Title`) sharp; description blurred.
- [ ] Open an unwatched movie detail page → summary blurred; tagline
      (when present) stays sharp.
- [ ] Open a show or season detail page → no blur.
- [ ] Press info-circle button → SummarySheet shows un-blurred full
      text.
- [ ] Click description on a blurred episode card → detail page
      opens, info button is the un-blur path.
- [ ] Mark an episode watched → blur lifts on that episode.
- [ ] Toggle Hide Spoilers off → all blurs disappear instantly.

### Single-season Recently Added fixes
- [ ] Open a single-season show via "Recently Added in TV Shows"
      hub: Play button focusable (resolves to Resume Chapter 1
      for in-progress items), parent-show summary appears in hero
      and info-button SummarySheet.
- [ ] Multi-season shows via the same hub: no regression.
- [ ] Shows opened via library browsing: no regression.