### PR TITLE
PreviewStateMachine: include .expandingHero in isExpanded

### DIFF
--- a/Rivulet/Views/Media/PreviewContext.swift
+++ b/Rivulet/Views/Media/PreviewContext.swift
@@ -79,7 +79,13 @@ struct PreviewStateMachine {
     }
 
     var isExpanded: Bool {
-        phase == .expandedHero || phase == .detailsStable
+        // Includes the in-progress `.expandingHero` animation phase
+        // because the user has already committed to expanding by the
+        // time we reach it (`beginExpand()` transitioned out of
+        // carousel-stable); the view is no longer carousel-interactive,
+        // so semantically the preview is "expanded" from the user's
+        // perspective for the duration of the animation.
+        phase == .expandingHero || phase == .expandedHero || phase == .detailsStable
     }
 
     mutating func completeEntryMorph() {


### PR DESCRIPTION
## Summary

`PreviewStateMachine.isExpanded` returns `false` during the
in-progress `.expandingHero` animation phase, but by the time we
reach that phase, `beginExpand()` has already transitioned out of
`.carouselStable` AND locked motion (`motionLocked=true`). The
preview view is no longer carousel-interactive, so semantically
it's "expanded" from the user's perspective for the duration of
the animation.

The corresponding test
(`PreviewFlowStateTests.testExpandFlowTransitionsIntoExpandedState`)
asserts `isExpanded == true` immediately after `beginExpand()`,
and has been red since the predicate was tightened in `a156d39`
to drop `.expandingHero`.

Adding `.expandingHero` alongside `.expandedHero` and
`.detailsStable` matches both the test's expectation and the
user-facing semantic.

## Test plan
- [x] `xcodebuild test … -only-testing:RivuletTests/PreviewFlowStateTests` — all pass (was 7/8, now 8/8)
- [x] Full Sim test plan unaffected outside this case