### PR TITLE
Restyle watched indicator as flush rounded badge

### DIFF
--- a/Rivulet/Views/Media/MediaDetailView.swift
+++ b/Rivulet/Views/Media/MediaDetailView.swift
@@ -3361,7 +3361,8 @@ struct EpisodeCard: View {
                 }
                 .overlay(alignment: .topTrailing) {
                     if episode.isWatched {
-                        WatchedCornerTag().accessibilityLabel("Watched")
+                        WatchedCornerTag(cornerRadius: 8)
+                            .accessibilityLabel("Watched")
                     }
                 }
                 .overlay(

--- a/Rivulet/Views/Media/MediaPosterCard.swift
+++ b/Rivulet/Views/Media/MediaPosterCard.swift
@@ -23,34 +23,32 @@ struct CardButtonStyle: ButtonStyle {
 
 // MARK: - Watched Corner Tag
 
-/// A triangular corner tag indicating the item has been watched
-/// Uses Path instead of Canvas for simpler GPU-backed rendering
+/// A rounded-rectangle badge indicating the item has been watched.
+/// Sits inside the top-trailing corner of artwork with a dark
+/// translucent fill and a white checkmark.
 struct WatchedCornerTag: View {
-    private let size: CGFloat = 48
-    private let checkSize: CGFloat = 18
+    var cornerRadius: CGFloat = ScaledDimensions.posterCornerRadius
 
-    /// Triangle shape for the corner tag
-    private struct CornerTriangle: Shape {
-        func path(in rect: CGRect) -> Path {
-            Path { p in
-                p.move(to: CGPoint(x: 0, y: 0))
-                p.addLine(to: CGPoint(x: rect.width, y: 0))
-                p.addLine(to: CGPoint(x: rect.width, y: rect.height))
-                p.closeSubpath()
-            }
-        }
-    }
+    private let size: CGFloat = 44
+    private let checkSize: CGFloat = 20
 
     var body: some View {
-        CornerTriangle()
-            .fill(.green)
-            .frame(width: size, height: size)
-            .overlay(alignment: .topTrailing) {
-                Image(systemName: "checkmark")
-                    .font(.system(size: checkSize, weight: .bold))
-                    .foregroundStyle(.white)
-                    .padding(6)
-            }
+        UnevenRoundedRectangle(
+            cornerRadii: .init(
+                topLeading: 0,
+                bottomLeading: cornerRadius,
+                bottomTrailing: 0,
+                topTrailing: 0
+            ),
+            style: .continuous
+        )
+        .fill(.black.opacity(0.55))
+        .frame(width: size, height: size)
+        .overlay {
+            Image(systemName: "checkmark")
+                .font(.system(size: checkSize, weight: .semibold))
+                .foregroundStyle(.white)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace the green triangular `WatchedCornerTag` with a dark translucent rounded-rectangle badge holding a white checkmark.
- Badge sits flush against the top and right edges of the artwork; only the inner (bottom-leading) corner is rounded.
- `cornerRadius` is parameterizable; episode thumbnails pass `8` to match their smaller container radius.

Closes #101

## Test plan
- [ ] Library grid: watched movies/episodes show new badge in top-right corner
- [ ] Fully-watched shows (all episodes viewed) show the badge
- [ ] Episode list within a show: watched episodes show the smaller-radius badge variant
- [ ] In-progress items still show the progress bar instead of the badge
- [ ] Unwatched show count badge (blue capsule) is unaffected