### PR TITLE
Library item titles + detail-page action-row scroll

### DIFF
--- a/Rivulet/Views/Media/MediaDetailView.swift
+++ b/Rivulet/Views/Media/MediaDetailView.swift
@@ -1063,13 +1063,24 @@ struct MediaDetailView: View {
     }
 
     private var actionButtons: some View {
-        HStack(spacing: 18) {
-            if isPlayableFromProvider {
-                playableActionButtons
-            } else {
-                watchlistActionButton
+        // ScrollView so the row keeps each button at its intrinsic width
+        // (play button + multiple circle-to-pill buttons) when the total
+        // exceeds the available width — happens on items with an extra
+        // optional button (e.g. Trailer) or when a focused button
+        // expands into a pill. tvOS focus engine auto-scrolls the
+        // focused button into view; .scrollClipDisabled lets the
+        // focus-driven pill expansion render past the viewport edge
+        // without clipping.
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 18) {
+                if isPlayableFromProvider {
+                    playableActionButtons
+                } else {
+                    watchlistActionButton
+                }
             }
         }
+        .scrollClipDisabled()
         .disabled(!allowActionRowInteraction)
     }
 
@@ -1363,15 +1374,26 @@ struct MediaDetailView: View {
                 }
             }
 
-            // Time: remaining if in progress, total duration otherwise
-            if effectiveIsInProgress, let remaining = effectiveRemainingFormatted {
-                Text(remaining)
-            } else if let duration = currentItemDurationFormatted {
-                Text(duration)
-            } else {
-                Text(text)
+            // Time: remaining if in progress, total duration otherwise.
+            // lineLimit(1)+fixedSize prevents the parent HStack squeezing
+            // an adjacent focused button from wrapping the time text
+            // ("43m" → "43" / "m") or hiding it entirely.
+            Group {
+                if effectiveIsInProgress, let remaining = effectiveRemainingFormatted {
+                    Text(remaining)
+                } else if let duration = currentItemDurationFormatted {
+                    Text(duration)
+                } else {
+                    Text(text)
+                }
             }
+            .lineLimit(1)
+            .fixedSize()
         }
+        // Make the play button hold its intrinsic width — without this
+        // the row's HStack shrinks the Play button to give space to a
+        // sibling that just expanded into a pill on focus.
+        .fixedSize(horizontal: true, vertical: false)
     }
 
     // MARK: - Body Modifier Chain (split for type-checker)

--- a/Rivulet/Views/Media/PlexHomeView.swift
+++ b/Rivulet/Views/Media/PlexHomeView.swift
@@ -1188,6 +1188,7 @@ struct InfiniteContentRow: View {
     @State private var hasReachedEnd = false
     @State private var totalSize: Int?
     @FocusState private var focusedItemId: String?  // Track which item is focused (format: "context:itemId")
+    @Environment(\.uiScale) private var uiScale
 
     /// Create a unique focus ID for an item in this row
     private func focusId(for item: PlexMetadata) -> String {
@@ -1288,11 +1289,38 @@ struct InfiniteContentRow: View {
                                     isFocused: focusedItemId == focusId(for: item)
                                 )
                             } else {
-                                MediaPosterCard(
-                                    item: item,
-                                    serverURL: serverURL,
-                                    authToken: authToken
-                                )
+                                // Whole tile scales uniformly on focus (poster +
+                                // title + year together) so the label below
+                                // doesn't get covered by MediaPosterCard's inner
+                                // hover-highlight.
+                                let tileFocused = focusedItemId == focusId(for: item)
+                                VStack(alignment: .leading, spacing: 10) {
+                                    MediaPosterCard(
+                                        item: item,
+                                        serverURL: serverURL,
+                                        authToken: authToken
+                                    )
+                                    .hoverEffectDisabled()
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(item.title ?? "")
+                                            .font(.system(size: 18, weight: .medium))
+                                            .foregroundStyle(.white.opacity(0.9))
+                                            .lineLimit(1)
+                                        if let year = item.year, item.type == "movie" {
+                                            Text(verbatim: "\(year)")
+                                                .font(.system(size: 14))
+                                                .foregroundStyle(.white.opacity(0.55))
+                                        }
+                                    }
+                                    // Cap label to poster width so a long
+                                    // title truncates rather than stretching
+                                    // the tile (LazyHStack doesn't enforce
+                                    // a per-item width the way LazyVGrid's
+                                    // columns do for the library grid).
+                                    .frame(width: ScaledDimensions.posterWidth * uiScale, height: 44, alignment: .topLeading)
+                                }
+                                .scaleEffect(tileFocused ? 1.10 : 1.0)
+                                .animation(.spring(response: 0.3, dampingFraction: 0.8), value: tileFocused)
                             }
                         }
                         .previewSourceAnchor(rowID: rowID, itemID: sourceItemID(for: item, index: index))

