### PR TITLE
PlexDataStore: include title/type in library-diff so renames surface

### DIFF
--- a/Rivulet/Services/Plex/PlexDataStore.swift
+++ b/Rivulet/Services/Plex/PlexDataStore.swift
@@ -1165,11 +1165,19 @@ class PlexDataStore: ObservableObject {
         return true
     }
 
-    /// Compare two library arrays to avoid unnecessary state updates
+    /// Compare two library arrays to avoid unnecessary state updates.
+    /// Includes `title` so a server-side rename (same key, new title)
+    /// surfaces on the next refresh — keys alone would treat the
+    /// renamed list as equal and the UI would stay stale until an
+    /// app restart. `type` is included too because a library
+    /// retype (movie ⇄ show, rare) also has to invalidate.
     private func librariesAreEqual(_ lhs: [PlexLibrary], _ rhs: [PlexLibrary]) -> Bool {
         guard lhs.count == rhs.count else { return false }
-        let lhsKeys = lhs.map { $0.key }
-        let rhsKeys = rhs.map { $0.key }
-        return lhsKeys == rhsKeys
+        for (l, r) in zip(lhs, rhs) {
+            if l.key != r.key || l.title != r.title || l.type != r.type {
+                return false
+            }
+        }
+        return true
     }
 }


### PR DESCRIPTION
`librariesAreEqual` currently compares only `key`, so any server-side
mutation that preserves the library section id — most commonly a
**rename** — is treated as no-change. `fetchLibrariesFromServer`
skips the `self.libraries = fetched` assignment, the cached array
keeps the old `title`, and the UI continues to display the stale
name until the user force-quits and relaunches Rivulet.

Reproduction:
1. Note a library's name in Rivulet's sidebar.
2. Rename it on the Plex server.
3. Pull the library list (any path that calls `refreshLibraries()` /
   the cache-refresh leg of `loadLibrariesIfNeeded`).
4. Observe Rivulet still showing the old name. Only `kill+restart`
   updates it.

Fix: compare `key`, `title`, and `type` per-position. Same count,
same `(key, title, type)` triple at each index ⇒ equal; anything else
⇒ not equal. `type` is included because a library re-type (movie ⇄
show, rare but possible) should also invalidate. Other library
fields (`updatedAt`, `scannedAt`, `Location`) change frequently for
reasons that don't affect what the UI shows, so they're left out to
avoid spurious re-renders on every Plex scan.

Manually verified on tvOS 26.5 (Apple TV 4K): renaming a library
on Plex server and re-triggering a fetch now updates the sidebar
immediately on the next refresh.