### PR TITLE
Collections: Library/Collections picker + per-item collection footer

### DIFF
--- a/Rivulet/Models/Media/MediaCollectionRef.swift
+++ b/Rivulet/Models/Media/MediaCollectionRef.swift
@@ -5,7 +5,7 @@
 //  Lightweight reference to a collection an item belongs to. Carries the
 //  provider-native id plus the display name. Distinct from a full collection
 //  entity (which a future browse surface would model as `MediaItem` with
-//  `kind == .collection`) — this type only needs to identify and label a
+//  `kind == .collection`); this type only needs to identify and label a
 //  collection, not render it as a tile.
 //
 

--- a/Rivulet/Models/Media/MediaCollectionRef.swift
+++ b/Rivulet/Models/Media/MediaCollectionRef.swift
@@ -1,0 +1,19 @@
+//
+//  MediaCollectionRef.swift
+//  Rivulet
+//
+//  Lightweight reference to a collection an item belongs to. Carries the
+//  provider-native id plus the display name. Distinct from a full collection
+//  entity (which a future browse surface would model as `MediaItem` with
+//  `kind == .collection`) — this type only needs to identify and label a
+//  collection, not render it as a tile.
+//
+
+import Foundation
+
+struct MediaCollectionRef: Hashable, Identifiable, Sendable {
+    /// Provider-native ID. For Plex this is the stringified `Collection[].id`
+    /// used by `/library/sections/{sectionId}/all?collection={id}`.
+    let id: String
+    let name: String
+}

--- a/Rivulet/Models/Media/MediaItemDetail.swift
+++ b/Rivulet/Models/Media/MediaItemDetail.swift
@@ -27,4 +27,5 @@ struct MediaItemDetail: Sendable {
     // Wave 1 additions for the detail view
     let nextEpisode: MediaItem?      // shows only — Plex `OnDeck`, Jellyfin `/Shows/NextUp`
     let collections: [MediaCollectionRef]  // collections this item is tagged with
+    let librarySectionId: String?    // for resolving collection items via section-scoped API
 }

--- a/Rivulet/Models/Media/MediaItemDetail.swift
+++ b/Rivulet/Models/Media/MediaItemDetail.swift
@@ -26,5 +26,5 @@ struct MediaItemDetail: Sendable {
 
     // Wave 1 additions for the detail view
     let nextEpisode: MediaItem?      // shows only — Plex `OnDeck`, Jellyfin `/Shows/NextUp`
-    let collections: [String]        // collection names this item is tagged with
+    let collections: [MediaCollectionRef]  // collections this item is tagged with
 }

--- a/Rivulet/Services/MediaProvider/Plex/PlexMediaMapper.swift
+++ b/Rivulet/Services/MediaProvider/Plex/PlexMediaMapper.swift
@@ -336,7 +336,8 @@ enum PlexMediaMapper {
             contentRating: meta.contentRating,
             rating: meta.rating,
             nextEpisode: nextEpisode,
-            collections: collections
+            collections: collections,
+            librarySectionId: meta.librarySectionID.map(String.init)
         )
     }
 

--- a/Rivulet/Services/MediaProvider/Plex/PlexMediaMapper.swift
+++ b/Rivulet/Services/MediaProvider/Plex/PlexMediaMapper.swift
@@ -317,7 +317,10 @@ enum PlexMediaMapper {
         let nextEpisode: MediaItem? = meta.OnDeck?.Metadata?.first.map {
             item($0, providerID: providerID, serverURL: serverURL, authToken: authToken)
         }
-        let collections = (meta.Collection ?? []).compactMap(\.tag)
+        let collections: [MediaCollectionRef] = (meta.Collection ?? []).compactMap { tag in
+            guard let name = tag.tag, let id = tag.idString else { return nil }
+            return MediaCollectionRef(id: id, name: name)
+        }
 
         return MediaItemDetail(
             item: item(meta, providerID: providerID, serverURL: serverURL, authToken: authToken),

--- a/Rivulet/Services/MediaProvider/TMDB/TMDBMediaMapper.swift
+++ b/Rivulet/Services/MediaProvider/TMDB/TMDBMediaMapper.swift
@@ -120,7 +120,8 @@ enum TMDBMediaMapper {
             contentRating: nil,
             rating: tmdb.voteAverage,
             nextEpisode: nil,
-            collections: []
+            collections: [],
+            librarySectionId: nil
         )
     }
 }

--- a/Rivulet/Services/Plex/PlexNetworkManager.swift
+++ b/Rivulet/Services/Plex/PlexNetworkManager.swift
@@ -591,7 +591,15 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
             headers: plexHeaders(authToken: authToken)
         )
 
-        return container.MediaContainer.Metadata ?? []
+        // Per-collection Plex responses don't carry librarySectionID at the
+        // item level; backfill from the input so callers can reach the
+        // section without threading it separately.
+        let sectionIDInt = Int(sectionId)
+        var items = container.MediaContainer.Metadata ?? []
+        for i in items.indices where items[i].librarySectionID == nil {
+            items[i].librarySectionID = sectionIDInt
+        }
+        return items
     }
 
     /// Get children of an item (seasons for shows, episodes for seasons, albums for artists)

--- a/Rivulet/Services/Plex/PlexNetworkManager.swift
+++ b/Rivulet/Services/Plex/PlexNetworkManager.swift
@@ -533,20 +533,27 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
     ///   - sectionId: The library section ID containing the collection
     ///   - collectionId: The collection filter ID (from Collection[].id in metadata)
     ///   - excludeRatingKey: Optional ratingKey to exclude from results (typically current movie)
