### PR TITLE
MediaDetailView: propagate Mark Watched through the episode carousel

### DIFF
--- a/Rivulet/Views/Media/MediaDetailView.swift
+++ b/Rivulet/Views/Media/MediaDetailView.swift
@@ -468,6 +468,15 @@ struct MediaDetailView: View {
                 presentPlayer()
             }
         }
+        // Refresh in-memory episode arrays when a child MediaDetailView
+        // (e.g. an episode pushed from this show's carousel) toggles its
+        // watched state. Without this, backing out from the child reveals
+        // the carousel still showing the pre-toggle state.
+        .onReceive(NotificationCenter.default.publisher(for: .episodeWatchedStatusChanged)) { note in
+            guard let rk = note.userInfo?["ratingKey"] as? String,
+                  let watched = note.userInfo?["watched"] as? Bool else { return }
+            applyEpisodeWatchedStatusUpdate(ratingKey: rk, watched: watched)
+        }
         // Pre-play audio / subtitle picker sheets. Tracks come from the
         // first MediaSource in detail (movies/episodes have exactly one).
         .sheet(isPresented: $showAudioTrackPicker) {
@@ -2403,6 +2412,11 @@ struct MediaDetailView: View {
                     )
                 }
                 isWatched = false
+                // Mirror MediaItemContextMenu's behaviour: update the
+                // PlexDataStore cache so when this view re-mounts (back
+                // out and back in) `item.userState.isPlayed` reads the
+                // post-toggle state rather than reverting to stale cache.
+                PlexDataStore.shared.updateItemWatchStatus(ratingKey: ratingKey, watched: false)
             } else {
                 if let prov = provider {
                     try await prov.markPlayed(currentItem.ref)
@@ -2421,9 +2435,20 @@ struct MediaDetailView: View {
                 // After animation, mark as watched and hide progress
                 try? await Task.sleep(nanoseconds: 500_000_000)
                 isWatched = true
+                PlexDataStore.shared.updateItemWatchStatus(ratingKey: ratingKey, watched: true)
             }
             // Notify home screen to refresh Continue Watching
             NotificationCenter.default.post(name: .plexDataNeedsRefresh, object: nil)
+            // Notify any parent MediaDetailView hosting this item in an
+            // episode carousel so it can refresh its in-memory episode
+            // array. Without this, navigating back from an
+            // episode-detail-page-after-toggle reveals the parent show's
+            // carousel still showing the pre-toggle watched state.
+            NotificationCenter.default.post(
+                name: .episodeWatchedStatusChanged,
+                object: nil,
+                userInfo: ["ratingKey": ratingKey, "watched": isWatched]
+            )
         } catch {
             print("Failed to toggle watched status: \(error)")
         }
@@ -2630,6 +2655,46 @@ struct MediaDetailView: View {
 
     /// Refresh a single episode's watch status without reloading the entire list.
     /// Uses provider.fullDetail to get fresh data, then patches the arrays in place.
+    /// Update the in-memory `episodes` / `unifiedEpisodes` arrays' watched
+    /// state for a single rating key, mirroring what `markPlayed`/`markUnplayed`
+    /// would have produced server-side. Used by the
+    /// `episodeWatchedStatusChanged` notification observer so a child
+    /// MediaDetailView's toggle propagates back up to this carousel.
+    private func applyEpisodeWatchedStatusUpdate(ratingKey: String, watched: Bool) {
+        func updated(_ original: MediaItem) -> MediaItem {
+            let newState = MediaUserState(
+                isPlayed: watched,
+                viewOffset: 0,
+                isFavorite: original.userState.isFavorite,
+                lastViewedAt: watched ? Date() : original.userState.lastViewedAt
+            )
+            return MediaItem(
+                ref: original.ref,
+                kind: original.kind,
+                title: original.title,
+                sortTitle: original.sortTitle,
+                overview: original.overview,
+                year: original.year,
+                runtime: original.runtime,
+                parentRef: original.parentRef,
+                grandparentRef: original.grandparentRef,
+                episodeNumber: original.episodeNumber,
+                seasonNumber: original.seasonNumber,
+                childProgress: original.childProgress,
+                userState: newState,
+                artwork: original.artwork,
+                parentArtwork: original.parentArtwork,
+                grandparentArtwork: original.grandparentArtwork
+            )
+        }
+        if let idx = episodes.firstIndex(where: { $0.ref.itemID == ratingKey }) {
+            episodes[idx] = updated(episodes[idx])
+        }
+        if let idx = unifiedEpisodes.firstIndex(where: { $0.ref.itemID == ratingKey }) {
+            unifiedEpisodes[idx] = updated(unifiedEpisodes[idx])
+        }
+    }
+
     private func refreshEpisodeWatchStatus(itemID: String) async {
         guard let prov = provider else { return }
         let ref = MediaItemRef(providerID: currentItem.ref.providerID, itemID: itemID)

--- a/Rivulet/Views/Player/UniversalPlayerViewModel.swift
+++ b/Rivulet/Views/Player/UniversalPlayerViewModel.swift
@@ -3857,6 +3857,13 @@ extension Notification.Name {
     /// Views showing Plex content should refresh their data when receiving this
     static let plexDataNeedsRefresh = Notification.Name("plexDataNeedsRefresh")
 
+    /// Posted when a specific item's watched state changes via the detail-page
+    /// Mark Watched / Unwatched button. Carries `ratingKey` (String) and
+    /// `watched` (Bool) in userInfo. Parent MediaDetailViews (e.g. a show
+    /// detail page hosting an episode carousel) listen for this so their
+    /// in-memory episode arrays reflect the change without a full reload.
+    static let episodeWatchedStatusChanged = Notification.Name("episodeWatchedStatusChanged")
+
     /// Posted when video playback starts (pauses hub polling)
     static let plexPlaybackStarted = Notification.Name("plexPlaybackStarted")
 


### PR DESCRIPTION
## Summary

Fixes a state-binding bug where toggling Mark Watched on a child
`MediaDetailView` (an episode pushed from a show's carousel) updated
the child's local `@State` and the server but left the parent show's
in-memory `episodes` / `unifiedEpisodes` arrays untouched. Navigating
back to the show reverted both the description blur (when
`hideSpoilersForUnwatched` is on) and the button label.

## Fix

Two changes work together:

- **Update the `PlexDataStore` cache** when `toggleWatched` runs from a
  detail view, mirroring what `MediaItemContextMenu` already does for
  the carousel context-menu Mark Watched path.

- **Post a new `.episodeWatchedStatusChanged` notification**
  (`ratingKey` + new state). `MediaDetailView` listens for it and
  patches the matching episode in its in-memory arrays via a small
  helper that rebuilds the `MediaItem` with a fresh `MediaUserState`.
  Subsequent re-entries into the carousel see the correct watched
  state.

## Test plan

- [ ] Open a show; in the episode carousel, tap an unwatched episode
      to push its detail page.
- [ ] Mark Watched on the episode detail page.
- [ ] Back out to the show — the episode card's description blur
      clears (with `hideSpoilersForUnwatched` on) and the button
      label reflects watched.
- [ ] Toggle back to Unwatched on the detail page — back-out shows
      the blur and Unwatched label.
- [ ] Mark Watched via the context menu in the carousel (existing
      path) — still works; no regression.