### PR TITLE
Library Item Titles: opt-in toggle

### DIFF
--- a/Rivulet/Views/Media/PlexHomeView.swift
+++ b/Rivulet/Views/Media/PlexHomeView.swift
@@ -1207,6 +1207,7 @@ struct InfiniteContentRow: View {
     @State private var hasReachedEnd = false
     @State private var totalSize: Int?
     @FocusState private var focusedItemId: String?  // Track which item is focused (format: "context:itemId")
+    @AppStorage("showLibraryItemTitles") private var showLibraryItemTitles = false
 
     /// Create a unique focus ID for an item in this row
     private func focusId(for item: PlexMetadata) -> String {
@@ -1307,11 +1308,35 @@ struct InfiniteContentRow: View {
                                     isFocused: focusedItemId == focusId(for: item)
                                 )
                             } else {
-                                MediaPosterCard(
-                                    item: item,
-                                    serverURL: serverURL,
-                                    authToken: authToken
-                                )
+                                // Whole tile scales uniformly on focus (poster +
+                                // title + year together) when labels are shown,
+                                // so the new label below doesn't get covered by
+                                // MediaPosterCard's inner hover-highlight.
+                                let tileFocused = focusedItemId == focusId(for: item)
+                                VStack(alignment: .leading, spacing: 10) {
+                                    MediaPosterCard(
+                                        item: item,
+                                        serverURL: serverURL,
+                                        authToken: authToken
+                                    )
+                                    .hoverEffectDisabled(showLibraryItemTitles)
+                                    if showLibraryItemTitles {
+                                        VStack(alignment: .leading, spacing: 2) {
+                                            Text(item.title ?? "")
+                                                .font(.system(size: 18, weight: .medium))
+                                                .foregroundStyle(.white.opacity(0.9))
+                                                .lineLimit(1)
+                                            if let year = item.year, item.type == "movie" {
+                                                Text(verbatim: "\(year)")
+                                                    .font(.system(size: 14))
+                                                    .foregroundStyle(.white.opacity(0.55))
+                                            }
+                                        }
+                                        .frame(height: 44, alignment: .top)
+                                    }
+                                }
+                                .scaleEffect(showLibraryItemTitles && tileFocused ? 1.10 : 1.0)
+                                .animation(.spring(response: 0.3, dampingFraction: 0.8), value: tileFocused)
                             }
                         }
                         .previewSourceAnchor(rowID: rowID, itemID: sourceItemID(for: item, index: index))

