### PR TITLE
DirectPlayPipeline: don't crash on stale pause-gate waiter

### DIFF
--- a/Rivulet/Services/Plex/Playback/Pipeline/DirectPlayPipeline.swift
+++ b/Rivulet/Services/Plex/Playback/Pipeline/DirectPlayPipeline.swift
@@ -689,14 +689,32 @@ final class DirectPlayPipeline {
     /// cheap check and this suspension.
     private func waitForResume() async {
         await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-            if !isPausedFlag {
+            // Cancelled read loops must not re-suspend on the gate — they
+            // would never be released, since the only path that resumes
+            // them is `fireResumeGate()` and the new task that supersedes
+            // them owns the gate from this point on. Wake the continuation
+            // immediately; the loop's next iteration observes
+            // `Task.isCancelled` and exits cleanly.
+            if Task.isCancelled || !isPausedFlag {
                 cont.resume()
                 return
             }
-            precondition(
-                pauseGateContinuation == nil,
-                "pauseGateContinuation already has a waiter — only the read loop should wait on this gate"
-            )
+            // Stale waiter from a prior read-loop iteration may still be
+            // parked here when rapid play / pause / seek interleaving
+            // queues a fresh start before the previous read task has
+            // woken from the gate. (`start()` does not currently await
+            // the previous `readTask?.value` the way `seek()` and
+            // `shutdown()` do.) Wake the stale waiter so its loop
+            // observes cancellation and exits, then install the new
+            // continuation. Strictly more permissive than the previous
+            // precondition-on-violation behavior; a stale waiter is a
+            // real concurrency hazard worth logging but not worth
+            // crashing over.
+            if let stale = pauseGateContinuation {
+                playerDebugLog("[DirectPlay] pauseGate: resuming stale waiter to install new one")
+                pauseGateContinuation = nil
+                stale.resume()
+            }
             pauseGateContinuation = cont
         }
     }


### PR DESCRIPTION
## Summary

`waitForResume()` precondition-fails when `pauseGateContinuation` is
already set on entry, on the assumption that only one read loop ever
suspends on the gate. That invariant breaks under rapid play / pause /
seek interleaving: `start()` does not await the previous
`readTask?.value` the way `seek()` and `shutdown()` do, so a fresh
`startReadLoop()` can install a new read task while a prior task is
still parked on the gate.

Repro path: paused playback → resume → seek → pause-from-remote-control
→ resume-from-remote-control → start playback of a different item from
the same player session. The fresh `start()` ran while the prior read
task was still suspended on the gate.

## Implementation

The fix is defensive rather than structural:

- Add a `Task.isCancelled` early-return so a cancelled read loop cannot
  re-suspend on the gate (it would never be released).
- Replace the precondition with a stale-waiter resume: if a previous
  continuation is still parked when a new one tries to install, resume
  the stale one (its loop will observe cancellation and exit naturally)
  and take the gate. Logged so this is visible in player diagnostics if
  it's a hot path.

The structural answer — making `start()` await the prior read task's
exit before launching a new one, mirroring `seek()` / `shutdown()` —
left as a follow-up. It touches more code paths and benefits from being
its own change.

Strictly more permissive than the previous behavior; a stale waiter no
longer crashes the app.

## Test plan

- [x] Reproduced the precondition crash on the same console-attached repro path before the fix.
- [x] Same repro path with the fix applied: no crash. Pipeline keeps playing across the rapid-control-event flurry. Console shows the new `[DirectPlay] pauseGate: resuming stale waiter to install new one` line at the moment a stale waiter would have tripped the precondition.
- [x] Ordinary play / pause / seek (no rapid interleaving) unchanged — the stale-waiter path is never reached.