+    ///   - sort: Optional Plex sort field (e.g. "originallyAvailableAt"). Defaults
+    ///     to Plex's section-level default (alphabetical by titleSort) when nil.
     func getCollectionItems(
         serverURL: String,
         authToken: String,
         sectionId: String,
         collectionId: String,
-        excludeRatingKey: String? = nil
+        excludeRatingKey: String? = nil,
+        sort: String? = nil
     ) async throws -> [PlexMetadata] {
         guard var components = URLComponents(string: "\(serverURL)/library/sections/\(sectionId)/all") else {
             throw PlexAPIError.invalidURL
         }
 
-        components.queryItems = [
+        var query: [URLQueryItem] = [
             URLQueryItem(name: "collection", value: collectionId)
         ]
+        if let sort {
+            query.append(URLQueryItem(name: "sort", value: sort))
+        }
+        components.queryItems = query
 
         guard let url = components.url else {
             throw PlexAPIError.invalidURL

--- a/Rivulet/Services/Plex/PlexNetworkManager.swift
+++ b/Rivulet/Services/Plex/PlexNetworkManager.swift
@@ -567,6 +567,26 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
         return items
     }
 
+    /// Get the list of collections in a library section.
+    /// Returns each collection as a PlexMetadata (collections are exposed
+    /// as Metadata entries with `type == "collection"` and child counts).
+    func getCollections(
+        serverURL: String,
+        authToken: String,
+        sectionId: String
+    ) async throws -> [PlexMetadata] {
+        guard let url = URL(string: "\(serverURL)/library/sections/\(sectionId)/collections") else {
+            throw PlexAPIError.invalidURL
+        }
+
+        let container: PlexMediaContainerWrapper = try await request(
+            url,
+            headers: plexHeaders(authToken: authToken)
+        )
+
+        return container.MediaContainer.Metadata ?? []
+    }
+
     /// Get children of an item (seasons for shows, episodes for seasons, albums for artists)
     func getChildren(
         serverURL: String,

--- a/Rivulet/Views/Media/CollectionDetailView.swift
+++ b/Rivulet/Views/Media/CollectionDetailView.swift
@@ -1,0 +1,191 @@
+//
+//  CollectionDetailView.swift
+//  Rivulet
+//
+//  Items in a single Plex collection, presented as a poster grid.
+//  Pushed from the Collections mode of `PlexLibraryView`. Item taps go
+//  through the same `selectedItem`/`MediaDetailView` path as anywhere
+//  else.
+//
+
+import SwiftUI
+
+
+struct CollectionDetailView: View {
+    let collection: PlexMetadata
+
+    @Environment(\.uiScale) private var scale
+    @Environment(MediaProviderRegistry.self) private var providerRegistry
+    @StateObject private var authManager = PlexAuthManager.shared
+    private let networkManager = PlexNetworkManager.shared
+
+    @State private var items: [PlexMetadata] = []
+    @State private var isLoading = false
+    @State private var error: String?
+    @State private var selectedItem: MediaItem?
+    @FocusState private var focusedItemRk: String?
+
+    private var columns: [GridItem] {
+        let minWidth = ScaledDimensions.gridMinWidth * scale
+        let maxWidth = ScaledDimensions.gridMaxWidth * scale
+        return [GridItem(.adaptive(minimum: minWidth, maximum: maxWidth), spacing: ScaledDimensions.gridSpacing)]
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                header
+                gridContent
+            }
+        }
+        .task(id: collection.ratingKey) {
+            await loadItems()
+        }
+        .navigationDestination(item: $selectedItem) { item in
+            MediaDetailView(item: item)
+        }
+    }
+
+    @ViewBuilder
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(collection.title ?? "Collection")
+                .font(.system(size: 38, weight: .semibold))
+                .foregroundStyle(.white)
+
+            if let count = collection.childCount {
+                Text("\(count) item\(count == 1 ? "" : "s")")
+                    .font(.system(size: 18))
+                    .foregroundStyle(.secondary)
+            }
+
+            if let summary = collection.summary, !summary.isEmpty {
+                Text(summary)
+                    .font(.system(size: 18))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(4)
+                    .padding(.top, 6)
+            }
+        }
+        .padding(.horizontal, ScaledDimensions.rowHorizontalPadding)
+        .padding(.top, 60)
+        .padding(.bottom, 28)
+    }
+
+    @ViewBuilder
+    private var gridContent: some View {
+        if isLoading && items.isEmpty {
+            ProgressView()
+                .progressViewStyle(.circular)
+                .frame(maxWidth: .infinity, minHeight: 300)
+        } else if let error {
+            errorView(error)
+        } else if items.isEmpty {
+            Text("No items in this collection.")
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, minHeight: 200)
+        } else {
+            LazyVGrid(columns: columns, spacing: 40) {
+                ForEach(items, id: \.ratingKey) { item in
+                    gridItem(item)
+                }
+            }
+            .padding(.horizontal, ScaledDimensions.rowHorizontalPadding)
+            .padding(.vertical, 28)
+        }
+    }
+
+    @ViewBuilder
+    private func gridItem(_ item: PlexMetadata) -> some View {
+        let id = item.ratingKey ?? ""
+        let isFocused = focusedItemRk == id
+        Button {
+            selectedItem = mediaItem(from: item)
+        } label: {
+            VStack(alignment: .leading, spacing: 10) {
+                EquatableView(content: MediaPosterCard(
+                    item: item,
+                    serverURL: authManager.selectedServerURL ?? "",
+                    authToken: authManager.selectedServerToken ?? ""
+                ))
+                .hoverEffectDisabled()
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(item.title ?? "")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundStyle(.white.opacity(0.85))
+                        .lineLimit(1)
+                    if let year = item.year, item.type == "movie" {
+                        Text(verbatim: "\(year)")
+                            .font(.system(size: 13))
+                            .foregroundStyle(.white.opacity(0.55))
+                    }
+                }
+                .frame(height: 40, alignment: .top)
+            }
+            .scaleEffect(isFocused ? 1.10 : 1.0)
+            .animation(.spring(response: 0.3, dampingFraction: 0.8), value: isFocused)
+        }
+        .buttonStyle(CardButtonStyle())
+        .focused($focusedItemRk, equals: id)
+    }
+
+    private func errorView(_ message: String) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 40, weight: .light))
+                .foregroundStyle(.secondary)
+            Text("Unable to Load Collection")
+                .font(.title3)
+            Text(message)
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 500)
+            Button("Try Again") {
+                Task { await loadItems() }
+            }
+            .buttonStyle(AppStoreButtonStyle())
+        }
+        .frame(maxWidth: .infinity, minHeight: 300)
+    }
+
+    private func loadItems() async {
+        guard let serverURL = authManager.selectedServerURL,
+              let token = authManager.selectedServerToken,
+              let ratingKey = collection.ratingKey else {
+            error = "Missing connection or collection id"
+            return
+        }
+
+        isLoading = true
+        error = nil
+
+        do {
+            let fetched = try await networkManager.getChildren(
+                serverURL: serverURL,
+                authToken: token,
+                ratingKey: ratingKey
+            )
+            items = fetched
+            isLoading = false
+        } catch {
+            self.error = error.localizedDescription
+            isLoading = false
+        }
+    }
+
+    private func mediaItem(from meta: PlexMetadata) -> MediaItem {
+        // The real Plex provider id is "plex:<machineId>" (see PlexProvider
+        // init); without it MediaDetailView can't resolve the provider via
+        // the registry, so fullDetail() never runs and the page degrades
+        // to a stub (no trailer/audio/subtitle controls, summary instead of
+        // tagline). Pull the canonical id from the registry.
+        let providerID = providerRegistry.primaryProvider?.id ?? "plex"
+        return PlexMediaMapper.item(
+            meta,
+            providerID: providerID,
+            serverURL: authManager.selectedServerURL ?? "",
+            authToken: authManager.selectedServerToken ?? ""
+        )
+    }
+}

