### PR TITLE
Tests: align RouteAudioPolicy + ContentRouter expectations with code

### DIFF
--- a/RivuletTests/Unit/Playback/ContentRouterPlaybackPlanTests.swift
+++ b/RivuletTests/Unit/Playback/ContentRouterPlaybackPlanTests.swift
@@ -21,9 +21,20 @@ final class ContentRouterPlaybackPlanTests: XCTestCase {
 
         let plan = ContentRouter.plan(for: context)
 
+        // Both branches route to HLS; the reasoning string differs:
+        //  - FFmpeg available   → Path 3 "plex_server_remux"
+        //  - FFmpeg unavailable → Path 5 "ffmpeg_unavailable"
+        // The Sim target builds against the FFmpeg stub
+        // (`isAvailable=false`); the device target builds against
+        // the real lib (`isAvailable=true`). Both should still
+        // produce a `.hls` primary with no fallbacks.
         if case .hls = plan.primary {
             XCTAssertTrue(plan.fallbacks.isEmpty, "HLS server remux should have no fallbacks")
-            XCTAssertTrue(plan.reasoning.contains("plex_server_remux"))
+            if FFmpegDemuxer.isAvailable {
+                XCTAssertTrue(plan.reasoning.contains("plex_server_remux"))
+            } else {
+                XCTAssertTrue(plan.reasoning.contains("ffmpeg_unavailable"))
+            }
         } else {
             XCTFail("Expected HLS primary route for MKV + DTS, got \(plan.primary)")
         }
@@ -44,7 +55,11 @@ final class ContentRouterPlaybackPlanTests: XCTestCase {
 
         if case .hls = plan.primary {
             XCTAssertTrue(plan.fallbacks.isEmpty)
-            XCTAssertTrue(plan.reasoning.contains("plex_server_remux"))
+            if FFmpegDemuxer.isAvailable {
+                XCTAssertTrue(plan.reasoning.contains("plex_server_remux"))
+            } else {
+                XCTAssertTrue(plan.reasoning.contains("ffmpeg_unavailable"))
+            }
         } else {
             XCTFail("Expected HLS primary route for MKV + EAC3, got \(plan.primary)")
         }

--- a/RivuletTests/Unit/Playback/RouteAudioPolicyTests.swift
+++ b/RivuletTests/Unit/Playback/RouteAudioPolicyTests.swift
@@ -15,8 +15,11 @@ final class RouteAudioPolicyTests: XCTestCase {
         let policy = PlaybackAudioSessionConfigurator.recommendedAudioPolicy(for: snapshot)
 
         XCTAssertEqual(policy.profile, .local)
-        XCTAssertEqual(policy.audioPullStartBufferDuration, 0)
-        XCTAssertEqual(policy.audioPullResumeBufferDuration, 0)
+        // Local HDMI uses a 0.5 s startup / 0.2 s resume audio cushion so
+        // the renderer doesn't underrun during the 4K DV/HDR HTTP warmup
+        // before the read loop steady-states (see configurator comment).
+        XCTAssertEqual(policy.audioPullStartBufferDuration, 0.5)
+        XCTAssertEqual(policy.audioPullResumeBufferDuration, 0.2)
         XCTAssertFalse(policy.preferAudioEngineForPCM)
         XCTAssertFalse(policy.forceClientDecodeAllAudio)
         XCTAssertTrue(policy.forceClientDecodeCodecs.isEmpty)
@@ -41,7 +44,9 @@ final class RouteAudioPolicyTests: XCTestCase {
         XCTAssertEqual(policy.profile, .airPlayStereo)
         XCTAssertEqual(policy.audioPullStartBufferDuration, 1.0)
         XCTAssertEqual(policy.audioPullResumeBufferDuration, 0.3)
-        XCTAssertEqual(policy.targetOutputSampleRate, 0)
+        // AirPlay path resamples to the route's reported sampleRate to
+        // avoid 48kHz-on-44.1kHz crackling (configurator comment).
+        XCTAssertEqual(policy.targetOutputSampleRate, 44_100)
         XCTAssertFalse(policy.preferAudioEngineForPCM)
         XCTAssertTrue(policy.forceClientDecodeAllAudio)
         XCTAssertTrue(policy.forceClientDecodeCodecs.isEmpty)
@@ -92,7 +97,7 @@ final class RouteAudioPolicyTests: XCTestCase {
         XCTAssertEqual(policy.profile, .airPlayMultichannel)
         XCTAssertEqual(policy.audioPullStartBufferDuration, 1.0)
         XCTAssertEqual(policy.audioPullResumeBufferDuration, 0.3)
-        XCTAssertEqual(policy.targetOutputSampleRate, 0)
+        XCTAssertEqual(policy.targetOutputSampleRate, 44_100)
         XCTAssertFalse(policy.preferAudioEngineForPCM)
         XCTAssertTrue(policy.forceClientDecodeAllAudio)
         XCTAssertTrue(policy.forceClientDecodeCodecs.isEmpty)
@@ -117,7 +122,7 @@ final class RouteAudioPolicyTests: XCTestCase {
         XCTAssertEqual(policy.profile, .airPlayStereo)
         XCTAssertEqual(policy.audioPullStartBufferDuration, 1.0)
         XCTAssertEqual(policy.audioPullResumeBufferDuration, 0.3)
-        XCTAssertEqual(policy.targetOutputSampleRate, 0)
+        XCTAssertEqual(policy.targetOutputSampleRate, 44_100)
         XCTAssertFalse(policy.preferAudioEngineForPCM)
         XCTAssertTrue(policy.forceClientDecodeAllAudio)
         XCTAssertTrue(policy.forceClientDecodeCodecs.isEmpty)


### PR DESCRIPTION
## Summary

Two unrelated groups of pre-existing test failures in the Sim test plan,
both fixable with test-side changes (no production behavior change):

- **RouteAudioPolicyTests** (4 cases): the assertions held the
  pre-fix `targetOutputSampleRate=0` and `audioPullStart/Resume`
  buffer durations of `0`, but `PlaybackAudioSessionConfigurator`
  intentionally resamples to the AirPlay route rate (avoid
  48kHz-on-44.1kHz crackling — comment in-file) and uses a
  `0.5s / 0.2s` audio-pull cushion on local HDMI (DV/HDR
  HTTP-warmup window — comment in-file). Updated the test
  expectations to match the deliberate values.

- **ContentRouterPlaybackPlanTests** (2 cases): the MKV→HLS
  cases asserted `plan.reasoning.contains("plex_server_remux")`,
  which only holds when `FFmpegDemuxer.isAvailable == true`. The
  Sim target builds against the FFmpeg stub (`isAvailable=false`),
  in which case the route still lands on `.hls` with no fallbacks,
  but the reasoning string is `"ffmpeg_unavailable"` instead. The
  fix branches the reasoning assertion on `FFmpegDemuxer.isAvailable`
  matching the pattern other tests in the same file already use
  (e.g., `testMP4WithAACRoutesToAVPlayerDirect`).

Net: 7 → 0 failures in the affected test areas on the Sim plan.

## Test plan
- [x] `xcodebuild test … -only-testing:RivuletTests/RouteAudioPolicyTests` (5/5 pass)
- [x] `xcodebuild test … -only-testing:RivuletTests/ContentRouterPlaybackPlanTests` (all pass)
- [x] Full Sim test plan unaffected outside these two areas