### PR TITLE
Settings: tighten Resume-or-Restart Prompt descriptor text

### DIFF
--- a/Rivulet/Views/Settings/SettingsDescriptors.swift
+++ b/Rivulet/Views/Settings/SettingsDescriptors.swift
@@ -137,7 +137,7 @@ enum SettingsDescriptorStore {
         "promptResumeOrRestart": SettingDescriptor(
             icon: "questionmark.circle",
             iconColor: .blue,
-            description: "When playing an in-progress item, ask whether to resume from where you left off or start over from the beginning. Off by default — pressing Play resumes silently like Apple TV+ and Plex's first-party app."
+            description: "Off by default. When on, in-progress items show a Resume / Start from Beginning prompt before playing — like Apple TV."
         ),
         "autoplayCountdown": SettingDescriptor(
             icon: "forward.end.alt",


### PR DESCRIPTION
## Summary

Two factual fixes plus a length pass on the "Resume or Restart Prompt"
descriptor:

- Apple's set-top device is **Apple TV**, not Apple TV+.
- Plex's first-party tvOS app does **not** silently resume in-progress
  episodes — pressing Play on a show takes you to the season carousel
  with the in-progress episode focused. Dropping the Plex comparison.
- Shortened for brevity.

No behavior change.

## Test plan

- [x] Settings → Playback → focus the Resume or Restart Prompt row → right-panel description shows the new wording.
- [x] Toggle behavior unchanged (still defaults off, still gates the prompt).