--- a/Rivulet/Views/Media/PlexLibraryView.swift
+++ b/Rivulet/Views/Media/PlexLibraryView.swift
@@ -22,6 +22,7 @@ struct PlexLibraryView: View {
     @AppStorage("showLibraryHero") private var showLibraryHero = false
     @AppStorage("showLibraryRecommendations") private var showLibraryRecommendations = true
     @AppStorage("showLibraryRecentRows") private var showLibraryRecentRows = true
+    @AppStorage("showLibraryItemTitles") private var showLibraryItemTitles = false
     @State private var currentSortOption: LibrarySortOption = .addedAtDesc
     @State private var items: [PlexMetadata] = []
     @State private var hubs: [PlexHub] = []  // Library-specific hubs from Plex API
@@ -998,16 +999,48 @@ struct PlexLibraryView: View {
     }
 
     @ViewBuilder
+    private func libraryGridLabel(item: PlexMetadata) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(item.title ?? "")
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(.white.opacity(0.9))
+                .lineLimit(1)
+                .truncationMode(.tail)
+            if let year = item.year, item.type == "movie" {
+                Text(verbatim: "\(year)")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.white.opacity(0.55))
+            }
+        }
+        // Cap label to poster width so a long title truncates (with
+        // tail ellipsis) instead of spilling horizontally and blowing
+        // out the grid column's footprint.
+        .frame(width: ScaledDimensions.posterWidth * scale, height: 44, alignment: .topLeading)
+    }
+
+    @ViewBuilder
     private func libraryGridItem(item: PlexMetadata, index: Int) -> some View {
+        let tileFocused = focusedItemId == gridFocusId(for: item)
         Button {
             selectedItem = selectMediaItem(item)
         } label: {
-            // EquatableView tells SwiftUI to use our custom == to skip unnecessary re-renders
-            EquatableView(content: MediaPosterCard(
-                item: item,
-                serverURL: authManager.selectedServerURL ?? "",
-                authToken: authManager.selectedServerToken ?? ""
-            ))
+            VStack(alignment: .leading, spacing: 10) {
+                // EquatableView tells SwiftUI to use our custom == to skip unnecessary re-renders
+                EquatableView(content: MediaPosterCard(
+                    item: item,
+                    serverURL: authManager.selectedServerURL ?? "",
+                    authToken: authManager.selectedServerToken ?? ""
+                ))
+                .hoverEffectDisabled(showLibraryItemTitles)
+                if showLibraryItemTitles {
+                    libraryGridLabel(item: item)
+                }
+            }
+            // Whole tile scales uniformly on focus (poster + label
+            // together) when labels are shown, so the label below isn't
+            // covered by an expanding poster.
+            .scaleEffect(showLibraryItemTitles && tileFocused ? 1.10 : 1.0)
+            .animation(.spring(response: 0.3, dampingFraction: 0.8), value: tileFocused)
         }
         .buttonStyle(CardButtonStyle())
         .focused($focusedItemId, equals: gridFocusId(for: item))

--- a/Rivulet/Views/Settings/SettingsDescriptors.swift
+++ b/Rivulet/Views/Settings/SettingsDescriptors.swift
@@ -97,6 +97,11 @@ enum SettingsDescriptorStore {
             iconColor: .mint,
             description: "Uses TMDB metadata and your watch history to surface personalized recommendations of unwatched content."
         ),
+        "libraryItemTitles": SettingDescriptor(
+            icon: "text.below.photo",
+            iconColor: .teal,
+            description: "Show the title (and release year, for movies) under each poster in library grids and home rows. Off by default."
+        ),
         "showDiscoverTab": SettingDescriptor(
             icon: "safari",
             iconColor: .blue,

--- a/Rivulet/Views/Settings/SettingsView.swift
+++ b/Rivulet/Views/Settings/SettingsView.swift
@@ -293,6 +293,7 @@ struct SettingsView: View {
     @AppStorage("useApplePlayer") private var useApplePlayer = true
     @AppStorage("autoplayCountdown") private var autoplayCountdownRaw = AutoplayCountdown.fiveSeconds.rawValue
     @AppStorage("showPostVideoUpNext") private var showPostVideoUpNext = true
+    @AppStorage("showLibraryItemTitles") private var showLibraryItemTitles = false
     @AppStorage("displaySize") private var displaySizeRaw = DisplaySize.normal.rawValue
     @AppStorage("musicLoudnessNormalization") private var musicLoudnessNormalization = false
     @AppStorage("musicCrossfadeDuration") private var musicCrossfadeDurationRaw = CrossfadeOption.off.rawValue
@@ -665,6 +666,12 @@ struct SettingsView: View {
                 title: "Personalized Recommendations",
                 isOn: $enablePersonalizedRecommendations,
                 onFocusChange: { if $0 { focusState.focusedSettingId = "personalizedRecs" } }
+            )
+
+            SettingsToggleRow(
+                title: "Library Item Titles",
+                isOn: $showLibraryItemTitles,
+                onFocusChange: { if $0 { focusState.focusedSettingId = "libraryItemTitles" } }
             )
 
             SettingsToggleRow(


### PR DESCRIPTION
## Summary

Re-files #161 with an opt-in toggle instead of unconditional titles.

Adds a "Library Item Titles" toggle (default OFF) that renders each
poster tile's title underneath, with the release year as a subtitle
for movies. Affects the library grid (PlexLibraryView) and home-screen
InfiniteContentRow tiles (Recently Added, etc.). Continue Watching
cards keep their existing self-contained layout.

When off, the original poster-only layout is preserved exactly,
including MediaPosterCard's native hover-highlight focus effect. When
on, the whole tile (poster + label) scales uniformly on focus via a
per-tile `@FocusState` and outer `scaleEffect`, with the inner
hover-highlight suppressed so the label is never covered by the
expanded poster.

## Context

Originally implemented with a toggle but stripped before upload to
avoid toggle creep; on reflection, and given your invitation in #161,
re-shipping it gated makes sense. Default OFF preserves the titleless
aesthetic for new installs; users who prefer a Plex-tvOS-style
labeled layout can opt in from Settings.

## Open questions for review

1. **Related row.** The toggle currently covers Library + Home rows.
   Should it also affect the Related row, where you just dropped
   poster titles via `f0d0e76`? Happy to either extend the toggle
   there or leave Related titleless regardless. Your call.

2. **Collections detail (#158).** Once #158 merges, I'd like to file
   a small follow-up gating `CollectionDetailView`'s per-tile labels
   behind the same toggle so the surfaces stay coherent. Including it
   in this PR would create a cross-PR dependency, so it lives as a
   follow-up.

## Test plan

- [ ] Settings shows "Library Item Titles" toggle, default OFF.
- [ ] Toggle OFF: library grid + home rows render poster-only (matches
      pre-#161 main exactly).
- [ ] Toggle ON: each tile shows title under poster; movie tiles show
      year under title; show/season tiles show title only.
- [ ] Focus scale-up: entire tile (poster + label) scales together;
      label is not covered by expanded poster.
- [ ] Continue Watching cards unchanged regardless of toggle state.