### PR TITLE
Sidebar: allow tab swap from detail views and Settings sub-pages

### DIFF
--- a/Rivulet/Views/Media/PlexHomeView.swift
+++ b/Rivulet/Views/Media/PlexHomeView.swift
@@ -239,6 +239,14 @@ struct PlexHomeView: View {
                     presentPreview(request: request)
                 }
             }
+            .onReceive(nestedNavState.popToRootSubject) { _ in
+                // Sidebar tab swap from inside a detail push: clear our
+                // nav-stack @State so the push pops to root, unblocking
+                // the tab swap. See NestedNavigationState.popToRootSubject.
+                selectedItem = nil
+                selectedMusicItem = nil
+                pendingPreviewNavigation = nil
+            }
         }
         .onChange(of: selectedItem) { _, newValue in
             print("[PlexHome] selectedItem changed: \(newValue?.title ?? "nil") (itemID: \(newValue?.ref.itemID ?? "nil"))")

--- a/Rivulet/Views/Media/PlexLibraryView.swift
+++ b/Rivulet/Views/Media/PlexLibraryView.swift
@@ -313,6 +313,13 @@ struct PlexLibraryView: View {
                     presentPreview(request: request)
                 }
             }
+            .onReceive(nestedNavState.popToRootSubject) { _ in
+                // Sidebar tab swap from inside a detail push: clear our
+                // nav-stack @State so the push pops to root, unblocking
+                // the tab swap. See NestedNavigationState.popToRootSubject.
+                selectedItem = nil
+                pendingPreviewNavigation = nil
+            }
     }
 
     // MARK: - Preview Presentation (UIKit Modal)

