### PR TITLE
Player UX: blur loading-splash summary for unwatched; return to detail on EOM

### DIFF
--- a/Rivulet/Views/Media/PlexHomeView.swift
+++ b/Rivulet/Views/Media/PlexHomeView.swift
@@ -327,11 +327,18 @@ struct PlexHomeView: View {
                 )
                 let useApplePlayer = UserDefaults.standard.bool(forKey: "useApplePlayer")
                 let playerVC: UIViewController
+                // Push the item's detail page after the player dismisses, so
+                // the user lands somewhere they can act on (next episode,
+                // related items, watched toggle) rather than back on the
+                // Continue Watching tile they launched from. Mirrors the
+                // launch-from-detail flow.
+                let onPlayerDismiss = {
+                    Task { await dataStore.refreshHubs() }
+                    selectItem(item)
+                }
                 if useApplePlayer {
                     let nativePlayer = NativePlayerViewController(viewModel: viewModel)
-                    nativePlayer.onDismiss = {
-                        Task { await dataStore.refreshHubs() }
-                    }
+                    nativePlayer.onDismiss = onPlayerDismiss
                     playerVC = nativePlayer
                 } else {
                     let inputCoordinator = PlaybackInputCoordinator()
@@ -341,9 +348,7 @@ struct PlexHomeView: View {
                         viewModel: viewModel,
                         inputCoordinator: inputCoordinator
                     )
-                    container.onDismiss = {
-                        Task { await dataStore.refreshHubs() }
-                    }
+                    container.onDismiss = onPlayerDismiss
                     playerVC = container
                 }
 

--- a/Rivulet/Views/Player/UniversalPlayerView.swift
+++ b/Rivulet/Views/Player/UniversalPlayerView.swift
@@ -667,6 +667,7 @@ private final class UniversalPlaybackInputTarget: PlaybackInputTarget {
 struct UniversalPlayerView: View {
     @StateObject private var viewModel: UniversalPlayerViewModel
     @StateObject private var remoteInput = RemoteInputHandler()
+    @AppStorage("hideSpoilersForUnwatched") private var hideSpoilersForUnwatched = false
     @State private var inputTarget: UniversalPlaybackInputTarget?
     private let inputCoordinator: PlaybackInputCoordinator
     @Environment(\.dismiss) private var dismiss
@@ -1093,7 +1094,13 @@ struct UniversalPlayerView: View {
                     }
                     .font(.body)
 
-                    // Description - prefer tagline (short), fallback to summary (long, ellipsed)
+                    // Description - prefer tagline (short), fallback to summary (long, ellipsed).
+                    // Apply the same spoiler-blur policy as MediaDetailView's hero summary:
+                    // movies + episodes are spoiler-prone; the summary blurs when the item
+                    // hasn't been watched. Tagline is marketing copy and stays sharp.
+                    let isUnwatched = (viewModel.metadata.viewCount ?? 0) == 0
+                    let summaryIsSpoilerProne = (viewModel.metadata.type == "movie" || viewModel.metadata.type == "episode")
+                    let shouldBlurSummary = hideSpoilersForUnwatched && isUnwatched && summaryIsSpoilerProne
                     if let tagline = viewModel.metadata.tagline, !tagline.isEmpty {
                         Text(tagline)
                             .font(.system(size: 32, weight: .medium))
@@ -1106,6 +1113,7 @@ struct UniversalPlayerView: View {
                             .foregroundStyle(.white.opacity(0.75))
                             .lineLimit(6)
                             .padding(.top, 24)
+                            .blur(radius: shouldBlurSummary ? 12 : 0)
                     }
 
                     Spacer(minLength: 120)  // Leave room above scrubber


### PR DESCRIPTION
## Summary

Two small player-UX fixes that are independent but share the same
file.

### 1. Loading-splash summary respects `hideSpoilersForUnwatched`

`UniversalPlayerView`'s loading-splash (the synopsis + thumbnail
screen that shows during playback startup) was rendering the item
summary completely sharp, briefly exposing spoilers for unwatched
items even when `hideSpoilersForUnwatched` is on. Applies the same
gate as `MediaDetailView`'s hero summary: blur the summary text when
the item is an unwatched movie or episode; the tagline (marketing
copy) always stays sharp.

### 2. Continue Watching EOM lands on the detail page

Playback launched from a Continue Watching tile now navigates to the
item's detail page when the player dismisses, instead of dropping the
user back on the Now Watching carousel. Matches the launch-from-detail
flow so EOM always lands somewhere actionable (watched toggle, next
episode, related items).

Implementation: factor the two `onDismiss` closures (Apple-player vs
custom-player paths) into one `onPlayerDismiss` that runs the
existing hub refresh and then pushes the item's detail page.

## Test plan

- [ ] Settings → `Hide Spoilers for Unwatched` ON. Launch an
      unwatched movie or episode — the loading-splash summary is
      blurred; tagline stays sharp.
- [ ] Same item after marking it Watched — summary is sharp.
- [ ] Setting OFF — summary is always sharp.
- [ ] Show with no tagline — summary still renders (and is blurred
      when appropriate).
- [ ] Continue Watching tile → play → EOM (or dismiss): lands on the
      item's detail page, not the home carousel.
- [ ] Continue Watching tile with both player paths (Settings →
      `Use Apple Player` ON and OFF): both honor the new
      detail-return behavior.
- [ ] Launching the same item from its detail page directly: dismiss
      still returns to the detail page (no double-push).