### PR TITLE
Preview overlay: route sub-item navigation through the host

### DIFF
--- a/Rivulet/Views/Discover/DiscoverView.swift
+++ b/Rivulet/Views/Discover/DiscoverView.swift
@@ -222,6 +222,22 @@ struct DiscoverView: View {
                     }
                 }
             },
+            onSubItemNavigation: { item in
+                // Stage the sub-item into the existing fullScreenCover
+                // binding, then dismiss the modal overlay so the cover
+                // is revealed underneath showing the new item's detail.
+                presentedPlexItem = item
+                if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                   let rootVC = scene.windows.first?.rootViewController {
+                    var topVC = rootVC
+                    while let presented = topVC.presentedViewController {
+                        topVC = presented
+                    }
+                    if let previewVC = topVC as? PreviewContainerViewController {
+                        previewVC.dismissPreview()
+                    }
+                }
+            },
             menuBridge: menuBridge
         )
 

--- a/Rivulet/Views/Media/MediaDetailView.swift
+++ b/Rivulet/Views/Media/MediaDetailView.swift
@@ -30,6 +30,15 @@ struct MediaDetailView: View {
     var backdropWindowFrame: CGRect? = nil
     var onPreviewExitRequested: (() -> Void)? = nil
     var onDetailsBecameVisible: (() -> Void)? = nil
+    /// When set, sub-item navigation (e.g. clicking an episode's description
+    /// tile to open the episode detail page) routes through this closure
+    /// instead of the local `navigateToEpisode` binding. Required when the
+    /// view is hosted inside `PreviewOverlayHost`: the preview is presented
+    /// via UIKit `UIViewController.present(_:)`, so the SwiftUI view tree
+    /// inside has no `NavigationStack` ancestor and `.navigationDestination`
+    /// is a no-op. The host (typically `PlexHomeView`) dismisses the preview
+    /// and pushes the destination onto its own `NavigationStack`.
+    var onSubItemNavigation: ((MediaItem) -> Void)? = nil
     var enableDetailDataLoading: Bool = true
     /// When hosted inside `PreviewOverlayHost`, reflects whether the entry /
     /// paging animation has fully settled. The detail data cascade is deferred
@@ -343,6 +352,13 @@ struct MediaDetailView: View {
                 navigateToSeason: $navigateToSeason,
                 navigateToShow: $navigateToShow,
                 navigateToEpisode: $navigateToEpisode,
+                // Disabled inside `PreviewOverlayHost`-hosted views: the
+                // overlay is presented via UIKit modal, so the SwiftUI
+                // tree has no `NavigationStack` ancestor and these
+                // destinations would be no-ops. Sub-item navigation in
+                // that context routes through `onSubItemNavigation`
+                // instead — see the host (PlexLibraryView /
+                // PlexHomeView).
                 isEnabled: onPreviewExitRequested == nil
             ))
     }
@@ -1659,7 +1675,11 @@ struct MediaDetailView: View {
                                         await refreshEpisodeWatchStatus(itemID: episode.ref.itemID)
                                     },
                                     onShowInfo: {
-                                        navigateToEpisode = episode
+                                        if let nav = onSubItemNavigation {
+                                            nav(episode)
+                                        } else {
+                                            navigateToEpisode = episode
+                                        }
                                     }
                                 )
                                 .padding(.leading, leadingPad)
@@ -1730,7 +1750,11 @@ struct MediaDetailView: View {
                                     await refreshEpisodeWatchStatus(itemID: episode.ref.itemID)
                                 },
                                 onShowInfo: {
-                                    navigateToEpisode = episode
+                                    if let nav = onSubItemNavigation {
+                                        nav(episode)
+                                    } else {
+                                        navigateToEpisode = episode
+                                    }
                                 }
                             )
                         }

