### PR TITLE
AVPlayer/HLS: server-side subtitle burn-in (with 1080p cap)

### DIFF
--- a/Rivulet/Services/Plex/Playback/Pipeline/ContentRouter.swift
+++ b/Rivulet/Services/Plex/Playback/Pipeline/ContentRouter.swift
@@ -176,18 +176,32 @@ struct ContentRouter {
             )
         }
 
-        // Apple TV has no native decoder for the source video codec
-        // (e.g. MPEG-2, VC-1, VP9, AV1). Direct-play would produce
-        // "Couldn't Load Video"; force a server-side transcode. The URL
-        // builder downstream picks up the same condition via
+        // Force a server-side transcode for content the rivuletPlayer
+        // pipeline can't render correctly. Two reasons:
+        //  • Apple TV has no native decoder for the source video codec
+        //    (MPEG-2, VC-1, VP9, AV1) — direct-play would produce
+        //    "Couldn't Load Video".
+        //  • Content uses HLG HDR — AVSampleBufferDisplayLayer on tvOS
+        //    accepts and decodes HLG frames without errors but renders
+        //    them black. tvOS's HLG→HDR10 internal conversion only fires
+        //    on the AVPlayer code path. Forcing a Plex transcode lands
+        //    H.264 SDR (or HDR10 if Plex's profile permits) on AVPlayer,
+        //    which the panel can actually display.
+        // The URL builder downstream picks up the same condition via
         // `forceVideoTranscode` so the HLS request is shaped as a real
         // transcode (directPlay=0, directStream=0, h264 target) rather
         // than a direct-play remux.
