### PR TITLE
Library hero: clamp oversized backdrop art, keep initial focus, fix entry flash, land on Play

### DIFF
--- a/Rivulet/Views/Media/Hero/HeroOverlayContent.swift
+++ b/Rivulet/Views/Media/Hero/HeroOverlayContent.swift
@@ -131,6 +131,15 @@ struct HeroOverlayContent: View {
         .onChange(of: focusedButton) { oldButton, newButton in
             if newButton != nil && oldButton == nil {
                 onHeroFocused?()
+                // Always land on Play when entering the hero. tvOS's directional
+                // focus otherwise lands on whichever button sits above the
+                // column you came up from (often the "next" arrow); Play is the
+                // hero's primary action, so re-anchor to it for a predictable
+                // entry. Only fires on entry (oldButton == nil), so navigating
+                // between buttons once inside is unaffected.
+                if newButton != .play {
+                    focusedButton = .play
+                }
             } else if newButton == nil && oldButton != nil {
                 onHeroExited?()
             }

--- a/Rivulet/Views/Media/HeroBackdropSupport.swift
+++ b/Rivulet/Views/Media/HeroBackdropSupport.swift
@@ -237,9 +237,21 @@ struct HeroBackdropImage<Placeholder: View>: View {
     }
 
     private func imageView(_ image: UIImage) -> some View {
-        Image(uiImage: image)
-            .resizable()
-            .aspectRatio(contentMode: .fill)
+        // Fill the *container* and clip, rather than letting the image's own
+        // dimensions drive layout. `.aspectRatio(.fill)` without a bounding
+        // frame reports the scaled image size as this view's layout size, so a
+        // source with extreme dimensions (e.g. a near-square poster used as a
+        // backdrop) balloons to thousands of points tall and shoves the hero
+        // off-screen. Anchoring to a flexible `Color.clear` pins the layout
+        // size to whatever the parent proposes; the image fills it as an
+        // overlay and the overflow is clipped.
+        Color.clear
+            .overlay(
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            )
+            .clipped()
     }
 
     @MainActor

--- a/Rivulet/Views/Media/PlexLibraryView.swift
+++ b/Rivulet/Views/Media/PlexLibraryView.swift
@@ -517,8 +517,13 @@ struct PlexLibraryView: View {
                             onInfo: { item in selectedItem = selectMediaItem(item) },
                             onPlay: { item in playItemDirectly(item) },
                             onHeroFocused: {
-                                withAnimation(.smooth(duration: 0.8)) {
-                                    scrollProxy.scrollTo("libraryHero", anchor: .top)
+                                // Only snap back to the hero when we're actually
+                                // scrolled down into content. On entry the hero is
+                                // already at the top, so this scrollTo is redundant.
+                                if heroScrollOffset > 1 {
+                                    withAnimation(.smooth(duration: 0.8)) {
+                                        scrollProxy.scrollTo("libraryHero", anchor: .top)
+                                    }
                                 }
                             }
                         )
@@ -589,8 +594,13 @@ struct PlexLibraryView: View {
         .onChange(of: hubs.count) { _, _ in
             // Recompute cached hubs (memoization)
             cachedProcessedHubs = computeProcessedHubs(from: hubs)
-            // Reselect hero whenever hubs change so the promoted list stays current.
-            selectHeroItems()
+            // Pick the hero from hubs only if it isn't already set. We do NOT
+            // re-pick an existing hero here: the instant pick and a later hub
+            // pick can differ, and swapping a beat after entry is the visible
+            // "flash". The hero is chosen once and kept.
+            if heroItems.isEmpty {
+                selectHeroItems()
+            }
         }
     }
 
@@ -605,10 +615,13 @@ struct PlexLibraryView: View {
         commitHeroItems(next)
     }
 
-    /// Variant used during instant library-switch restoration, where cached
-    /// items are available before hubs finish loading.
+    /// Variant used during instant library-switch restoration. Prefers the
+    /// hub-based pick (same priority as `selectHeroItems`) so the instant pick
+    /// matches the eventual one and the hero doesn't visibly swap ("flash")
+    /// when hubs finish loading. Falls back to the item list when no hubs are
+    /// cached yet.
     private func selectHeroItemsFromCurrentData() {
-        let next = computeHeroItems(preferItemsFirst: true)
+        let next = computeHeroItems(preferItemsFirst: false)
         commitHeroItems(next)
     }
 
@@ -1667,8 +1680,22 @@ struct PlexLibraryView: View {
     }
     */
 
-    /// Ensure the first grid item receives focus when entering a library
+    /// Whether the library hero is currently on screen.
+    private var heroIsActive: Bool {
+        showLibraryHero && !heroItems.isEmpty
+    }
+
+    /// Ensure the first grid item receives focus when entering a library.
+    ///
+    /// When the library hero is on screen it owns the initial focus (its Play
+    /// button), so we must NOT pull focus down into the grid; doing so buries
+    /// the hero under the poster rows. This only bit freshly-loaded libraries:
+    /// their items arrive via an `items.count` change that fires this, whereas
+    /// cache-warm libraries never trip it. `selectHeroItems()` runs just before
+    /// this in the same change handler, so `heroIsActive` is already true here
+    /// for hero libraries.
     private func ensureInitialFocusIfNeeded() {
+        guard !heroIsActive else { return }
         guard focusedItemId == nil else { return }
         guard let first = firstDisplayedItem else { return }
 


### PR DESCRIPTION
## Summary

Four pre-existing fixes to the library hero, each independent of any
one library. They only surface with the Library Hero enabled (Settings
→ Appearance), which is off by default, so they are easy to miss.

- **Backdrop art no longer balloons the layout.** `HeroBackdropImage`
  rendered its art with `.aspectRatio(.fill)` but no bounding frame, so
  an item whose source art has extreme dimensions (e.g. a near-square
  title card used as a backdrop) reported the scaled image size as its
  own layout size, ballooning the content stack to thousands of points
  and, via the center-aligned state ZStack, shoving the hero a full
  screen off the top (posters appeared to cover the hero). The image is
  now anchored to a flexible `Color.clear` and clipped, so it fills its
  container regardless of source dimensions.

- **Hero keeps initial focus.** On freshly-loaded libraries the grid's
  `ensureInitialFocusIfNeeded` pulled focus into the poster grid,
  burying the hero. It now stands down while the hero is on screen, so
  the hero's Play button keeps the focus it takes on entry.

- **No cold-entry flash.** The instant hero pick during library-switch
  restoration used the item list while the eventual pick used the
  promoted hub, so the hero visibly swapped a beat after entry. The
  instant pick now prefers the same hub-based pick, and the hero is
  chosen once and not re-picked when hubs change.

- **Entering the hero lands on Play.** tvOS directional focus landed on
  whichever button sat above the column focus came up from (often the
  "next" arrow); the hero now re-anchors to its Play button on entry.
  Only fires on entry, so navigating between the hero's buttons
  afterwards is unaffected.

Developed alongside the Collections picker work in #158, which builds
its picker-reveal-over-hero behavior on the "keep initial focus" fix
here. Both touch `PlexLibraryView` and will have a trivial overlap in
the `onHeroFocused` closure if both land.

## Test plan

(requires Settings → Appearance → Library Hero on)

- [ ] Open a library whose hero art is off-shape (very tall/wide or
      near-square) — the hero fills its band and is not pushed
      off-screen.
- [ ] Open a freshly-loaded library — focus lands on the hero's Play
      button, not the poster grid below.
- [ ] Switch between libraries quickly — the hero does not visibly swap
      to a different item a beat after entry.
- [ ] Move focus onto the hero from the rows below — it lands on Play,
      then arrow-navigates to the other buttons normally.
- [ ] Library Hero off (default) — no behavior change.
