### PR TITLE
Cast & Crew row: render real headshots and make it D-pad navigable

### DIFF
--- a/Rivulet/Services/MediaProvider/Plex/PlexMediaMapper.swift
+++ b/Rivulet/Services/MediaProvider/Plex/PlexMediaMapper.swift
@@ -51,8 +51,20 @@ enum PlexMediaMapper {
     // MARK: - Artwork
 
     /// Helper for building Plex artwork URLs from arbitrary paths.
+    ///
+    /// Most thumb/art fields come back as server-relative paths (e.g.
+    /// `/library/metadata/123/thumb/456`) that need the server origin
+    /// prepended and an `X-Plex-Token` appended. Cast/crew thumbs and
+    /// some other people-related artwork instead come back as fully
+    /// qualified URLs into Plex's public metadata CDN (e.g.
+    /// `https://metadata-static.plex.tv/.../people/<hash>.jpg`). Return
+    /// those unchanged — prepending the server origin produces a
+    /// malformed URL whose request fails, falling back to a placeholder.
     static func artworkURL(_ path: String?, serverURL: String, authToken: String) -> URL? {
         guard let path else { return nil }
+        if path.hasPrefix("http://") || path.hasPrefix("https://") {
+            return URL(string: path)
+        }
         return URL(string: "\(serverURL)\(path)?X-Plex-Token=\(authToken)")
     }
 
@@ -263,8 +275,7 @@ enum PlexMediaMapper {
         authToken: String
     ) -> MediaItemDetail {
         func personURL(_ thumb: String?) -> URL? {
-            guard let thumb else { return nil }
-            return URL(string: "\(serverURL)\(thumb)?X-Plex-Token=\(authToken)")
+            Self.artworkURL(thumb, serverURL: serverURL, authToken: authToken)
         }
 
         let cast = (meta.Role ?? []).map { role in

--- a/Rivulet/Views/Media/CastMemberCard.swift
+++ b/Rivulet/Views/Media/CastMemberCard.swift
@@ -103,6 +103,14 @@ struct CastCrewRow: View {
     let cast: [MediaPerson]
     let directors: [MediaPerson]
 
+    // tvOS's focus engine doesn't enter a section if it can't find a
+    // focus-tracked target — without `@FocusState`/`.focused`, the row
+    // is unreachable by D-pad and the horizontal ScrollView can't be
+    // scrolled. Mirror the working pattern from the detail-page
+    // Related row (`MediaItemAgnosticRow`): @FocusState focusedID +
+    // `.focused($focusedID, equals: id)` per button.
+    @FocusState private var focusedID: String?
+
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Cast & Crew")
@@ -114,6 +122,7 @@ struct CastCrewRow: View {
                 LazyHStack(spacing: 24) {
                     // Directors first
                     ForEach(directors) { director in
+                        let isFocused = focusedID == director.id
                         Button { } label: {
                             PersonCard(
                                 name: director.name,
@@ -122,12 +131,16 @@ struct CastCrewRow: View {
                                 serverURL: "",
                                 authToken: ""
                             )
+                            .scaleEffect(isFocused ? 1.10 : 1.0)
+                            .animation(.spring(response: 0.3, dampingFraction: 0.8), value: isFocused)
                         }
                         .buttonStyle(CircleCardButtonStyle())
+                        .focused($focusedID, equals: director.id)
                     }
 
                     // Cast members
                     ForEach(cast) { actor in
+                        let isFocused = focusedID == actor.id
                         Button { } label: {
                             PersonCard(
                                 name: actor.name,
@@ -136,8 +149,11 @@ struct CastCrewRow: View {
                                 serverURL: "",
                                 authToken: ""
                             )
+                            .scaleEffect(isFocused ? 1.10 : 1.0)
+                            .animation(.spring(response: 0.3, dampingFraction: 0.8), value: isFocused)
                         }
                         .buttonStyle(CircleCardButtonStyle())
+                        .focused($focusedID, equals: actor.id)
                     }
                 }
                 .padding(.horizontal, 48)

--- a/Rivulet/Views/Media/CastMemberCard.swift
+++ b/Rivulet/Views/Media/CastMemberCard.swift
@@ -17,7 +17,7 @@ struct PersonCard: View {
     let serverURL: String
     let authToken: String
 
-    private let circleSize: CGFloat = 140
+    private let circleSize: CGFloat = 188
 
     var body: some View {
         VStack(spacing: 10) {


### PR DESCRIPTION
## Summary

The Cast & Crew row on a media detail page was broken in two visible ways. After this PR it shows real cast/crew headshots and is reachable by the focus engine.

## Issue 1: Every person showed a generic icon

`PlexMediaMapper.detail` and `PlexMediaMapper.artworkURL` unconditionally prepended `serverURL` and appended `X-Plex-Token` to every thumb path. That works for server-relative thumbs (e.g. `/library/metadata/123/thumb/456`), but cast/crew thumbs come back from Plex as fully-qualified URLs into the public metadata CDN:

```
thumb=https://metadata-static.plex.tv/a/people/<hash>.jpg
```

The composed URL ended up like `https://<server>https://metadata-static.plex.tv/...?X-Plex-Token=…`, the request failed, and `PersonCard` fell back to its `person.fill` placeholder — for every actor. Detect `http://`/`https://` paths in `artworkURL` and return them unchanged; route the inline `personURL` closure in `detail()` through the helper so the same handling applies to cast, directors, writers, and chapter thumbs.

## Issue 2: Focus engine couldn't enter the row

`CastCrewRow` wrapped each card in `Button { } label: …` with no `@FocusState`/`.focused` tracking and no focus-driven visual effect. The focus engine never traversed into the section, so the row wasn't reachable by D-pad and its horizontal `ScrollView` couldn't be scrolled to reveal additional cast members.

Mirror the existing pattern from the detail-page Related row (`MediaItemAgnosticRow`): a local `@FocusState focusedID: String?`, `.focused($focusedID, equals: id)` on each button, and a 1.10× scale-up when focused. Empty button actions are kept — there's no person-detail destination yet — but the buttons are now valid focus targets, so the engine traverses into the row.

## Test plan

- [ ] Open any movie detail page → scroll down to Cast & Crew → real headshots render (no generic person icon for actors with a CDN thumb; placeholder still appears for entries Plex didn't supply a thumb for).
- [ ] D-pad down lands on a person card; the focused card scales up.
- [ ] D-pad right scrolls the row horizontally, revealing additional cast members.
- [ ] Posters, backdrops, and other artwork still render normally (server-relative paths unaffected by `artworkURL`'s pass-through branch).