### PR TITLE
UIScale: bump section title size to 30pt

### DIFF
--- a/Rivulet/Services/UIScale.swift
+++ b/Rivulet/Services/UIScale.swift
@@ -77,7 +77,7 @@ enum ScaledDimensions {
     // Typography
     static let posterTitleSize: CGFloat = 24
     static let posterSubtitleSize: CGFloat = 19
-    static let sectionTitleSize: CGFloat = 28
+    static let sectionTitleSize: CGFloat = 30
     static let heroTitleSize: CGFloat = 56
 
     // Spacing


### PR DESCRIPTION
## Summary
- Raise `ScaledDimensions.sectionTitleSize` from 28pt → 30pt. Affects every section title that flows through `ScaledDimensions` (Home rows, Watchlist hub, Discover, etc.).

Refs #96 — not closing because that issue asks for broader "bigger Apple-style rows," which involves poster/row dimensions, not just the title font size. Leaving the issue open for the larger pass.

## Test plan
- [ ] Home page section titles render slightly larger
- [ ] Watchlist hub title scales correctly with `uiScale`
- [ ] No layout overflow in narrow rows