### PR TITLE
ContentRouter: force HLS transcode for MPEG-4 Part 2 (DivX/Xvid)

### DIFF
--- a/Rivulet/Services/Plex/Playback/Pipeline/ContentRouter.swift
+++ b/Rivulet/Services/Plex/Playback/Pipeline/ContentRouter.swift
@@ -129,6 +129,8 @@ struct ContentRouter {
         "vc1", "wmv3",                          // VC-1 (older WMV-derived encodes)
         "vp9",                                  // VP9 (no Apple TV hardware decoder)
         "av1",                                  // AV1 (no Apple TV hardware decoder through A15 / 3rd-gen)
+        "mpeg4", "mp4v",                        // MPEG-4 Part 2 / DivX / Xvid (no Apple TV decoder)
+        "msmpeg4v1", "msmpeg4v2", "msmpeg4v3",  // Microsoft MPEG-4 v1/v2/v3 (.avi/.wmv rips)
     ]
 
     // MARK: - Route Decision

--- a/Rivulet/Services/Plex/PlexNetworkManager.swift
+++ b/Rivulet/Services/Plex/PlexNetworkManager.swift
@@ -1479,7 +1479,7 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
         // Keep our explicit limitations (dvhe/hev1 remap) to ensure compatible codec tags.
         let clientProfile = [
             // Direct play profiles - tells the server what formats we can preserve in the HLS remux path
-            "add-direct-play-profile(type=videoProfile&protocol=http&container=mp4,mov&videoCodec=h264,mpeg4,hevc&audioCodec=aac,ac3,eac3&subtitleCodec=mov_text,tx3g,ttxt,text,webvtt)",
+            "add-direct-play-profile(type=videoProfile&protocol=http&container=mp4,mov&videoCodec=h264,hevc&audioCodec=aac,ac3,eac3&subtitleCodec=mov_text,tx3g,ttxt,text,webvtt)",
             "add-direct-play-profile(type=musicProfile&protocol=http&container=flac&audioCodec=flac)",
             "add-direct-play-profile(type=musicProfile&protocol=http&container=mp4&audioCodec=alac)",
 


### PR DESCRIPTION
MPEG-4 Part 2 video — FFmpeg codec `mpeg4` (DivX/Xvid), plus the `mp4v` tag and the Microsoft MPEG-4 v1/v2/v3 variants — has no Apple TV decoder. It was missing from `videoCodecsRequiringTranscode`, so this content routed to the direct-play FFmpeg pipeline. There `FFmpegDemuxer.createVideoFormatDescription` only builds a format description for H.264 and HEVC; for anything else it yields a nil description, `DirectPlayPipeline` fails with `noCodecParameters`, and the player shows "Couldn't Load Video" — with no HLS fallback on that path, even though the Plex server could transcode the file fine.

This is the natural extension of #120 (force HLS transcode for codecs Apple TV cannot decode — MPEG-2, VC-1, VP9, AV1):

- Add the MPEG-4 Part 2 family (`mpeg4`, `mp4v`, `msmpeg4v1/v2/v3`) to `ContentRouter.videoCodecsRequiringTranscode`. Such content now routes through AVPlayer + Plex's HLS transcode, exactly as MPEG-2 does.
- Drop the false `mpeg4` claim from the direct-play profile advertised to the Plex server (`videoCodec=h264,mpeg4,hevc` → `h264,hevc`) — the pipeline can't decode MPEG-4, so the profile shouldn't claim it.

Repro: any DivX/Xvid-encoded library content (common for classic-TV rips) fails with "Couldn't Load Video" before this change and plays after.
