### PR TITLE
Player: opt-out toggle for the post-video Up Next panel

### DIFF
--- a/Rivulet/Views/Player/UniversalPlayerViewModel.swift
+++ b/Rivulet/Views/Player/UniversalPlayerViewModel.swift
@@ -3144,7 +3144,7 @@ final class UniversalPlayerViewModel: ObservableObject {
                    credits.id == firstCredits.id,
                    time >= credits.startTimeSeconds && !hasTriggeredPostVideo {
                     hasTriggeredPostVideo = true
-                    Task { await handlePlaybackEnded() }
+                    triggerPostVideoTransition()
                 }
                 return
             }
@@ -3189,7 +3189,7 @@ final class UniversalPlayerViewModel: ObservableObject {
             // Only trigger if we're both near the end AND have watched most of the content
             if time >= triggerTime && time >= minCompletionTime && !hasTriggeredPostVideo {
                 hasTriggeredPostVideo = true
-                Task { await handlePlaybackEnded() }
+                triggerPostVideoTransition()
                 return
             }
         }
@@ -3399,6 +3399,27 @@ final class UniversalPlayerViewModel: ObservableObject {
     // MARK: - Post-Video Handling
 
     /// Handle video end - transition to post-video summary
+    /// Called by `processMarkers` at the first-credits boundary (or at the
+    /// 45-seconds-from-end heuristic for content without markers). Decides
+    /// whether to enter the panel flow now or let playback continue to true
+    /// EOF, based on the user's `showPostVideoUpNext` preference. When the
+    /// panel is suppressed for episodes, we still mark the item as watched
+    /// at credits-start (so manual mid-credits dismissal doesn't leave the
+    /// episode in a "not yet finished" state); the actual panel entry —
+    /// when applicable — happens later from `handlePlaybackEnded` itself,
+    /// or doesn't happen at all when the user has opted out. The pref is
+    /// read via `object as? Bool` so a missing key reads as the default-
+    /// true preserve-existing-behavior path rather than `false`.
+    private func triggerPostVideoTransition() {
+        let showUpNext = UserDefaults.standard.object(forKey: "showPostVideoUpNext") as? Bool ?? true
+        let isEpisode = metadata.type == "episode"
+        if showUpNext || !isEpisode {
+            Task { await handlePlaybackEnded() }
+        } else {
+            Task { await markCurrentAsWatched() }
+        }
+    }
+
     func handlePlaybackEnded() async {
         // Don't re-enter if already showing post-video
         guard postVideoState == .hidden else { return }
@@ -3410,8 +3431,16 @@ final class UniversalPlayerViewModel: ObservableObject {
 
         let isEpisode = metadata.type == "episode"
 
+        // Per-user opt-out of the post-video "Up Next" chooser for TV
+        // episodes. When disabled, episodes follow the same path movies
+        // already take — credits play uninterrupted at full size. Default
+        // is on so the chooser still appears for users who like it; key
+        // pulled via `object as? Bool` so a missing key reads as the
+        // default rather than `false`.
+        let showUpNext = UserDefaults.standard.object(forKey: "showPostVideoUpNext") as? Bool ?? true
+
         // Movies: No PostVideo - just let the video play through to the end
-        guard isEpisode else {
+        guard isEpisode && showUpNext else {
             postVideoState = .hidden
             return
         }

--- a/Rivulet/Views/Player/UniversalPlayerViewModel.swift
+++ b/Rivulet/Views/Player/UniversalPlayerViewModel.swift
@@ -1197,7 +1197,15 @@ final class UniversalPlayerViewModel: ObservableObject {
         case .buffering:
             playbackState = .buffering
         case .ended:
-            playbackState = .ended
+            // Route through `updatePlaybackState` (not direct assignment) so
+            // the EOF → `handlePlaybackEnded` chain at line ~1000 fires for
+            // the rivuletPlayer pipeline too. Without this, only the
+            // marker-based triggers in `processMarkers` lead into
+            // `handlePlaybackEnded`; a true end-of-stream on rivuletPlayer
+            // is silently ignored. AVPlayer's path already routes through
+            // `updatePlaybackState(.ended)` via the
+            // `AVPlayerItemDidPlayToEndTime` notification.
+            updatePlaybackState(.ended)
         case .failed:
             // Error details come through errorPublisher
             break

--- a/Rivulet/Views/Settings/SettingsDescriptors.swift
+++ b/Rivulet/Views/Settings/SettingsDescriptors.swift
@@ -144,6 +144,11 @@ enum SettingsDescriptorStore {
             iconColor: .purple,
             description: "How long to wait before automatically playing the next episode. Set to Off to disable autoplay."
         ),
+        "showPostVideoUpNext": SettingDescriptor(
+            icon: "rectangle.stack",
+            iconColor: .purple,
+            description: "When off, closing credits play uninterrupted and the player returns to Home at the end of the episode."
+        ),
         "useApplePlayer": SettingDescriptor(
             icon: "play.rectangle",
             iconColor: .blue,

--- a/Rivulet/Views/Settings/SettingsView.swift
+++ b/Rivulet/Views/Settings/SettingsView.swift
@@ -291,6 +291,7 @@ struct SettingsView: View {
     @AppStorage("promptResumeOrRestart") private var promptResumeOrRestart = false
     @AppStorage("useApplePlayer") private var useApplePlayer = true
     @AppStorage("autoplayCountdown") private var autoplayCountdownRaw = AutoplayCountdown.fiveSeconds.rawValue
+    @AppStorage("showPostVideoUpNext") private var showPostVideoUpNext = true
     @AppStorage("displaySize") private var displaySizeRaw = DisplaySize.normal.rawValue
     @AppStorage("musicLoudnessNormalization") private var musicLoudnessNormalization = false
     @AppStorage("musicCrossfadeDuration") private var musicCrossfadeDurationRaw = CrossfadeOption.off.rawValue
@@ -735,6 +736,12 @@ struct SettingsView: View {
                 value: autoplayCountdown.wrappedValue.description,
                 action: { navigate(to: .autoplayCountdownPicker) },
                 onFocusChange: { if $0 { focusState.focusedSettingId = "autoplayCountdown" } }
+            )
+
+            SettingsToggleRow(
+                title: "Show Up Next Panel",
+                isOn: $showPostVideoUpNext,
+                onFocusChange: { if $0 { focusState.focusedSettingId = "showPostVideoUpNext" } }
             )
 
 


### PR DESCRIPTION
Adds a `showPostVideoUpNext` @AppStorage toggle in Settings → Playback
(default on, preserving existing behavior). When off, TV episodes
follow the same path movies already take — credits play uninterrupted
at full size and the player walks off-screen when the video itself
ends, instead of shrinking into a corner the moment credits start to
overlay a "Play Next / Dismiss / Go to Season / Go to Show" chooser.

**Two commits in this PR:**

**1. `Player: route rivuletPlayer .ended through updatePlaybackState`** — small prerequisite bug fix. `handleRivuletStateChange` was assigning to `playbackState` directly in every case, bypassing `updatePlaybackState`'s post-end work that fires `handlePlaybackEnded`. AVPlayer's path already routes correctly via the `AVPlayerItemDidPlayToEndTime` notification; this brings rivuletPlayer to parity. Only the `.ended` case is changed; other cases keep their direct-assignment pattern.

Without this, the opt-out path below would play credits through to true EOF and then sit at the end frame because the rivuletPlayer EOF event never reached `handlePlaybackEnded`.

**2. `Player: opt-out toggle for the post-video Up Next panel`** — adds the toggle and the two-piece gating that supports it:

- `triggerPostVideoTransition` (new) is the per-trigger gate that `processMarkers` calls at the first-credits boundary and at the no-markers 45s-from-end heuristic. When the panel is suppressed for episodes, it marks-as-watched immediately (so a manual mid-credits dismissal doesn't leave the episode "not yet finished") but does not enter `handlePlaybackEnded()` — playback continues to true EOF.
- `handlePlaybackEnded()` keeps the toggle check at its own entry too, so the EOF-path call (from `updatePlaybackState(.ended)`) correctly takes the no-panel branch. Movie / last-episode paths are unaffected.

**User-visible:** a new toggle "Show Up Next Panel" in Settings → Playback, alongside Autoplay Countdown. Default on, so existing users see no change unless they opt out.

Tested locally on tvOS 26.4 across both toggle states, on rivuletPlayer and AVPlayer paths, on episodes with and without credits markers.