### PR TITLE
PlexAuthManager: fix server-selection identity mismatch on multi-server accounts

### DIFF
--- a/Rivulet/Services/Plex/PlexAuthManager.swift
+++ b/Rivulet/Services/Plex/PlexAuthManager.swift
@@ -547,6 +547,15 @@ class PlexAuthManager: ObservableObject {
         // Clear user profile selection
         PlexUserProfileManager.shared.reset()
 
+        // Clear cached library / hub / metadata content from the previous
+        // session. Without this, after a sign-out + sign-in to a different
+        // server (or even the same one), the user sees the previous
+        // session's cached hubs and libraries until fresh fetches replace
+        // them — visually confusing on a multi-server account because the
+        // UI labels the connection with the new server while showing the
+        // previous server's content.
+        PlexDataStore.shared.reset()
+
         state = .idle
     }
 

--- a/Rivulet/Services/Plex/PlexAuthManager.swift
+++ b/Rivulet/Services/Plex/PlexAuthManager.swift
@@ -188,11 +188,22 @@ class PlexAuthManager: ObservableObject {
         // Cancel any in-progress server selection
         serverSelectionTask?.cancel()
 
-        selectedServer = server
-
         // Create a tracked task for the connection test
         let task = Task { @MainActor () -> Bool in
             if let workingURL = await findBestConnection(for: server) {
+                // Flip identity + URL + token atomically once the connection
+                // is verified. Setting `selectedServer = server` eagerly
+                // (before the async test) caused a confusing UI / data-
+                // fetch mismatch on multi-server accounts: views bound to
+                // `selectedServer.name` showed the newly-picked server's
+                // name while in-flight fetches still used the previous
+                // `selectedServerURL`. On a failed connection test the
+                // same path left users staring at a "you are on server X"
+                // label while data continued to come from whichever server
+                // they'd been on before. User-visible symptom: the UI
+                // labels you as on one Plex server while the libraries
+                // and items you see come from a different one.
+                selectedServer = server
                 selectedServerURL = workingURL
                 userDefaults.set(selectedServerURL, forKey: serverURLKey)
                 userDefaults.set(server.name, forKey: serverNameKey)
@@ -615,12 +626,25 @@ class PlexAuthManager: ObservableObject {
             connectionError = "Cannot connect to Plex server"
 
             // Try to find a better connection without clearing credentials
-            // This allows cached content to still be shown
+            // This allows cached content to still be shown.
+            //
+            // Match the saved server by URL first, then by saved name as a
+            // fallback (Plex occasionally rotates a server's connection
+            // URIs, which breaks URL-matching while the name stays stable).
+            // If neither identifies the saved server, leave selection alone
+            // — the prior `?? servers.first` fallback silently swapped users
+            // to whichever server happened to be first in the account's
+            // server list, which on a multi-server account (e.g. own + shared)
+            // could pull them onto the wrong server entirely.
             do {
                 let servers = try await networkManager.getServers(authToken: token)
-                if let currentServer = servers.first(where: { server in
+                let savedName = savedServerName
+                let matchedServer = servers.first(where: { server in
                     server.connections?.contains { $0.uri == currentURL } == true
-                }) ?? servers.first {
+                }) ?? (savedName.flatMap { name in
+                    servers.first(where: { $0.name == name })
+                })
+                if let currentServer = matchedServer {
                     // Try to find a working connection on this server
                     if let workingURL = await findBestConnection(for: currentServer) {
                         selectedServerURL = workingURL


### PR DESCRIPTION
Three related bugs that confused users with access to multiple Plex servers (their own + shared libraries from other accounts) about which server they were actually browsing.

## 1. `selectServer(_:)` race

`selectedServer = server` was assigned synchronously before the async `findBestConnection` connectivity test ran. UI bindings to `selectedServer.name` flipped to the newly-picked server immediately, but `selectedServerURL` / `selectedServerToken` were only updated inside the success branch of the test. Two problems:

- **Race window:** during the multi-second connection test, library fetches that read `selectedServerURL` still hit the previous server while the UI labeled the connection as the new one.
- **Failed connection test:** the else branch surfaced an error ("Could not connect to server. Check your network.") but left `selectedServer = server` in place. After the user dismissed the error, the UI continued to label them as on the new server while data fetches kept using the previous server's URL and token.

Fixed by moving `selectedServer = server` inside the success branch, so identity / URL / token flip together atomically once the connection is verified. On a failed test the user stays on the server they were already connected to and just sees the error.

## 2. `verifyAndFixConnection()` arbitrary-server fallback

When the saved URL didn't match any server's connection list on a startup re-verification, the code fell back to `?? servers.first` — picking whichever server happened to come first in the Plex.tv API response. On a multi-server account this could silently swap the user to a different server without any UI indication.

Fixed with a saved-name fallback: match by URL first, then by the saved `serverNameKey` value (Plex occasionally rotates a server's connection URIs while the name stays stable), and if neither identifies the saved server, leave the selection alone — surface the error rather than silently switching servers.

## 3. PlexDataStore cache survives sign-out

`PlexDataStore.shared.reset()` exists but is never called — not from `signOut()`, not from anywhere else. After a sign-out the auth state correctly clears (token, selectedServer, selectedServerURL, UserDefaults entries) but the in-memory cache of hubs / libraries / metadata from the previous session is retained.

On a multi-server account this produces a third flavor of identity mismatch: sign out from server A, sign in, pick server B → UI labels the connection as server B (from the fresh `selectedServer`) while the user sees server A's hubs and libraries (from the stale `PlexDataStore` cache) until fresh fetches replace them. The data-store cache survives the auth-state clear, so bugs #1 and #2 fixes don't address it.

The `PlexUserProfileManager.shared.reset()` call was already in `signOut`; this just adds the analogous data-store reset alongside it.

## Repros

**Repro for #1:** on an account with at least two servers (own + a shared library), open the server picker and select a different server than the currently-connected one. While the connection test is running, navigate to a library hub view; the hub data will come from the previous server while the chrome shows the new one. If the connection test fails outright the mismatch persists indefinitely.

**Repro for #2:** harder to trigger reliably; needs the saved URL to no longer appear in any server's connection list (e.g. after a Plex connection-URI rotation). Visible as a silent server switch at app launch.

**Repro for #3:** on a multi-server account, sign out, sign in, select a different server than the one you were previously on. The library / hub views briefly show the previous server's content under the new server's label until in-flight fetches replace them.

Verified locally on tvOS 26.5 by triggering #1's race window and #3's sign-out cache; mismatches no longer reproduce. #2's path is less testable directly but the saved-name fallback is well-bounded.