--- a/Rivulet/Views/Media/PlexHomeView.swift
+++ b/Rivulet/Views/Media/PlexHomeView.swift
@@ -33,6 +33,14 @@ struct PlexHomeView: View {
     @State private var showPreviewCover = false
     @State private var heroScrollOffset: CGFloat = 0
 
+    /// Sub-item navigation requested from inside an expanded preview (e.g.
+    /// the user clicked an episode's description tile in `PreviewOverlayHost`).
+    /// The preview overlay is presented via UIKit modal and lives outside
+    /// our `NavigationStack`, so its `MediaDetailView` cannot push directly.
+    /// We dismiss the overlay and `.navigationDestination(item:)` (attached
+    /// to the NavigationStack content below) handles the push.
+    @State private var pendingPreviewNavigation: MediaItem?
+
     // Resume-or-restart prompt for in-progress items launched directly from
     // Continue Watching / hero carousel (bypassing the detail view). Off
     // by default; the "Watch from Beginning" context-menu action bypasses
@@ -212,6 +220,9 @@ struct PlexHomeView: View {
                 default: EmptyView()
                 }
             }
+            .navigationDestination(item: $pendingPreviewNavigation) { item in
+                MediaDetailView(item: item)
+            }
             .overlayPreferenceValue(PreviewSourceFramePreferenceKey.self) { anchors in
                 // Resolve anchor frames into CGRects
                 GeometryReader { proxy in
@@ -380,6 +391,22 @@ struct PlexHomeView: View {
                 _ = menuBridge  // prevent retain cycle warning
                 previewRestoreTarget = sourceTarget
                 // Find and dismiss the preview VC
+                if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                   let rootVC = scene.windows.first?.rootViewController {
+                    var topVC = rootVC
+                    while let presented = topVC.presentedViewController {
+                        topVC = presented
+                    }
+                    if let previewVC = topVC as? PreviewContainerViewController {
+                        previewVC.dismissPreview()
+                    }
+                }
+            },
+            onSubItemNavigation: { item in
+                // Stage the navigation push (the navigationDestination on
+                // the NavigationStack picks it up), then dismiss the modal
+                // overlay so the new view is revealed underneath.
+                pendingPreviewNavigation = item
                 if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
                    let rootVC = scene.windows.first?.rootViewController {
                     var topVC = rootVC

--- a/Rivulet/Views/Media/PlexLibraryView.swift
+++ b/Rivulet/Views/Media/PlexLibraryView.swift
@@ -29,6 +29,14 @@ struct PlexLibraryView: View {
     @State private var isLoadingMore = false  // Loading additional pages
     @State private var error: String?
     @State private var selectedItem: MediaItem?
+
+    /// Sub-item navigation requested from inside an expanded preview (e.g.
+    /// the user clicked an episode's description tile in `PreviewOverlayHost`).
+    /// The preview overlay is presented via UIKit modal and lives outside
+    /// our `NavigationStack`, so its `MediaDetailView` cannot push directly.
+    /// We dismiss the overlay and `.navigationDestination(item:)` (attached
+    /// to the NavigationStack content below) handles the push.
+    @State private var pendingPreviewNavigation: MediaItem?
     @State private var heroItems: [PlexMetadata] = []
     @State private var heroCurrentIndex: Int = 0
     @State private var heroScrollOffset: CGFloat = 0
@@ -287,6 +295,9 @@ struct PlexLibraryView: View {
             .navigationDestination(item: $selectedItem) { item in
                 MediaDetailView(item: item)
             }
+            .navigationDestination(item: $pendingPreviewNavigation) { item in
+                MediaDetailView(item: item)
+            }
             .overlayPreferenceValue(PreviewSourceFramePreferenceKey.self) { anchors in
                 GeometryReader { proxy in
                     Color.clear
@@ -314,6 +325,22 @@ struct PlexLibraryView: View {
             sourceFrames: capturedSourceFrames,
             onDismiss: { sourceTarget in
                 previewRestoreTarget = sourceTarget
+                if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                   let rootVC = scene.windows.first?.rootViewController {
+                    var topVC = rootVC
+                    while let presented = topVC.presentedViewController {
+                        topVC = presented
+                    }
+                    if let previewVC = topVC as? PreviewContainerViewController {
+                        previewVC.dismissPreview()
+                    }
+                }
+            },
+            onSubItemNavigation: { item in
+                // Stage the navigation push (the navigationDestination on
+                // the NavigationStack picks it up), then dismiss the modal
+                // overlay so the new view is revealed underneath.
+                pendingPreviewNavigation = item
                 if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
                    let rootVC = scene.windows.first?.rootViewController {
                     var topVC = rootVC

--- a/Rivulet/Views/Media/PreviewOverlayHost.swift
+++ b/Rivulet/Views/Media/PreviewOverlayHost.swift
@@ -49,6 +49,14 @@ struct PreviewOverlayHost: View {
     let request: PreviewRequest
     let sourceFrames: [PreviewSourceTarget: CGRect]
     let onDismiss: (PreviewSourceTarget) -> Void
+    /// Called when a hosted `MediaDetailView` wants to navigate to a
+    /// sub-item (e.g. the user clicked an episode's description tile to
+    /// open the episode detail page). Required because the preview is
+    /// presented via UIKit modal, so the SwiftUI view tree inside has no
+    /// `NavigationStack` ancestor — `.navigationDestination` is a no-op.
+    /// The host (typically `PlexHomeView`) handles the dismissal of this
+    /// modal and pushes the destination onto its own `NavigationStack`.
+    var onSubItemNavigation: ((MediaItem) -> Void)? = nil
     @ObservedObject var menuBridge: PreviewMenuBridge
 
     /// Carousel-local copy of the request's items. Mutable so the prefetch
@@ -87,11 +95,13 @@ struct PreviewOverlayHost: View {
         request: PreviewRequest,
         sourceFrames: [PreviewSourceTarget: CGRect],
         onDismiss: @escaping (PreviewSourceTarget) -> Void,
+        onSubItemNavigation: ((MediaItem) -> Void)? = nil,
         menuBridge: PreviewMenuBridge
     ) {
         self.request = request
         self.sourceFrames = sourceFrames
         self.onDismiss = onDismiss
+        self.onSubItemNavigation = onSubItemNavigation
         self.menuBridge = menuBridge
         self._selectedIndex = State(initialValue: request.selectedIndex)
         self._items = State(initialValue: request.items)
@@ -156,6 +166,7 @@ struct PreviewOverlayHost: View {
                                 stateMachine.markDetailsStable()
                             }
                         },
+                        onSubItemNavigation: onSubItemNavigation,
                         cornerRadius: cardCornerRadius(for: index),
                         opacity: cardOpacity(for: index)
                     )
@@ -718,6 +729,7 @@ private struct PreviewCarouselCard: View {
     let previewAnimationSettled: Bool
     let onPreviewExitRequested: () -> Void
     let onDetailsBecameVisible: () -> Void
+    let onSubItemNavigation: ((MediaItem) -> Void)?
     let cornerRadius: CGFloat
     let opacity: Double
 
@@ -755,6 +767,7 @@ private struct PreviewCarouselCard: View {
                     backdropWindowFrame: stageWindowFrame,
                     onPreviewExitRequested: onPreviewExitRequested,
                     onDetailsBecameVisible: onDetailsBecameVisible,
+                    onSubItemNavigation: onSubItemNavigation,
                     enableDetailDataLoading: isCurrent,
                     previewAnimationSettled: previewAnimationSettled
                 )
@@ -819,6 +832,7 @@ private struct PreviewHeroSurface: View {
     let backdropWindowFrame: CGRect
     let onPreviewExitRequested: () -> Void
     let onDetailsBecameVisible: () -> Void
+    let onSubItemNavigation: ((MediaItem) -> Void)?
     let enableDetailDataLoading: Bool
     let previewAnimationSettled: Bool
 
@@ -838,6 +852,7 @@ private struct PreviewHeroSurface: View {
             backdropWindowFrame: backdropWindowFrame,
             onPreviewExitRequested: onPreviewExitRequested,
             onDetailsBecameVisible: onDetailsBecameVisible,
+            onSubItemNavigation: onSubItemNavigation,
             enableDetailDataLoading: enableDetailDataLoading,
             previewAnimationSettled: previewAnimationSettled
         )


### PR DESCRIPTION
## Summary

Tapping an episode card inside an expanded preview overlay (e.g.
opening a show via "Recently Added in TV Shows" → tapping an
episode in the carousel) had no visible effect. The click registered
and the binding updated, but no navigation push happened.

## Mechanism

`PreviewOverlayHost` is presented via UIKit
`UIViewController.present(_:)`, which creates a hosting controller
whose SwiftUI tree has no `NavigationStack` (or fullScreenCover)
ancestor. MediaDetailView's `.navigationDestination(item:)` modifiers
are silent no-ops in that context, so setting
`navigateToEpisode = episode` on tap fired the binding update but
produced no push. The existing
`isEnabled: onPreviewExitRequested == nil` gate on
`NavigationDestinationsModifier` reflected the architectural
limitation but didn't provide a fallback path.

This affects every navigation binding inside MediaDetailView when
hosted in a preview overlay — `navigateToEpisode`,
`navigateToShow`, `navigateToSeason`. Long-press context menu's
"More Info" path is also affected (it routes through the same
`onShowInfo` callback).

## Fix

Thread an optional `onSubItemNavigation: ((MediaItem) -> Void)?`
closure from each host that presents PreviewOverlayHost
(`PlexHomeView`, `PlexLibraryView`, `DiscoverView`) down through
`PreviewOverlayHost` → `PreviewCarouselCard` → `PreviewHeroSurface` →
`MediaDetailView`. When set, the EpisodeCard's `onShowInfo` callback
invokes it instead of the local `navigateToEpisode` binding.

Each host handles the navigation in its own scope:
- **PlexHomeView** and **PlexLibraryView**: capture the requested
  item in a new `pendingPreviewNavigation` state, dismiss the UIKit
  modal, and a `.navigationDestination(item: $pendingPreviewNavigation)`
  on the host's NavigationStack pushes the destination.
- **DiscoverView**: stage the item into the existing
  `presentedPlexItem` binding (which already drives a fullScreenCover
  with MediaDetailView), then dismiss the modal so the cover beneath
  becomes visible.

The local `navigateToEpisode` binding remains the path for instances
of MediaDetailView reached via the regular NavigationStack (library
browsing, deeper drill-downs from an already-pushed detail page).

## Notes

- The pre-existing `isEnabled: onPreviewExitRequested == nil` gate
  is preserved (disabling modifiers that would no-op anyway), with
  an updated comment explaining the new external-navigation route.
- `navigateToShow` / `navigateToSeason` paths invoked from inside
  preview overlays were equally broken before this change (less
  commonly hit from inside an overlay, but the gate disabled them
  uniformly). They now fall back to the local binding when
  `onSubItemNavigation` is nil and route through the host when
  it's set, same as `navigateToEpisode`.

## Test plan

- [x] "Recently Added in TV Shows" → multi-season show → tap an
      episode card: episode detail page pushes onto the host's
      NavigationStack, preview overlay dismisses cleanly.
      Empirically validated via diagnostic logs confirming the
      closure routes through the host and `pendingPreviewNavigation`
      triggers the push.
- [x] Library-browsing entry point (regular NavigationStack) — no
      regression. The local navigateToEpisode binding is still used
      since `onSubItemNavigation` is nil.
- [x] Thumbnail-style tap (Play) inside preview overlay (where
      applicable) — unchanged (uses `showPlayer = true`
      fullScreenCover, bypasses navigationDestination entirely).