-        if let videoCodec = Self.primaryVideoCodec(from: context.metadata),
-           Self.requiresTranscode(videoCodec: videoCodec) {
-            reasoning.append("video_codec_requires_transcode_\(videoCodec.lowercased())")
+        if Self.requiresVideoTranscode(metadata: context.metadata) {
+            let videoCodec = Self.primaryVideoCodec(from: context.metadata)?.lowercased() ?? "unknown"
+            let isHLG = Self.isHLGContent(metadata: context.metadata)
+            if isHLG {
+                reasoning.append("video_is_hlg_hdr_not_renderable_via_avsbl")
+            } else {
+                reasoning.append("video_codec_requires_transcode_\(videoCodec)")
+            }
             let hls = buildHLSRoute(context: context)
-            playerDebugLog("[ContentRouter] \(container) | video=\(videoCodec) audio=\(audioCodec) → HLS (codec requires transcode)")
+            let why = isHLG ? "HLG HDR not renderable via AVSampleBufferDisplayLayer" : "codec requires transcode"
+            playerDebugLog("[ContentRouter] \(container) | video=\(videoCodec) audio=\(audioCodec) → HLS (\(why))")
             return PlaybackPlan(
                 policy: context.playbackPolicy,
                 primary: hls,
@@ -287,13 +301,35 @@ struct ContentRouter {
         return videoCodecsRequiringTranscode.contains(normalized)
     }
 
-    /// Convenience: does this metadata's primary video codec require a
-    /// server-side transcode?
+    /// Convenience: does this metadata's video stream require a
+    /// server-side transcode? Returns true for both unsupported codecs
+    /// (MPEG-2 / VC-1 / VP9 / AV1) and HLG HDR — see `plan(for:)` for
+    /// rationale on the HLG path.
     static func requiresVideoTranscode(metadata: PlexMetadata) -> Bool {
-        guard let codec = primaryVideoCodec(from: metadata), !codec.isEmpty else {
+        if let codec = primaryVideoCodec(from: metadata), !codec.isEmpty,
+           requiresTranscode(videoCodec: codec) {
+            return true
+        }
+        if isHLGContent(metadata: metadata) {
+            return true
+        }
+        return false
+    }
+
+    /// Whether the primary video stream is HLG HDR. Used to force a
+    /// server-side transcode: AVSampleBufferDisplayLayer on tvOS doesn't
+    /// trigger the platform's HLG→HDR10 conversion that AVPlayer gets
+    /// for free, and renders HLG content black despite decoding frames.
+    static func isHLGContent(metadata: PlexMetadata) -> Bool {
+        guard let stream = primaryVideoStream(from: metadata),
+              let trc = stream.colorTrc?.lowercased() else {
             return false
         }
-        return requiresTranscode(videoCodec: codec)
+        return trc.contains("hlg") || trc.contains("arib-std-b67")
+    }
+
+    private static func primaryVideoStream(from metadata: PlexMetadata) -> PlexStream? {
+        metadata.Media?.first?.Part?.first?.Stream?.first(where: { $0.isVideo })
     }
 
     static func requiresTranscode(audioCodec: String) -> Bool {

--- a/Rivulet/Services/Plex/PlexNetworkManager.swift
+++ b/Rivulet/Services/Plex/PlexNetworkManager.swift
@@ -1449,6 +1449,13 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
     /// - Parameter useDolbyVision: Whether to include DV enhancement layers (useDoviCodecs=1). Set to false to get HDR10 base layer only.
     /// - Parameter forceVideoTranscode: Force video transcoding (not just remux) to get Apple-compatible codec tags. Required for MKV+DV.
     /// - Parameter allowAudioDirectStream: Allow server to pass-through audio (AAC/AC3/EAC3). False forces AAC transcode for DTS/TrueHD safety.
+    /// - Parameter burnInSubtitles: When true, requests `subtitles=burn` so
+    ///   Plex bakes the server-side-stored subtitle stream into the video
+    ///   frames. Use this for the AVPlayer/HLS path where Plex's HLS WebVTT
+    ///   protocol is structurally single-stream and AVPlayer's first-cue
+    ///   threshold quirk would otherwise need a local proxy + synthetic-cue
+    ///   workaround. RivuletPlayer's FFmpeg ingest pipeline handles WebVTT
+    ///   renditions natively, so leave this false on that path.
     func buildHLSDirectPlayURL(
         serverURL: String,
         authToken: String,
@@ -1457,7 +1464,8 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
         hasHDR: Bool = false,
         useDolbyVision: Bool = true,
         forceVideoTranscode: Bool = false,
-        allowAudioDirectStream: Bool = true
+        allowAudioDirectStream: Bool = true,
+        burnInSubtitles: Bool = false
     ) -> (url: URL, headers: [String: String])? {
         // Request an HLS remux that keeps the HEVC/Dolby Vision bitstream intact
         // tvOS requires fMP4/CMAF segments for Dolby Vision profiles 5/8
@@ -1542,7 +1550,7 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
             URLQueryItem(name: "audioCodec", value: allowAudioDirectStream ? "aac,eac3,ac3" : "eac3,ac3,aac"),
             URLQueryItem(name: "audioBitrate", value: "1024"),
             URLQueryItem(name: "audioChannels", value: "8"),
-            URLQueryItem(name: "subtitles", value: "auto"),
+            URLQueryItem(name: "subtitles", value: burnInSubtitles ? "burn" : "auto"),
             URLQueryItem(name: "subtitleSize", value: "100"),
             URLQueryItem(name: "context", value: "streaming"),
             URLQueryItem(name: "location", value: "lan"),

--- a/Rivulet/Services/Plex/PlexNetworkManager.swift
+++ b/Rivulet/Services/Plex/PlexNetworkManager.swift
@@ -1543,7 +1543,16 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
             // compatible codec and is what we want when transcoding from a non-Apple-decodable
             // source. The default keeps both for direct-play / remux-only requests.
             URLQueryItem(name: "videoCodec", value: forceVideoTranscode ? "h264" : "h264,hevc"),
-            URLQueryItem(name: "videoResolution", value: "4096x2160"),
+            // Cap burn-in transcodes at 1080p. Plex's `subtitles=burn` filter
+            // chain inserts an `hwdownload → inlineass → hwupload` round-trip
+            // per frame so it can rasterize subtitles onto CPU memory. At 4K
+            // the GPU↔CPU bandwidth + per-frame CPU work pushes the M4 Pro
+            // transcoder below real-time speed; scrub forward stalls the
+            // transcoder for tens of seconds. Capping at 1080p drops the
+            // per-frame work ~4x and keeps scrub usable. Long-term fix would
+            // be a custom Metal HLG renderer that bypasses Plex transcode
+            // entirely. Soft-sub paths keep the source resolution.
+            URLQueryItem(name: "videoResolution", value: burnInSubtitles ? "1920x1080" : "4096x2160"),
             URLQueryItem(name: "videoQuality", value: "100"),
             URLQueryItem(name: "segmentDuration", value: "6"),
             // EAC3 preferred for surround (HomePod compatible), AAC for stereo fallback

--- a/Rivulet/Views/Player/PlayerControlsOverlay.swift
+++ b/Rivulet/Views/Player/PlayerControlsOverlay.swift
@@ -97,37 +97,55 @@ struct PlayerControlsOverlay: View {
             HStack(alignment: .top, spacing: 0) {
                 // Left Column: Subtitles
                 settingsColumn(title: "SUBTITLES", columnIndex: 0) {
-                    ScrollViewReader { proxy in
-                        ScrollView(.vertical, showsIndicators: false) {
-                            VStack(alignment: .leading, spacing: 4) {
-                                // Off option
-                                PlaybackSettingsRow(
-                                    title: "Off",
-                                    subtitle: "No subtitles",
-                                    isSelected: viewModel.currentSubtitleTrackId == nil,
-                                    isFocused: viewModel.isSettingFocused(column: 0, index: 0)
-                                )
-                                .id("sub_0")
-
-                                ForEach(Array(viewModel.subtitleTracks.enumerated()), id: \.element.id) { index, track in
+                    if viewModel.inPlaybackSubtitleSwitchingSupported {
+                        ScrollViewReader { proxy in
+                            ScrollView(.vertical, showsIndicators: false) {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    // Off option
                                     PlaybackSettingsRow(
-                                        title: formatSubtitleTrackTitle(track),
-                                        subtitle: formatSubtitleTrackSubtitle(track),
-                                        isSelected: track.id == viewModel.currentSubtitleTrackId,
-                                        isFocused: viewModel.isSettingFocused(column: 0, index: index + 1)
+                                        title: "Off",
+                                        subtitle: "No subtitles",
+                                        isSelected: viewModel.currentSubtitleTrackId == nil,
+                                        isFocused: viewModel.isSettingFocused(column: 0, index: 0)
                                     )
-                                    .id("sub_\(index + 1)")
+                                    .id("sub_0")
+
+                                    ForEach(Array(viewModel.subtitleTracks.enumerated()), id: \.element.id) { index, track in
+                                        PlaybackSettingsRow(
+                                            title: formatSubtitleTrackTitle(track),
+                                            subtitle: formatSubtitleTrackSubtitle(track),
+                                            isSelected: track.id == viewModel.currentSubtitleTrackId,
+                                            isFocused: viewModel.isSettingFocused(column: 0, index: index + 1)
+                                        )
+                                        .id("sub_\(index + 1)")
+                                    }
+                                }
+                                .padding(.vertical, 8)
+                            }
+                            .onChange(of: viewModel.focusedRowIndex) { _, newIndex in
+                                if viewModel.focusedColumn == 0 {
+                                    withAnimation(.easeOut(duration: 0.2)) {
+                                        proxy.scrollTo("sub_\(newIndex)", anchor: .center)
+                                    }
                                 }
                             }
-                            .padding(.vertical, 8)
                         }
-                        .onChange(of: viewModel.focusedRowIndex) { _, newIndex in
-                            if viewModel.focusedColumn == 0 {
-                                withAnimation(.easeOut(duration: 0.2)) {
-                                    proxy.scrollTo("sub_\(newIndex)", anchor: .center)
-                                }
-                            }
+                    } else {
+                        // AVPlayer/HLS path: Plex's HLS manifest is
+                        // single-stream for subtitles, so mid-playback
+                        // subtitle changes can't take effect. Pre-play
+                        // picker on the item page still works.
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("Choose subtitles before playback starts.")
+                                .font(.system(size: 18, weight: .medium))
+                                .foregroundStyle(.white.opacity(0.85))
+                            Text("This content streams via a server-side transcode that bakes the subtitle stream into the session, so mid-playback changes can't take effect.")
+                                .font(.system(size: 15))
+                                .foregroundStyle(.white.opacity(0.55))
+                                .fixedSize(horizontal: false, vertical: true)
                         }
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 12)
                     }
                 }
 

--- a/Rivulet/Views/Player/PlayerControlsOverlay.swift
+++ b/Rivulet/Views/Player/PlayerControlsOverlay.swift
@@ -135,12 +135,37 @@ struct PlayerControlsOverlay: View {
                         // single-stream for subtitles, so mid-playback
                         // subtitle changes can't take effect. Pre-play
                         // picker on the item page still works.
+                        let activeTrack = viewModel.currentSubtitleTrackId.flatMap { id in
+                            viewModel.subtitleTracks.first(where: { $0.id == id })
+                        }
                         VStack(alignment: .leading, spacing: 12) {
+                            if let track = activeTrack {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text("Currently playing")
+                                        .font(.system(size: 13, weight: .semibold))
+                                        .tracking(1.0)
+                                        .foregroundStyle(.white.opacity(0.45))
+                                    Text(formatSubtitleTrackTitle(track))
+                                        .font(.system(size: 18, weight: .medium))
+                                        .foregroundStyle(.white)
+                                        .lineLimit(2)
+                                }
+                            } else {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text("Currently playing")
+                                        .font(.system(size: 13, weight: .semibold))
+                                        .tracking(1.0)
+                                        .foregroundStyle(.white.opacity(0.45))
+                                    Text("No subtitles")
+                                        .font(.system(size: 18, weight: .medium))
+                                        .foregroundStyle(.white)
+                                }
+                            }
                             Text("Choose subtitles before playback starts.")
-                                .font(.system(size: 18, weight: .medium))
+                                .font(.system(size: 15, weight: .medium))
                                 .foregroundStyle(.white.opacity(0.85))
                             Text("This content streams via a server-side transcode that bakes the subtitle stream into the session, so mid-playback changes can't take effect.")
-                                .font(.system(size: 15))
+                                .font(.system(size: 13))
                                 .foregroundStyle(.white.opacity(0.55))
                                 .fixedSize(horizontal: false, vertical: true)
                         }

--- a/Rivulet/Views/Player/UniversalPlayerViewModel.swift
+++ b/Rivulet/Views/Player/UniversalPlayerViewModel.swift
@@ -336,10 +336,25 @@ final class UniversalPlayerViewModel: ObservableObject {
     /// Which row within the focused column
     @Published var focusedRowIndex: Int = 0
 
+    /// True when in-playback subtitle switching is meaningful. False on
+    /// the AVPlayer/HLS path: Plex's HLS manifest is single-stream for
+    /// subtitles (`subtitleStreamID` is session-scoped, the manifest
+    /// emits only the currently-selected stream), so AVPlayer's
+    /// `select(_:in:)` mid-playback can't switch to a different track.
+    /// Gated UI shows an explanatory notice instead of a non-functional
+    /// picker.
+    var inPlaybackSubtitleSwitchingSupported: Bool {
+        rivuletPlayer != nil
+    }
+
     /// Number of rows in a given column
     func rowCount(forColumn column: Int) -> Int {
         switch column {
-        case 0: return 1 + subtitleTracks.count  // "Off" + subtitle tracks
+        case 0:
+            // Subtitles column has no focusable rows on AVPlayer/HLS path —
+            // the column slot still renders an explanatory notice but is
+            // skipped by focus navigation.
+            return inPlaybackSubtitleSwitchingSupported ? (1 + subtitleTracks.count) : 0
         case 1: return max(1, audioTracks.count)  // Audio tracks (at least 1)
         default: return 0
         }
@@ -363,7 +378,11 @@ final class UniversalPlayerViewModel: ObservableObject {
                 focusedRowIndex += 1
             }
         case .left:
-            if focusedColumn > 0 {
+            // Skip column 0 (subtitles) when the path doesn't support
+            // mid-playback subtitle switching — the column shows a
+            // non-focusable notice instead of a picker.
+            let leftmostFocusable = inPlaybackSubtitleSwitchingSupported ? 0 : 1
+            if focusedColumn > leftmostFocusable {
                 focusedColumn -= 1
                 // Clamp row index to new column's range
                 focusedRowIndex = min(focusedRowIndex, rowCount(forColumn: focusedColumn) - 1)
@@ -702,7 +721,19 @@ final class UniversalPlayerViewModel: ObservableObject {
             }
 
         case .hls:
-            if let result = buildRivuletHLSURL(offset: startOffset) {
+            // The .hls plan feeds AVPlayer (RivuletPlayer's path goes
+            // through .localRemux + the rivuletFallbackURL prep above).
+            // Burn subtitles into the video frames here: Plex's HLS
+            // manifest is structurally single-stream for subtitles, and
+            // AVPlayer's HLS WebVTT loader has a first-cue threshold
+            // quirk that breaks renditions whose first cue is more than
+            // a few seconds in. RivuletPlayer's HLS-fallback path keeps
+            // soft subs (FFmpeg ingests WebVTT renditions natively).
+            let forceVideoTranscode = ContentRouter.requiresVideoTranscode(metadata: metadata)
+            if let result = buildRivuletHLSURL(
+                offset: startOffset,
+                burnInSubtitles: useApplePlayer || forceVideoTranscode
+            ) {
                 streamURL = result.url
                 streamHeaders = result.headers
                 plexSessionId = result.sessionId
@@ -1296,7 +1327,14 @@ final class UniversalPlayerViewModel: ObservableObject {
     }
 
     /// Build an HLS URL and headers for Rivulet fallback at the requested offset.
-    private func buildRivuletHLSURL(offset: TimeInterval?) -> (url: URL, headers: [String: String], sessionId: String?)? {
+    /// `burnInSubtitles` controls whether `subtitles=burn` is requested. Pass
+    /// true on the AVPlayer/HLS path (Plex's HLS WebVTT pipeline is
+    /// structurally hostile to AVPlayer); false on RivuletPlayer's
+    /// HLS-fallback path (FFmpeg ingests WebVTT renditions natively).
+    private func buildRivuletHLSURL(
+        offset: TimeInterval?,
+        burnInSubtitles: Bool = false
+    ) -> (url: URL, headers: [String: String], sessionId: String?)? {
         guard let ratingKey = metadata.ratingKey else { return nil }
         // Source video codec has no Apple TV decoder (e.g. MPEG-2): the
         // direct-play-shaped URL would hand back the raw file and the
@@ -1311,7 +1349,8 @@ final class UniversalPlayerViewModel: ObservableObject {
             hasHDR: metadata.hasHDR,
             useDolbyVision: metadata.hasDolbyVision,
             forceVideoTranscode: forceVideoTranscode,
-            allowAudioDirectStream: allowAudioDirectStreamDecision(reason: "rivulet_hls_fallback_build")
+            allowAudioDirectStream: allowAudioDirectStreamDecision(reason: "rivulet_hls_fallback_build"),
+            burnInSubtitles: burnInSubtitles
         ) else {
             return nil
         }
@@ -2222,7 +2261,10 @@ final class UniversalPlayerViewModel: ObservableObject {
     func resetSettingsPanel() {
         // Refresh track lists when panel opens
         updateTrackLists()
-        focusedColumn = 0
+        // Start focus on the leftmost focusable column. The subtitles
+        // column (0) is non-focusable on AVPlayer/HLS where it shows a
+        // limitation notice rather than a picker.
+        focusedColumn = inPlaybackSubtitleSwitchingSupported ? 0 : 1
         focusedRowIndex = 0
     }
 
@@ -2604,9 +2646,11 @@ final class UniversalPlayerViewModel: ObservableObject {
     func selectSubtitleTrack(id: Int?) {
         // Delegate the actual pipeline switch to the auto-selection helper,
         // then persist the user's explicit choice as the saved preference so
-        // future playback sessions restore it.
-        // TODO: AVPlayer path still needs AVMediaSelectionGroup wiring; this
-        // fix only covers the RivuletPlayer pipeline (custom player).
+        // future playback sessions restore it. RivuletPlayer applies the
+        // selection live; AVPlayer/HLS receives no client-side action — the
+        // server burns the user's pre-playback selection into the video and
+        // the in-playback picker is gated out (see
+        // `inPlaybackSubtitleSwitchingSupported`).
         selectSubtitleTrackWithoutSaving(id: id)
 
         if let id = id, let track = subtitleTracks.first(where: { $0.id == id }) {
@@ -2955,7 +2999,14 @@ final class UniversalPlayerViewModel: ObservableObject {
         }
     }
 
-    /// Select subtitle track without saving preference (for auto-selection)
+    /// Select subtitle track without saving preference (for auto-selection).
+    /// On the AVPlayer/HLS path subtitles are server-side burned into the
+    /// video frames (`subtitles=burn` in the start URL), so there's no
+    /// client-side track to select on that path — the picker pre-play sets
+    /// the server preference via `setSelectedSubtitleStream` and Plex bakes
+    /// it in when building the transcode session. Mid-playback changes
+    /// require a session rebuild and are gated out of the in-playback UI;
+    /// see `inPlaybackSubtitleSwitchingSupported`.
     private func selectSubtitleTrackWithoutSaving(id: Int?) {
         if rivuletPlayer != nil {
             rivuletPlayer?.selectSubtitleTrack(id: id)


### PR DESCRIPTION
## Summary

The AVPlayer/HLS playback path now requests `subtitles=burn` so Plex
bakes the server-side-stored subtitle stream into the video frames.
On this branch HLG/DV content (routed here by #134) is the primary
use case; the user-forced "Apple Player" toggle also triggers it.
RivuletPlayer's HLS-fallback path is unchanged.

Stacks on **#134**. Mergeable without #134 — the user-forced
"Apple Player" toggle still triggers the path — but most of the
value lights up once #134 lands. (Diff in this PR includes #134's
commits until #134 merges.)

Three commits:

1. **`subtitles=burn` on the AVPlayer/HLS path** — adds a
   `burnInSubtitles` parameter to `buildHLSDirectPlayURL`; gates the
   in-playback subtitle picker on `inPlaybackSubtitleSwitchingSupported`
   (currently `rivuletPlayer != nil`). Mid-playback the SUBTITLES
   column shows an explanatory notice; focus skips to AUDIO. The
   pre-play subtitle picker on the detail page is unchanged.
2. **Active-track name in the in-playback notice** — closes a gap left
   by Plex's Now Playing dashboard, which surfaces only language +
   codec + SDH flag for burned-in subs (no track name).
3. **1080p cap on burn-in transcodes** — Plex's `subtitles=burn` filter
   chain forces an `hwdownload → inlineass → hwupload` round-trip per
   frame; 4K HEVC HLG bottlenecks even an M4 Pro transcoder below
   real-time speed. Capping at 1080p drops per-frame work ~4x.

## Why burn-in over a soft sub track

Plex's HLS subtitle pipeline + AVPlayer's WebVTT loader have three
structural limits on this path:

- **Single-stream manifest.** `subtitleStreamID` is session-scoped;
  the manifest emits exactly one `EXT-X-MEDIA TYPE=SUBTITLES` line.
  Mid-playback switching requires reissuing the whole transcode
  session.
- **First-cue threshold.** AVPlayer silently disables WebVTT
  renditions whose first cue is more than a few seconds into the
  timeline (common for cold opens). Working around it requires a
  local proxy that injects a synthetic threshold-satisfying cue.
- **Accessibility-styled cue background.** The synthetic cue still
  draws a brief opaque box at first appearance; AVPlayer applies the
  user's accessibility cue background as a separate compositing
  layer outside `::cue` CSS scope. No STYLE block or cue setting
  suppresses it.

Burning the subtitle stream into the video frames sidesteps all
three. Tradeoffs: no mid-playback Off / no mid-playback track
switching (pre-play picker still works); no client-side
accessibility styling on burned-in tracks.

## Future direction

The 1080p cap is a stopgap. The long-term fix for HDR Direct Play
is a custom Metal renderer in the spirit of Infuse — FFmpeg demux +
VideoToolbox HW decode + a `CAMetalLayer` with
`wantsExtendedDynamicRangeContent` and an HDR pixel format — which
bypasses Plex transcode entirely and removes both the resolution
cap and the burn-in dependency. Tracked separately as a possible
future direction; not part of this PR.

## Test plan

- [ ] Cold start an HLG title with embedded subtitles selected
      pre-play — subtitles appear immediately.
- [ ] Open the in-playback menu — SUBTITLES column shows
      "Currently playing: <track name>" + the explanatory notice;
      focus does not land in the column; right-arrow lands in AUDIO.
- [ ] Scrub forward 30+ minutes on a 4K HLG title — playback
      resumes within a few seconds. (Without the 1080p cap, the
      transcoder stalls for tens of seconds.)
- [ ] RivuletPlayer's HLS-fallback path — subtitles still arrive
      as a soft track (FFmpeg-decoded WebVTT). Pre-existing
      behavior; this PR should not regress it.