--- a/Rivulet/Views/Media/PlexLibraryView.swift
+++ b/Rivulet/Views/Media/PlexLibraryView.swift
@@ -986,16 +986,41 @@ struct PlexLibraryView: View {
     }
 
     @ViewBuilder
+    private func libraryGridLabel(item: PlexMetadata) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(item.title ?? "")
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(.white.opacity(0.9))
+                .lineLimit(1)
+            if let year = item.year, item.type == "movie" {
+                Text(verbatim: "\(year)")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.white.opacity(0.55))
+            }
+        }
+        .frame(height: 44, alignment: .top)
+    }
+
+    @ViewBuilder
     private func libraryGridItem(item: PlexMetadata, index: Int) -> some View {
+        let tileFocused = focusedItemId == gridFocusId(for: item)
         Button {
             selectedItem = selectMediaItem(item)
         } label: {
-            // EquatableView tells SwiftUI to use our custom == to skip unnecessary re-renders
-            EquatableView(content: MediaPosterCard(
-                item: item,
-                serverURL: authManager.selectedServerURL ?? "",
-                authToken: authManager.selectedServerToken ?? ""
-            ))
+            VStack(alignment: .leading, spacing: 10) {
+                // EquatableView tells SwiftUI to use our custom == to skip unnecessary re-renders
+                EquatableView(content: MediaPosterCard(
+                    item: item,
+                    serverURL: authManager.selectedServerURL ?? "",
+                    authToken: authManager.selectedServerToken ?? ""
+                ))
+                .hoverEffectDisabled()
+                libraryGridLabel(item: item)
+            }
+            // Whole tile scales uniformly on focus (poster + label
+            // together) so the label isn't covered by an expanding poster.
+            .scaleEffect(tileFocused ? 1.10 : 1.0)
+            .animation(.spring(response: 0.3, dampingFraction: 0.8), value: tileFocused)
         }
         .buttonStyle(CardButtonStyle())
         .focused($focusedItemId, equals: gridFocusId(for: item))


### PR DESCRIPTION
## Summary

Two independent UI improvements bundled because they share files.

### 1. Library item titles

Library grid (`PlexLibraryView`) and home-screen `InfiniteContentRow`
tiles (Recently Added etc.) now show the item's title under each
poster, with the release year as a subtitle for movies. Continue
Watching cards keep their existing self-contained layout.

This matches Plex's own tvOS client default — title under every
poster, year under movie posters.

Implementation notes:

- The whole tile (poster + label) scales uniformly on focus via a
  per-tile `@FocusState` and outer `scaleEffect`, with the inner
  `MediaPosterCard` hover-highlight suppressed so the label is never
  covered by the expanded poster.
- Label is clamped to `ScaledDimensions.posterWidth` so long titles
  truncate within poster width rather than stretching the tile.
  `LazyHStack` doesn't enforce a per-item width the way `LazyVGrid`'s
  columns do — that's why the library grid was already truncating
  correctly and Home rows weren't.

### 2. Detail-page action-row horizontal scroll

`MediaDetailView`'s `actionButtons` HStack was overflowing on items
with many buttons (e.g. movies that also surface a Trailer button):
the Play button collapsed and wrapped its time text ("43m" → "43"
and "m" on separate lines), and the sibling circle-to-pill buttons
got clipped on both sides when focused.

Two changes:

- `playButtonLabel` uses `lineLimit(1).fixedSize()` on the time text
  and `fixedSize(horizontal: true, vertical: false)` on its HStack,
  so the play button holds its intrinsic width regardless of what a
  sibling does on focus.
- The `actionButtons` HStack is wrapped in
  `ScrollView(.horizontal, showsIndicators: false).scrollClipDisabled()`.
  When the row exceeds available width, tvOS's focus engine
  auto-scrolls the focused button into view; `scrollClipDisabled`
  keeps the focus-driven pill expansion from being clipped at the
  viewport edge. When the row fits naturally there's no scrolling and
  the layout is identical to before.

## Test plan

- [ ] Home (Continue Watching + Recently Added rows): poster tiles
      show title underneath; movie tiles show year as subtitle.
- [ ] Library grid: same labels; long titles truncate within poster
      width (try "4 Artists Paint 1 Tree: A Walt Disney 'Adventure
      in Art'" in a Shorts library if you have one).
- [ ] Focus a tile — the whole tile (poster + label) scales together;
      label never gets covered by the expanding poster.
- [ ] Continue Watching cards retain their existing self-contained
      layout (no double labels).
- [ ] Detail page for a movie with a Trailer button — action row
      fits naturally; Play button's time text doesn't wrap.
- [ ] Detail page for a movie with many extra buttons — the action
      row scrolls horizontally as focus moves; pill expansion isn't
      clipped at the edge.