### PR TITLE
DirectPlay: cut hasDV preroll target from 3.0s to 0.5s

### DIFF
--- a/Rivulet/Services/Plex/Playback/Pipeline/DirectPlayPipeline.swift
+++ b/Rivulet/Services/Plex/Playback/Pipeline/DirectPlayPipeline.swift
@@ -1707,15 +1707,19 @@ final class DirectPlayPipeline {
                     guard let anchor = prerollAnchorPTSSeconds, let maxVPTS = prerollMaxVideoPTSSeconds else { return 0 }
                     return max(0, maxVPTS - anchor)
                 }()
-                // Required video lead before the clock starts. DV/HDR content from Plex
-                // takes ~10 s for the HTTP read loop to warm up; during that warmup the
-                // read loop sustains roughly 0.4–0.82× realtime, so a too-small lead is
-                // depleted before the network reaches steady state and the audio renderer
-                // underruns. Aim for enough buffer to bridge the entire warmup phase
-                // (warmup_seconds × (1 - average_warmup_rate) ≈ 3 s).
+                // Required video lead before the clock starts.
+                //   - Conversion (HLS transcode): 5.0 s — bridges the HLS HTTP rate-up
+                //     window where segments arrive at ~0.4× realtime for the first few
+                //     seconds. Smaller values cause renderer underrun → "first ~10s
+                //     skipped" mode.
+                //   - hasDV / HDR direct-stream: 0.5 s — direct-stream HTTP is fast
+                //     (~12-25× realtime), so a deep preroll is unnecessary AND harmful:
+                //     it stacks frames the cold HW decoder can't drain at realtime,
+                //     producing a sustained slow-clock window (~0.5× wall) at startup.
+                //   - Default: 0.20 s — already-clean SDR/AVC fast path.
                 let requiredPrerollLeadSeconds: Double = {
                     if requiresConversion { return 5.0 }
-                    if hasDV { return 3.0 }
+                    if hasDV { return 0.5 }
                     return 0.20
                 }()
                 let videoReady = videoLeadSeconds >= requiredPrerollLeadSeconds
@@ -1728,7 +1732,7 @@ final class DirectPlayPipeline {
                 // by a too-aggressive timeout.
                 let prerollTimeout: Double = {
                     if requiresConversion { return 12000 }
-                    if hasDV { return 10000 }
+                    if hasDV { return 1500 }
                     return 1000
                 }()
                 let timedOut = hasAudioPath && waitedMs >= prerollTimeout
@@ -2127,7 +2131,7 @@ final class DirectPlayPipeline {
                                 }()
                                 let requiredPrerollLeadSeconds: Double = {
                                     if requiresConversion { return 5.0 }
-                                    if hasDV { return 3.0 }
+                                    if hasDV { return 0.5 }
                                     return 0.20
                                 }()
                                 let waitedMs: Double = {


### PR DESCRIPTION
## Summary

Companion to #140 for the same conceptual fix on a different code path:
shorten the preroll lead so the post-preroll throttle has less ahead-
state to drain. This PR addresses the `hasDV` (direct-stream Dolby
Vision, no profile conversion) branch; #140 addresses `requiresConversion`
(DV P7→P8.1 inline conversion).

## The cost of a deep preroll

The 3-second `hasDV` preroll was stacking frames that the cold HW
decoder couldn't drain at realtime, producing ~7-13 seconds of slow-
clock playback (~0.5× wall) at every cold start of DV content.
Direct-stream HTTP via the parallel-segment `URLSessionAVIO` delivers
~12-25× realtime, so 0.5 s suffices for buffer warmup without
amplifying the cold-decoder cost. Matching timeout adjusted 10 s → 1.5 s.

## Changes

- `requiredPrerollLeadSeconds` for `hasDV`: 3.0 s → 0.5 s. Updates both
  copies of the constant (main path + diagnostic-log block).
- `prerollTimeout` for `hasDV`: 10 s → 1.5 s.
- Comment block rewritten to explain the per-path reasoning.

`requiresConversion` / non-DV / default paths are unchanged in this PR.

## Verification

Tested on direct-stream Dolby Vision content (4K DV WEB-DL) with the
Apple TV's *Match Frame Rate* and *Match Dynamic Range* settings
disabled (the panel-side HDMI renegotiation otherwise masks the
pipeline's actual behaviour with 2–7 s of black). Playback starts
within ~1 s of pressing Play, without the prior multi-second slow-
clock window. Tested cleanly alongside the changes in #140.

## Note on merge order vs #140

Both PRs rewrite the same comment block in `DirectPlayPipeline.swift`
above `requiredPrerollLeadSeconds`. Whichever lands second will need a
trivial rebase to keep both adjustments. The code-line changes
themselves are on different conditional branches and don't overlap.