### PR TITLE
PostVideo: blur next-episode thumbnail + description under hideSpoilersForUnwatched

### DIFF
--- a/Rivulet/Views/Player/PostVideo/NextEpisodeCard.swift
+++ b/Rivulet/Views/Player/PostVideo/NextEpisodeCard.swift
@@ -12,6 +12,8 @@ struct NextEpisodeCard: View {
     let serverURL: String
     let authToken: String
 
+    @AppStorage("hideSpoilersForUnwatched") private var hideSpoilersForUnwatched = false
+
     private var thumbURL: URL? {
         guard let thumb = episode.thumb else { return nil }
         return URL(string: "\(serverURL)\(thumb)?X-Plex-Token=\(authToken)")
@@ -25,6 +27,14 @@ struct NextEpisodeCard: View {
 
     private var showTitle: String {
         episode.grandparentTitle ?? ""
+    }
+
+    /// Same idiom MediaDetailView's episode rows use: blur when the global
+    /// spoiler-hide setting is on AND the next episode isn't fully watched.
+    /// In-progress next episodes stay blurred so a partial-watch state
+    /// doesn't leak a spoiler before the user has committed to finishing.
+    private var blurForSpoilers: Bool {
+        hideSpoilersForUnwatched && !episode.isWatched
     }
 
     var body: some View {
@@ -54,6 +64,7 @@ struct NextEpisodeCard: View {
                 }
             }
             .frame(width: 280, height: 158)
+            .blur(radius: blurForSpoilers ? 18 : 0)
             .clipShape(RoundedRectangle(cornerRadius: 12))
 
             // Episode info
@@ -85,6 +96,7 @@ struct NextEpisodeCard: View {
                         .foregroundStyle(.white.opacity(0.7))
                         .lineLimit(3)
                         .multilineTextAlignment(.leading)
+                        .blur(radius: blurForSpoilers ? 6 : 0)
                 }
 
                 // Duration if available


### PR DESCRIPTION
The Up Next panel's `NextEpisodeCard` bypassed the global `hideSpoilersForUnwatched` setting, so a user with spoiler-hide on would still see an unblurred screenshot and full synopsis of the next (unwatched) episode the moment credits began. Applies the same blur idiom that `MediaDetailView`'s episode rows already use: 18-radius blur on the thumbnail, 6-radius on the summary text, gated on setting-on AND `!episode.isWatched`. In-progress next episodes stay blurred (matches the carousel) so a partial-watch state doesn't leak a spoiler before the user has committed to finishing.

The just-finished episode's "About This Episode" block at the bottom of the panel is left unblurred — that episode is marked watched at the credits-marker boundary before the panel renders, so by definition it's no longer unwatched.

Tested locally on tvOS 26.4 with `hideSpoilersForUnwatched` on: next-episode thumbnail and summary now blurred, just-finished episode's description shows clearly.