### PR TITLE
fix(library): seed settings init from the persisted profile id

### DIFF
--- a/Rivulet/Services/Plex/LibrarySettingsManager.swift
+++ b/Rivulet/Services/Plex/LibrarySettingsManager.swift
@@ -64,6 +64,11 @@ class LibrarySettingsManager: ObservableObject {
     /// Current user ID for per-user settings (nil = default/no profile)
     private var currentUserId: Int?
 
+    /// UserDefaults key under which `PlexUserProfileManager` persists the
+    /// last-selected Plex Home profile id (`selectedUserIdKey` there).
+    /// Read-only mirror — keep in sync with that owner of the key.
+    private let persistedSelectedUserIdKey = "selectedPlexUserId"
+
     // MARK: - Initialization
 
     private init() {
@@ -73,6 +78,25 @@ class LibrarySettingsManager: ObservableObject {
         self.librariesShownOnHome = []
         self.homeVisibilityConfigured = false
         self.librarySortOptions = [:]
+
+        // PRIVACY: this singleton initializes before the Plex profile
+        // resolves. If we loaded the BASE keys here, a Plex Home /
+        // multi-profile account (whose real hidden set lives under
+        // `<key>_user_<id>`) would get an EMPTY hidden set at launch, so
+        // `isLibraryVisible` would report every library — including
+        // private ones the profile hid — as visible until the async
+        // per-user load lands. That race fails OPEN and leaks private
+        // libraries into the launch list.
+        //
+        // The last-selected profile id is, however, already persisted
+        // synchronously by PlexUserProfileManager (it restores from the
+        // same key). Seed `currentUserId` from it so the FIRST load below
+        // reads the correct per-user keys immediately — no race, no
+        // network wait. `nil` (never selected a profile ⇒ legit
+        // single-user / no Plex Home) keeps the base keys, which are
+        // authoritative there. `onProfileSwitched` still corrects this if
+        // the profile changes in-session.
+        currentUserId = userDefaults.object(forKey: persistedSelectedUserIdKey) as? Int
 
         // Load settings for current user (if any)
         loadSettingsForCurrentUser()


### PR DESCRIPTION
`LibrarySettingsManager` is a singleton whose `init()` runs before the Plex profile resolves, so it loaded the BASE `UserDefaults` keys. For a Plex Home / multi-profile account the real per-user hidden set lives under `<key>_user_<id>`; the empty base set meant `isLibraryVisible()` reported every library — including private ones the profile hid — as visible until the async per-user load landed. The race fails open and leaks private libraries into the launch sidebar / Home list.

The last-selected profile id is already persisted synchronously by `PlexUserProfileManager` (it restores the profile from the same `selectedPlexUserId` key). Seed `currentUserId` from it in `init()` so the first `loadSettingsForCurrentUser()` reads the correct per-user keys immediately — no race, no network dependency. `nil` (never selected a profile = single-user / no Plex Home) keeps the base keys, which are authoritative there; `onProfileSwitched()` still corrects it on an in-session profile switch.
