### PR TITLE
Library list: refresh on app foreground + on Library Visibility entry

### DIFF
--- a/Rivulet/ContentView.swift
+++ b/Rivulet/ContentView.swift
@@ -15,6 +15,7 @@ private let splashLog = Logger(subsystem: "com.rivulet.app", category: "Splash")
 
 struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.scenePhase) private var scenePhase
 
     @StateObject private var dataStore = PlexDataStore.shared
     @StateObject private var authManager = PlexAuthManager.shared
@@ -85,6 +86,20 @@ struct ContentView: View {
         .onChange(of: authManager.selectedServerToken) { _, _ in
             MediaProviderRegistry.shared.populateFromCurrentAuth()
             MusicProviderRegistry.shared.populateFromCurrentAuth()
+        }
+        // Refresh the server-side library list on every transition
+        // to .active so a library added or renamed on the Plex server
+        // while Rivulet was backgrounded (or while the user was on the
+        // tvOS Home Screen) surfaces without an app restart.
+        // `loadLibrariesIfNeeded` returns early once the cache is
+        // populated, so without this hook the cached list never
+        // reconciles against current server state. Library visibility
+        // is fail-open (a hidden-libraries deny-list), so a freshly
+        // discovered library auto-appears in the sidebar.
+        .onChange(of: scenePhase) { _, phase in
+            if phase == .active {
+                Task { await dataStore.refreshLibraries() }
+            }
         }
     }
 

--- a/Rivulet/Views/Settings/LibrarySettingsView.swift
+++ b/Rivulet/Views/Settings/LibrarySettingsView.swift
@@ -71,6 +71,15 @@ struct LibrarySettingsView: View {
                 onDismiss: { reorderingLibrary = nil }
             )
         }
+        .onAppear {
+            // Refresh against the server every time the user enters
+            // this screen — they're explicitly in "manage my libraries"
+            // territory, so a freshly-added Plex library should be
+            // visible here without an app restart. Complements the
+            // scenePhase=.active auto-refresh wired in ContentView for
+            // the silent case.
+            Task { await dataStore.refreshLibraries() }
+        }
     }
 
     /// Libraries sorted by user preference


### PR DESCRIPTION
Once the library list is cached on first launch, `loadLibrariesIfNeeded`
returns early and `refreshLibraries()` is only called from the
`PlexHomeView .refreshable` closure — which isn't a discoverable
gesture on tvOS. Net effect: a library added or renamed on the Plex
server never propagates to Rivulet without an app kill+restart.

Two reliable paths:

1. **`ContentView` observes `scenePhase`** and calls
   `dataStore.refreshLibraries()` on every foreground transition.
   Silent, no UI to discover. Catches the common flow: server-side
   library mutation while Rivulet was backgrounded → user reopens →
   list is fresh.

2. **`LibrarySettingsView .onAppear`** calls `refreshLibraries()`.
   The user is explicitly in "manage my libraries" territory, so an
   automatic refresh on entry fits the screen's purpose. Plex tvOS
   and Infuse do similar things.

`refreshLibraries()` is safe to call when not authenticated (it
early-returns on missing token), so neither path needs an explicit
auth gate. Library visibility is fail-open (`hiddenLibraryKeys` is a
deny-list), so a freshly-discovered library auto-appears in the
sidebar — no Settings configuration required for new libraries.

Pairs with **#156** (`librariesAreEqual` diff-fix); either change
alone is insufficient for the rename case to surface — without #156,
even the refreshed fetch result is silently discarded by the
equality check; without this PR, #156's improved diff function is
only reached on app launch.

Verified on tvOS 26.5 (Apple TV 4K): renaming a library on the Plex
server and either (a) backgrounding+foregrounding Rivulet, or (b)
opening Settings → Library Visibility, updates the visible title
without an app restart.