### PR TITLE
Continue Watching menu: relabel "Go to Episode" → "More Info" (wrong for movies)

### DIFF
--- a/Rivulet/Views/Media/PlexHomeView.swift
+++ b/Rivulet/Views/Media/PlexHomeView.swift
@@ -1041,11 +1041,14 @@ struct ContinueWatchingContextMenuModifier: ViewModifier {
                     Label("Watch from Beginning", systemImage: "arrow.counterclockwise")
                 }
 
-                // Go to Episode
+                // More Info (navigate to detail view — any media type;
+                // the entry is not episode-specific, it just opens the
+                // item's detail page, so the label must not say "Episode"
+                // for movies. Mirrors MediaItemContextMenu's "More Info".)
                 Button {
                     onGoToItem?(item)
                 } label: {
-                    Label("Go to Episode", systemImage: "info.circle")
+                    Label("More Info", systemImage: "info.circle")
                 }
 
                 Divider()


### PR DESCRIPTION
The Continue Watching context-menu entry calls `onGoToItem` → the item detail page for *any* media type (movie, show, episode), so the label "Go to Episode" reads wrong for a movie.

Align it with `MediaItemContextMenu`, which already labels the identical generic detail-view navigation "More Info" (same `info.circle` glyph). Label + clarifying comment only; no behavior change.

Single commit off `main`.