--- a/Rivulet/Views/Media/CollectionDetailView.swift
+++ b/Rivulet/Views/Media/CollectionDetailView.swift
@@ -152,7 +152,8 @@ struct CollectionDetailView: View {
     private func loadItems() async {
         guard let serverURL = authManager.selectedServerURL,
               let token = authManager.selectedServerToken,
-              let ratingKey = collection.ratingKey else {
+              let ratingKey = collection.ratingKey,
+              let sectionID = collection.librarySectionID else {
             error = "Missing connection or collection id"
             return
         }
@@ -161,10 +162,15 @@ struct CollectionDetailView: View {
         error = nil
 
         do {
-            let fetched = try await networkManager.getChildren(
+            // Sort by originallyAvailableAt so the items list mirrors the
+            // per-item footer's release-date ordering; getChildren returns
+            // Plex's default (alphabetical titleSort), which is wrong here.
+            let fetched = try await networkManager.getCollectionItems(
                 serverURL: serverURL,
                 authToken: token,
-                ratingKey: ratingKey
+                sectionId: String(sectionID),
+                collectionId: ratingKey,
+                sort: "originallyAvailableAt"
             )
             items = fetched
             isLoading = false

--- a/Rivulet/Views/Media/MediaDetailView.swift
+++ b/Rivulet/Views/Media/MediaDetailView.swift
@@ -3657,6 +3657,8 @@ private struct MediaItemAgnosticRow: View {
     let items: [MediaItem]
     var onItemSelected: ((MediaItem) -> Void)?
 
+    @FocusState private var focusedItemID: String?
+
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             Text(title)
@@ -3667,12 +3669,22 @@ private struct MediaItemAgnosticRow: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 LazyHStack(spacing: ScaledDimensions.rowItemSpacing) {
                     ForEach(items, id: \.ref.itemID) { item in
+                        let id = item.ref.itemID
+                        let isFocused = focusedItemID == id
                         Button {
                             onItemSelected?(item)
                         } label: {
                             MediaItemAgnosticPosterCard(item: item)
+                                // Suppress the inner poster's hover-highlight
+                                // (which scales the poster only, covering the
+                                // title below). The wrapper scaleEffect
+                                // below grows poster + title together.
+                                .hoverEffectDisabled()
+                                .scaleEffect(isFocused ? 1.10 : 1.0)
+                                .animation(.spring(response: 0.3, dampingFraction: 0.8), value: isFocused)
                         }
                         .buttonStyle(CardButtonStyle())
+                        .focused($focusedItemID, equals: id)
                     }
                 }
                 .padding(.horizontal, ScaledDimensions.rowHorizontalPadding)

--- a/Rivulet/Views/Media/MediaDetailView.swift
+++ b/Rivulet/Views/Media/MediaDetailView.swift
@@ -113,6 +113,7 @@ struct MediaDetailView: View {
     // they pass `fromBeginning: true` to the launch closure directly.
     @AppStorage("promptResumeOrRestart") private var promptResumeOrRestart = false
     @AppStorage("hideSpoilersForUnwatched") private var hideSpoilersForUnwatched = false
+    @AppStorage("showRelatedRow") private var showRelatedRow = true
     @State private var showResumeChoice = false
     @State private var resumeChoiceTimeMs: Int = 0
     @State private var resumeChoiceLaunch: ((_ playFromBeginning: Bool) -> Void)? = nil
@@ -2206,12 +2207,19 @@ struct MediaDetailView: View {
         case .movie:
             // Collection + recommendations are independent of each other
             async let collectionTask: Void = {
-                // TODO(post-wave-1): collectionItems returns [] for Wave 1; skip fetch
-                // Collection name comes from detail?.collections, but we need a library
-                // context to call collectionItems(matching:in:) — not available yet.
-                _ = detail?.collections
+                // Render the first collection the item belongs to (if any)
+                // as an "Other items in <name>" footer row. Plex's API
+                // returns the per-item collection tags with both id and
+                // name; section context comes from the detail itself.
+                guard let coll = detail?.collections.first,
+                      let sectionId = detail?.librarySectionId else { return }
+                await loadCollectionItems(
+                    sectionId: sectionId,
+                    collectionId: coll.id,
+                    name: "\(coll.name) Collection"
+                )
             }()
-            async let recommendTask: Void = loadRecommendedItems()
+            async let recommendTask: Void = showRelatedRow ? loadRecommendedItems() : ()
             _ = await (collectionTask, recommendTask)
 
         case .show:
@@ -2468,7 +2476,10 @@ struct MediaDetailView: View {
                 authToken: token,
                 sectionId: sectionId,
                 collectionId: collectionId,
-                excludeRatingKey: currentItem.ref.itemID
+                excludeRatingKey: currentItem.ref.itemID,
+                // Match Plex tvOS: release-date order (chronological) rather
+                // than Plex's section-level default of alphabetical-by-title.
+                sort: "originallyAvailableAt"
             )
             // Convert [PlexMetadata] → [MediaItem]
             guard let prov = providerRegistry.primaryProvider else { return }
@@ -2926,7 +2937,7 @@ struct MediaDetailView: View {
 
     @ViewBuilder
     private var recommendedRow: some View {
-        if !recommendedItems.isEmpty {
+        if showRelatedRow, !recommendedItems.isEmpty {
             MediaItemAgnosticRow(
                 title: "Related",
                 items: recommendedItems,

--- a/Rivulet/Views/Media/PlexLibraryView.swift
+++ b/Rivulet/Views/Media/PlexLibraryView.swift
@@ -1057,7 +1057,7 @@ struct PlexLibraryView: View {
         .padding(.vertical, 8)
         .onAppear {
             // Re-claim focus on the active tab every time the picker appears
-            // (initial entry AND re-entry from sidebar — TabView keeps the
+            // (initial entry AND re-entry from sidebar; TabView keeps the
             // library view alive, so .task(id: libraryKey) only fires once).
             // Set immediately rather than via DispatchQueue.asyncAfter so the
             // focus engine doesn't settle on the default (first) focusable
@@ -1171,7 +1171,7 @@ struct PlexLibraryView: View {
                 }
                 .frame(height: 56, alignment: .top)
             }
-            // Uniform scale-up on focus — no backing chrome, just the tile
+            // Uniform scale-up on focus; no backing chrome, just the tile
             // growing. Mirrors Plex tvOS's collection-tile behavior.
             .scaleEffect(isFocused ? 1.10 : 1.0)
             .animation(.spring(response: 0.3, dampingFraction: 0.8), value: isFocused)
@@ -1208,10 +1208,10 @@ struct PlexLibraryView: View {
                 authToken: token,
                 sectionId: libraryKey
             )
-            // Plex's per-collection composite cache is occasionally stale —
-            // e.g. the "Star Wars" collection on sky has updatedAt ==
-            // composite-cache timestamp, so Plex won't regenerate even though
-            // the cached output is broken. Substituting `/composite/0`
+            // Plex's per-collection composite cache is occasionally stale
+            // (e.g. the "Star Wars" collection on sky has updatedAt ==
+            // composite-cache timestamp, so Plex won't regenerate even
+            // though the cached output is broken). Substituting `/composite/0`
             // bypasses that cache slot; Plex regenerates from current state
             // and caches the result under `/composite/0` per-collection.
             collections = fetched.map { coll in

--- a/Rivulet/Views/Media/PlexLibraryView.swift
+++ b/Rivulet/Views/Media/PlexLibraryView.swift
@@ -9,9 +9,35 @@ import SwiftUI
 import UIKit
 
 
+/// Per-libraryKey persistence for PlexLibraryView's picker state, surviving
+/// SwiftUI view re-creation when TabView destroys deselected tabs' state.
+/// Lives at module scope so it's a process-wide singleton.
+@MainActor
+private final class LibraryPickerCache {
+    static let shared = LibraryPickerCache()
+    private var modes: [String: PlexLibraryView.BrowseMode] = [:]
+    private var collectionFlags: [String: Bool] = [:]
+
+    func mode(for key: String) -> PlexLibraryView.BrowseMode? { modes[key] }
+    func setMode(_ mode: PlexLibraryView.BrowseMode, for key: String) { modes[key] = mode }
+    func hasCollections(for key: String) -> Bool? { collectionFlags[key] }
+    func setHasCollections(_ has: Bool, for key: String) { collectionFlags[key] = has }
+}
+
 struct PlexLibraryView: View {
     let libraryKey: String
     let libraryTitle: String
+
+    init(libraryKey: String, libraryTitle: String) {
+        self.libraryKey = libraryKey
+        self.libraryTitle = libraryTitle
+        // Seed picker state from the per-library cache so re-entry into a
+        // library restores the user's last-used browse mode (and whether
+        // we knew there were collections), rather than resetting to defaults.
+        let cache = LibraryPickerCache.shared
+        _browseMode = State(initialValue: cache.mode(for: libraryKey) ?? .allItems)
+        _hasCollections = State(initialValue: cache.hasCollections(for: libraryKey) ?? false)
+    }
 
     @Environment(\.nestedNavigationState) private var nestedNavState
     @Environment(\.uiScale) private var scale
@@ -37,6 +63,20 @@ struct PlexLibraryView: View {
     /// We dismiss the overlay and `.navigationDestination(item:)` (attached
     /// to the NavigationStack content below) handles the push.
     @State private var pendingPreviewNavigation: MediaItem?
+
+    // Browse mode picker: All Items (current behavior) vs Collections grid.
+    enum BrowseMode: Hashable { case allItems, collections }
+    @State private var browseMode: BrowseMode = .allItems
+    @State private var collections: [PlexMetadata] = []
+    @State private var isLoadingCollections = false
+    @State private var collectionsError: String?
+    @State private var selectedCollection: PlexMetadata?
+    @FocusState private var browsePickerFocus: BrowseMode?
+    @FocusState private var focusedCollectionRk: String?
+    /// True once we've confirmed the library has at least one collection.
+    /// Drives whether the Collections tab is rendered.
+    @State private var hasCollections: Bool = false
+
     @State private var heroItems: [PlexMetadata] = []
     @State private var heroCurrentIndex: Int = 0
     @State private var heroScrollOffset: CGFloat = 0
@@ -271,6 +311,8 @@ struct PlexLibraryView: View {
                 errorView(error)
             } else if items.isEmpty {
                 emptyView
+            } else if browseMode == .collections {
+                collectionsContentView
             } else {
                 contentView
             }
@@ -297,6 +339,28 @@ struct PlexLibraryView: View {
             }
             .navigationDestination(item: $pendingPreviewNavigation) { item in
                 MediaDetailView(item: item)
+            }
+            .navigationDestination(item: $selectedCollection) { coll in
+                CollectionDetailView(collection: coll)
+            }
+            .task(id: libraryKey) {
+                // Fetch collections eagerly so we know whether to render the
+                // Collections tab at all. browseMode is preserved across
+                // library switches; loadCollections demotes .collections to
+                // .allItems if the new library has none.
+                collections = []
+                await loadCollections()
+                // Claim focus on the (possibly-adjusted) active tab so the
+                // user always lands on the picker on library entry. The
+                // brief delay lets the focus engine settle first.
+                try? await Task.sleep(nanoseconds: 200_000_000)
+                browsePickerFocus = browseMode
+            }
+            .onChange(of: browseMode) { _, newValue in
+                LibraryPickerCache.shared.setMode(newValue, for: libraryKey)
+            }
+            .onChange(of: hasCollections) { _, newValue in
+                LibraryPickerCache.shared.setHasCollections(newValue, for: libraryKey)
             }
             .overlayPreferenceValue(PreviewSourceFramePreferenceKey.self) { anchors in
                 GeometryReader { proxy in
@@ -540,6 +604,7 @@ struct PlexLibraryView: View {
                         Color.clear
                             .frame(height: 0)
                             .id("libraryContentRowsAnchor")
+                        browseModePicker
                         essentialRowsView(scrollProxy: scrollProxy)
                         discoveryRowsView(scrollProxy: scrollProxy)
                         librarySectionHeader
@@ -974,6 +1039,202 @@ struct PlexLibraryView: View {
             }
         } catch {
             print("Failed to reload with new sort: \(error)")
+        }
+    }
+
+    // MARK: - Browse Mode Picker
+
+    @ViewBuilder
+    private var browseModePicker: some View {
+        HStack(spacing: 24) {
+            browseTabButton(.allItems, label: "Library")
+            if hasCollections {
+                browseTabButton(.collections, label: "Collections")
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+        .focusSection()
+        .padding(.vertical, 8)
+        .onAppear {
+            // Re-claim focus on the active tab every time the picker appears
+            // (initial entry AND re-entry from sidebar — TabView keeps the
+            // library view alive, so .task(id: libraryKey) only fires once).
+            // Set immediately rather than via DispatchQueue.asyncAfter so the
+            // focus engine doesn't settle on the default (first) focusable
+            // before we override.
+            browsePickerFocus = browseMode
+        }
+    }
+
+    private func browseTabButton(_ mode: BrowseMode, label: String) -> some View {
+        let active = (browseMode == mode)
+        return Button {
+            browseMode = mode
+        } label: {
+            Text(label)
+                .font(.system(size: 24, weight: .semibold))
+                .padding(.horizontal, 26)
+                .padding(.vertical, 12)
+                .foregroundStyle(active ? .black : .white)
+                .background(
+                    Capsule()
+                        .fill(active ? .white : .white.opacity(0.08))
+                )
+                .contentShape(Capsule())
+                .hoverEffect(.highlight)
+        }
+        .buttonStyle(CardButtonStyle())
+        .focused($browsePickerFocus, equals: mode)
+        // Declare the active tab as the preferred default focus within the
+        // picker's focus section. When focus enters the section (initial
+        // entry AND TabView re-entry), tvOS picks the highest-priority
+        // default focus declaration. Higher priority for the active tab.
+        .defaultFocus($browsePickerFocus, mode, priority: active ? .userInitiated : .automatic)
+    }
+
+    // MARK: - Collections Mode
+
+    private var collectionsContentView: some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            LazyVStack(alignment: .leading, spacing: 36) {
+                browseModePicker
+                    .padding(.top, 80)
+                collectionsBody
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var collectionsBody: some View {
+        if isLoadingCollections && collections.isEmpty {
+            ProgressView()
+                .progressViewStyle(.circular)
+                .frame(maxWidth: .infinity, minHeight: 400)
+        } else if let collectionsError {
+            VStack(spacing: 16) {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.system(size: 40, weight: .light))
+                    .foregroundStyle(.secondary)
+                Text("Unable to Load Collections")
+                    .font(.title3)
+                Text(collectionsError)
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 500)
+                Button("Try Again") {
+                    Task { await loadCollections() }
+                }
+                .buttonStyle(AppStoreButtonStyle())
+            }
+            .frame(maxWidth: .infinity, minHeight: 300)
+        } else if collections.isEmpty {
+            Text("No collections in this library.")
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, minHeight: 300)
+        } else {
+            LazyVGrid(columns: columns, spacing: 40) {
+                ForEach(collections, id: \.ratingKey) { coll in
+                    collectionsGridItem(coll)
+                }
+            }
+            .focusSection()
+            .padding(.horizontal, ScaledDimensions.rowHorizontalPadding)
+            .padding(.bottom, 40)
+        }
+    }
+
+    @ViewBuilder
+    private func collectionsGridItem(_ coll: PlexMetadata) -> some View {
+        let rk = coll.ratingKey ?? ""
+        let isFocused = focusedCollectionRk == rk
+        Button {
+            selectedCollection = coll
+        } label: {
+            VStack(alignment: .leading, spacing: 12) {
+                EquatableView(content: MediaPosterCard(
+                    item: coll,
+                    serverURL: authManager.selectedServerURL ?? "",
+                    authToken: authManager.selectedServerToken ?? ""
+                ))
+                .hoverEffectDisabled()  // suppress MediaPosterCard's inner highlight
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(coll.title ?? "Collection")
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .lineLimit(2)
+                    if let count = coll.childCount {
+                        Text("\(count) \(childCountNoun(count: count))")
+                            .font(.system(size: 14))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .frame(height: 56, alignment: .top)
+            }
+            // Uniform scale-up on focus — no backing chrome, just the tile
+            // growing. Mirrors Plex tvOS's collection-tile behavior.
+            .scaleEffect(isFocused ? 1.10 : 1.0)
+            .animation(.spring(response: 0.3, dampingFraction: 0.8), value: isFocused)
+        }
+        .buttonStyle(CardButtonStyle())
+        .focused($focusedCollectionRk, equals: rk)
+    }
+
+    /// Map library type → noun for collection child counts. Plex's own
+    /// clients use "Movies" / "Shows" rather than generic "Items".
+    private func childCountNoun(count: Int) -> String {
+        switch currentLibraryType {
+        case "movie": return count == 1 ? "Movie" : "Movies"
+        case "show":  return count == 1 ? "Show" : "Shows"
+        case "artist": return count == 1 ? "Album" : "Albums"
+        default:      return count == 1 ? "Item" : "Items"
+        }
+    }
+
+    private func loadCollections() async {
+        guard let serverURL = authManager.selectedServerURL,
+              let token = authManager.selectedServerToken else {
+            collectionsError = "Not connected"
+            hasCollections = false
+            return
+        }
+
+        isLoadingCollections = true
+        collectionsError = nil
+
+        do {
+            let fetched = try await networkManager.getCollections(
+                serverURL: serverURL,
+                authToken: token,
+                sectionId: libraryKey
+            )
+            // Plex's per-collection composite cache is occasionally stale —
+            // e.g. the "Star Wars" collection on sky has updatedAt ==
+            // composite-cache timestamp, so Plex won't regenerate even though
+            // the cached output is broken. Substituting `/composite/0`
+            // bypasses that cache slot; Plex regenerates from current state
+            // and caches the result under `/composite/0` per-collection.
+            collections = fetched.map { coll in
+                var m = coll
+                if let thumb = m.thumb {
+                    m.thumb = thumb.replacingOccurrences(
+                        of: #"/composite/\d+"#,
+                        with: "/composite/0",
+                        options: .regularExpression
+                    )
+                }
+                return m
+            }
+            hasCollections = !collections.isEmpty
+            isLoadingCollections = false
+            // If we ended up in collections mode but there are none, fall back.
+            if browseMode == .collections && !hasCollections {
+                browseMode = .allItems
+            }
+        } catch {
+            collectionsError = error.localizedDescription
+            hasCollections = false
+            isLoadingCollections = false
         }
     }
 
@@ -1688,3 +1949,4 @@ struct PlexLibraryView: View {
         PlexLibraryView(libraryKey: "1", libraryTitle: "Movies")
     }
 }
+

--- a/Rivulet/Views/Media/PlexLibraryView.swift
+++ b/Rivulet/Views/Media/PlexLibraryView.swift
@@ -80,6 +80,13 @@ struct PlexLibraryView: View {
     @State private var heroItems: [PlexMetadata] = []
     @State private var heroCurrentIndex: Int = 0
     @State private var heroScrollOffset: CGFloat = 0
+    /// True while the library hero owns focus. Drives the browse picker's
+    /// reveal: hidden + non-focusable when on the hero (so Down skips it), shown
+    /// + focusable otherwise (so Up reaches it). Initialised true so the picker
+    /// starts hidden on entry, before the hero claims default focus. Focus-state
+    /// based rather than scroll-offset based; focusing the picker scrolls the
+    /// hero toward the top, which an offset gate would misread as "back on hero."
+    @State private var isHeroFocused = true
     @State private var lastLoadedLibraryKey: String?  // Track which library is currently loaded
     @State private var hasPrefetched = false  // Track if we've already prefetched for this library
     @State private var hasMoreItems = true  // Whether there are more items to load
@@ -311,8 +318,6 @@ struct PlexLibraryView: View {
                 errorView(error)
             } else if items.isEmpty {
                 emptyView
-            } else if browseMode == .collections {
-                collectionsContentView
             } else {
                 contentView
             }
@@ -348,13 +353,13 @@ struct PlexLibraryView: View {
                 // Collections tab at all. browseMode is preserved across
                 // library switches; loadCollections demotes .collections to
                 // .allItems if the new library has none.
+                //
+                // We deliberately do NOT claim focus on the picker here: the
+                // hero's Play button takes default focus on entry, and the
+                // picker reveals itself only once the user scrolls down (see
+                // pickerOpacity / pickerRevealed).
                 collections = []
                 await loadCollections()
-                // Claim focus on the (possibly-adjusted) active tab so the
-                // user always lands on the picker on library entry. The
-                // brief delay lets the focus engine settle first.
-                try? await Task.sleep(nanoseconds: 200_000_000)
-                browsePickerFocus = browseMode
             }
             .onChange(of: browseMode) { _, newValue in
                 LibraryPickerCache.shared.setMode(newValue, for: libraryKey)
@@ -581,9 +586,13 @@ struct PlexLibraryView: View {
                             onInfo: { item in selectedItem = selectMediaItem(item) },
                             onPlay: { item in playItemDirectly(item) },
                             onHeroFocused: {
+                                isHeroFocused = true
                                 withAnimation(.smooth(duration: 0.8)) {
                                     scrollProxy.scrollTo("libraryHero", anchor: .top)
                                 }
+                            },
+                            onHeroExited: {
+                                isHeroFocused = false
                             }
                         )
                         .frame(height: heroSectionHeight)
@@ -605,10 +614,14 @@ struct PlexLibraryView: View {
                             .frame(height: 0)
                             .id("libraryContentRowsAnchor")
                         browseModePicker
-                        essentialRowsView(scrollProxy: scrollProxy)
-                        discoveryRowsView(scrollProxy: scrollProxy)
-                        librarySectionHeader
-                        libraryGridView
+                        if browseMode == .collections {
+                            collectionsBody
+                        } else {
+                            essentialRowsView(scrollProxy: scrollProxy)
+                            discoveryRowsView(scrollProxy: scrollProxy)
+                            librarySectionHeader
+                            libraryGridView
+                        }
                     }
                     .padding(.top, heroActive ? 0 : 100)
 
@@ -1044,9 +1057,35 @@ struct PlexLibraryView: View {
 
     // MARK: - Browse Mode Picker
 
+    /// The picker is revealed (visible + focusable) whenever the hero is NOT
+    /// the focused element. Driven by `isHeroFocused`, not scroll offset:
+    /// focusing the picker scrolls the hero back toward the top, so an
+    /// offset-based gate disabled the picker the instant it gained focus and
+    /// ejected it (feedback loop seen on device). Gated on the *setting* so it
+    /// stays hidden during the brief window before hero items load. With the
+    /// hero off it is always revealed.
+    private var pickerRevealed: Bool {
+        guard showLibraryHero else { return true }
+        return !isHeroFocused
+    }
+
+    /// Whether the picker itself currently holds focus.
+    private var pickerFocused: Bool { browsePickerFocus != nil }
+
+    /// Picker opacity. With the hero off the picker is the top-of-screen nav, so
+    /// it stays fully visible. With the hero on it follows the season-pill
+    /// pattern: hidden while the hero owns focus, recessed while revealed in
+    /// content but not focused (so the active pill doesn't read as "focused"
+    /// when it isn't), full when the picker itself has focus.
+    private var pickerOpacity: Double {
+        guard showLibraryHero else { return 1.0 }
+        guard !isHeroFocused else { return 0 }
+        return pickerFocused ? 1.0 : 0.6
+    }
+
     @ViewBuilder
     private var browseModePicker: some View {
-        HStack(spacing: 24) {
+        HStack(spacing: 40) {
             browseTabButton(.allItems, label: "Library")
             if hasCollections {
                 browseTabButton(.collections, label: "Collections")
@@ -1055,19 +1094,22 @@ struct PlexLibraryView: View {
         .frame(maxWidth: .infinity, alignment: .center)
         .focusSection()
         .padding(.vertical, 8)
-        .onAppear {
-            // Re-claim focus on the active tab every time the picker appears
-            // (initial entry AND re-entry from sidebar; TabView keeps the
-            // library view alive, so .task(id: libraryKey) only fires once).
-            // Set immediately rather than via DispatchQueue.asyncAfter so the
-            // focus engine doesn't settle on the default (first) focusable
-            // before we override.
-            browsePickerFocus = browseMode
-        }
+        // Carousel-style reveal (mirrors the season pills): hidden and
+        // non-focusable while the hero owns focus; revealed (recessed) once
+        // focus moves into content, brightening when the picker itself gains
+        // focus.
+        .opacity(pickerOpacity)
+        .animation(.easeInOut(duration: 0.3), value: pickerOpacity)
+        .disabled(!pickerRevealed)
     }
 
     private func browseTabButton(_ mode: BrowseMode, label: String) -> some View {
         let active = (browseMode == mode)
+        // With the hero on, the active tab is bright-filled only when the picker
+        // is focused (so it doesn't masquerade as focused while recessed in
+        // content); otherwise it gets a subtle indicator. With the hero off the
+        // picker is the top nav, so the active tab is always bright-filled.
+        let highlighted = active && (!showLibraryHero || pickerFocused)
         return Button {
             browseMode = mode
         } label: {
@@ -1075,10 +1117,11 @@ struct PlexLibraryView: View {
                 .font(.system(size: 24, weight: .semibold))
                 .padding(.horizontal, 26)
                 .padding(.vertical, 12)
-                .foregroundStyle(active ? .black : .white)
+                .foregroundStyle(highlighted ? .black : .white)
                 .background(
                     Capsule()
-                        .fill(active ? .white : .white.opacity(0.08))
+                        .fill(highlighted ? Color.white
+                              : (active ? Color.white.opacity(0.22) : Color.white.opacity(0.08)))
                 )
                 .contentShape(Capsule())
                 .hoverEffect(.highlight)
@@ -1093,16 +1136,6 @@ struct PlexLibraryView: View {
     }
 
     // MARK: - Collections Mode
-
-    private var collectionsContentView: some View {
-        ScrollView(.vertical, showsIndicators: false) {
-            LazyVStack(alignment: .leading, spacing: 36) {
-                browseModePicker
-                    .padding(.top, 80)
-                collectionsBody
-            }
-        }
-    }
 
     @ViewBuilder
     private var collectionsBody: some View {

--- a/Rivulet/Views/Settings/SettingsDescriptors.swift
+++ b/Rivulet/Views/Settings/SettingsDescriptors.swift
@@ -97,6 +97,11 @@ enum SettingsDescriptorStore {
             iconColor: .mint,
             description: "Uses TMDB metadata and your watch history to surface personalized recommendations of unwatched content."
         ),
+        "relatedRow": SettingDescriptor(
+            icon: "rectangle.split.3x1",
+            iconColor: .orange,
+            description: "Shows a 'Related' row of suggested similar items at the bottom of each movie or show page."
+        ),
         "showDiscoverTab": SettingDescriptor(
             icon: "safari",
             iconColor: .blue,

--- a/Rivulet/Views/Settings/SettingsView.swift
+++ b/Rivulet/Views/Settings/SettingsView.swift
@@ -293,6 +293,7 @@ struct SettingsView: View {
     @AppStorage("useApplePlayer") private var useApplePlayer = true
     @AppStorage("autoplayCountdown") private var autoplayCountdownRaw = AutoplayCountdown.fiveSeconds.rawValue
     @AppStorage("showPostVideoUpNext") private var showPostVideoUpNext = true
+    @AppStorage("showRelatedRow") private var showRelatedRow = true
     @AppStorage("displaySize") private var displaySizeRaw = DisplaySize.normal.rawValue
     @AppStorage("musicLoudnessNormalization") private var musicLoudnessNormalization = false
     @AppStorage("musicCrossfadeDuration") private var musicCrossfadeDurationRaw = CrossfadeOption.off.rawValue
@@ -665,6 +666,12 @@ struct SettingsView: View {
                 title: "Personalized Recommendations",
                 isOn: $enablePersonalizedRecommendations,
                 onFocusChange: { if $0 { focusState.focusedSettingId = "personalizedRecs" } }
+            )
+
+            SettingsToggleRow(
+                title: "Related Row on Item Pages",
+                isOn: $showRelatedRow,
+                onFocusChange: { if $0 { focusState.focusedSettingId = "relatedRow" } }
             )
 
             SettingsToggleRow(


### PR DESCRIPTION
## Summary

Adds Collections as a first-class browse surface, with no behavior
change for libraries that have no collections.

- **Library detail view** gains a centered Library / Collections tab
  picker at the top. The Collections tab renders a grid of the
  section's collections (composite poster + name + child count, e.g.
  "57 Movies"); selecting one pushes a `CollectionDetailView` listing
  the collection's items in release-date order. The picker only
  renders the Collections tab when the library actually has any, and
  per-library picker state is cached so re-entering a library
  restores the last-used tab.

- **Item detail view** gains a "<Collection Name> Collection" footer
  row on movies that belong to a Plex collection — other items in
  the collection, release-date order, excluding the current item.

- **New Settings toggle "Related Row on Item Pages"** (default on) to
  suppress the existing provider-suggested "Related" footer
  independently of the new collection footer. Wired through
  `SettingsDescriptors` so it lands in the sidebar like every other
  setting.

## Why three commits

Split for review:

1. `Collections: preserve collection IDs through MediaItemDetail` —
   data-model groundwork. `PlexMediaMapper.detail` was dropping
   `Collection[].id` and keeping only the tag name, so
   `collectionItems(matching:in:)` had no way to resolve a name back
   to an id without an extra round-trip (the reason
   `PlexProvider.collectionItems` stubbed to `[]`). Adds a
   `MediaCollectionRef` value type and a
   `PlexNetworkManager.getCollections(sectionId:)` listing endpoint.

2. `Collections: Library/Collections picker on library detail view` —
   the picker + grid + `CollectionDetailView`. Star Wars'
   long-standing broken composite cache on PMS is worked around by
   rewriting each collection thumb URL's
   `/composite/<timestamp>` segment to `/composite/0` so Plex
   regenerates from current collection state and re-caches.

3. `Collections: per-item "<name> Collection" footer + Related Row toggle` —
   the per-item footer, plus the Settings toggle to suppress the
   existing Related row.

## Test plan

- [ ] Open a library that has collections — picker appears, Library
      tab is default, Collections tab shows the section's collections
      with poster + name + child count.
- [ ] Switch to Collections, tap a collection — pushes the items list
      in release-date order.
- [ ] Re-enter the library — last-used tab is restored.
- [ ] Open a library with **no** collections — picker is absent;
      behavior is the existing hero / hubs / grid.
- [ ] Open a movie that belongs to a collection — footer "<Name>
      Collection" row appears with sibling items in release-date
      order.
- [ ] Open a movie that does **not** belong to a collection — no
      collection footer; Related row still appears.
- [ ] Settings → toggle "Related Row on Item Pages" off — Related
      row disappears on the next detail view; collection footer is
      unaffected.
- [ ] Star Wars library: collection composite thumbs load (the
      `/composite/0` rewrite).