--- a/Rivulet/Views/Media/PlexSearchView.swift
+++ b/Rivulet/Views/Media/PlexSearchView.swift
@@ -100,6 +100,13 @@ struct PlexSearchView: View {
         .onChange(of: selectedItem) { _, newValue in
             nestedNavState.isNested = newValue != nil
         }
+        .onReceive(nestedNavState.popToRootSubject) { _ in
+            // Sidebar tab swap from inside a detail push: clear our
+            // nav-stack @State so the push pops to root, unblocking
+            // the tab swap. See NestedNavigationState.popToRootSubject.
+            selectedItem = nil
+            selectedMusicItem = nil
+        }
         .onSubmit {
             submitSearch()
         }

--- a/Rivulet/Views/Music/MusicHomeView.swift
+++ b/Rivulet/Views/Music/MusicHomeView.swift
@@ -123,6 +123,14 @@ struct MusicHomeView: View {
         .onChange(of: selectedPlaylist) { _, new in
             nestedNavState.isNested = new != nil || selectedArtist != nil || selectedAlbum != nil
         }
+        .onReceive(nestedNavState.popToRootSubject) { _ in
+            // Sidebar tab swap from inside a detail push: clear our
+            // nav-stack @State so the push pops to root, unblocking
+            // the tab swap. See NestedNavigationState.popToRootSubject.
+            selectedArtist = nil
+            selectedAlbum = nil
+            selectedPlaylist = nil
+        }
         .task(id: libraryKey) {
             await loadRecentlyAdded()
             await loadGenres()

--- a/Rivulet/Views/Settings/SettingsView.swift
+++ b/Rivulet/Views/Settings/SettingsView.swift
@@ -487,6 +487,12 @@ struct SettingsView: View {
         .onDisappear {
             nestedNavState.isSettingsSubPage = false
         }
+        .onReceive(nestedNavState.popToRootSubject) { _ in
+            // Sidebar tab swap from inside a sub-page: reset our internal
+            // nav stack to root so the swap isn't visually locked to the
+            // current sub-page. See NestedNavigationState.popToRootSubject.
+            navigationStack = [.root]
+        }
         .onExitCommand(perform: currentPage != .root ? { goBack() } : nil)
     }
 

--- a/Rivulet/Views/TVNavigation/NavigationEnvironment.swift
+++ b/Rivulet/Views/TVNavigation/NavigationEnvironment.swift
@@ -38,11 +38,19 @@ enum SidebarTab: Hashable {
 class NestedNavigationState: ObservableObject {
     @Published var isNested: Bool = false
     @Published var isSettingsSubPage: Bool = false
+
+    /// Sent by `TVSidebarView` when the user picks a sidebar tab while the
+    /// active tab has a NavigationStack push on screen. tvOS locks the
+    /// visible tab content to the navigation stack while it's at depth ≥ 1,
+    /// so a selection write lands in state but the displayed tab doesn't
+    /// switch. Subscribers (per-tab content views) clear their detail
+    /// `@State` so the push pops to root, unblocking the swap.
+    let popToRootSubject = PassthroughSubject<Void, Never>()
 }
 
 /// Environment key for nested navigation state
 private struct NestedNavigationStateKey: EnvironmentKey {
-    static let defaultValue: NestedNavigationState = NestedNavigationState()
+    @MainActor static let defaultValue: NestedNavigationState = NestedNavigationState()
 }
 
 extension EnvironmentValues {

--- a/Rivulet/Views/TVNavigation/TVSidebarView.swift
+++ b/Rivulet/Views/TVNavigation/TVSidebarView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Combine
 import os.log
 
 // Temporary diagnostic logger for intermittent sidebar focus loss.
@@ -75,17 +76,30 @@ struct TVSidebarView: View {
         Binding(
             get: { selectedTab },
             set: { newTab in
-                // Block tab changes while in nested navigation (carousel,
-                // detail view, or deep Settings sub-page).
-                guard !nestedNavState.isNested, !nestedNavState.isSettingsSubPage else { return }
-
                 if newTab == .account {
                     if profileManager.hasMultipleProfiles {
                         showProfileSwitcher = true
                     }
                     return  // Never store .account — selectedTab stays unchanged
                 }
-                selectedTab = newTab
+
+                // When the user picks a sidebar tab while a detail view
+                // (NavigationStack push) or a Settings sub-page is on
+                // screen, tvOS locks the visible tab content to that
+                // stack: writing `selectedTab` lands in @State but the
+                // displayed tab doesn't follow. Signal the active tab's
+                // content view to clear its detail @State (popping to
+                // root), then write the new selection on the next
+                // runloop so SwiftUI sees a clean root-level tab swap.
+                // Matches Apple TV+ app behavior.
+                if nestedNavState.isNested || nestedNavState.isSettingsSubPage {
+                    nestedNavState.popToRootSubject.send()
+                    Task { @MainActor in
+                        selectedTab = newTab
+                    }
+                } else {
+                    selectedTab = newTab
+                }
             }
         )
     }
@@ -334,7 +348,14 @@ struct TVSidebarView: View {
             }
         }
         .tabViewStyle(.sidebarAdaptable)
-        .toolbarVisibility((nestedNavState.isNested || isMusicLibrarySelected || nestedNavState.isSettingsSubPage) ? .hidden : .automatic, for: .tabBar)
+        // Hiding the tab bar leaves the sidebar visually surfaceable via
+        // touchpad swipe-left but non-interactive, so the user can summon
+        // the menu and find that tab selection silently no-ops. Detail
+        // views and Settings sub-pages are reached via swap-on-pop (see
+        // `tabSelection.set`), so they no longer hide the tab bar. Music
+        // library views own the whole screen with their own internal
+        // layout — keep `.hidden` there.
+        .toolbarVisibility(isMusicLibrarySelected ? .hidden : .automatic, for: .tabBar)
         .animation(.easeInOut(duration: 0.18), value: nestedNavState.isNested)
         .onChange(of: nestedNavState.isNested) { _, isNested in
             guard isNested else { return }


### PR DESCRIPTION
## Summary

Selecting a sidebar tab while a detail view (NavigationStack push) or a Settings sub-page was on screen used to be a no-op. The sidebar still surfaced via touchpad swipe-left, but taps had no effect.

Three cooperating causes, all addressed:

1. `toolbarVisibility(.hidden, for: .tabBar)` was applied while `nestedNavState.isNested` or `isSettingsSubPage` was true. With the tab bar hidden, tvOS still lets touchpad swipe-left surface the sidebar visually — but the surface is non-interactive, so taps don't reach the binding setter.
2. Even if a tap had reached the setter, `tabSelection.set` short-circuited via `guard !isNested, !isSettingsSubPage else { return }`.
3. The deeper structural issue: tvOS locks the visible tab content to its NavigationStack while the stack is at depth ≥ 1. With (1) and (2) fixed, the setter fires and `selectedTab` writes to `@State` successfully, but the displayed tab doesn't follow until the push is popped.

## Fix

- Drop the guard and the `isNested`/`isSettingsSubPage` parts of the toolbar-hide condition.
- Add `NestedNavigationState.popToRootSubject` (Combine `PassthroughSubject`). When the sidebar setter fires from a nested state, broadcast pop-to-root.
- Each per-tab content view (`PlexHomeView`, `PlexLibraryView`, `PlexSearchView`, `MusicHomeView`, `SettingsView`) subscribes via `.onReceive` and clears its detail/sub-page `@State` on receipt.
- Defer the `selectedTab` write to the next runloop via `Task { @MainActor in }` so SwiftUI processes the pop first and then sees a clean root-level tab swap.

Music library views keep `toolbarVisibility(.hidden)` — they own the whole screen and have their own internal layout.

Menu/back from a Settings sub-page still triggers `goBack()` as before; in-Settings back navigation is unaffected.

## Test plan

- [ ] From Home, open a movie detail → swipe-left → tap a library → detail dismisses, library root appears.
- [ ] Same from show, episode, extra detail pages.
- [ ] From a Settings sub-page → swipe-left → tap a tab → sub-page pops, tab switches.
- [ ] Settings sub-page back navigation (menu/back) still pops one level at a time.
- [ ] Normal root-level tab swap unchanged.
- [ ] Returning to a library after tab-swapping from its detail lands at the library root, not the prior detail page (intentional — abandoned detail).