### PR TITLE
Detail metadata: variant-accurate audio, resolution, and full episode air date

### DIFF
--- a/Rivulet/Models/Media/AudioTrack.swift
+++ b/Rivulet/Models/Media/AudioTrack.swift
@@ -10,9 +10,11 @@ import Foundation
 struct AudioTrack: Hashable, Sendable, Identifiable {
     let id: String
     let index: Int                 // stream index in the container (AVPlayer track index)
-    let codec: String              // "eac3", "dts", "truehd", "aac", "opus"
-    let channels: Int?             // 2, 6, 8
-    let channelLayout: String?     // "5.1", "7.1", "Atmos" if present
+    let codec: String              // "eac3", "dca", "truehd", "aac", "opus"
+    let profile: String?           // Plex codec profile: "ma" (DTS-HD MA),
+                                   // "dolby truehd + dolby atmos", etc.
+    let channels: Int?             // 1, 2, 6, 8
+    let channelLayout: String?     // Plex layout, e.g. "5.1(side)", "stereo"
     let language: String?          // "en", "ja"
     let title: String?             // displayable (e.g. "English Commentary")
     let extendedTitle: String?     // long-form Plex `extendedDisplayTitle` etc.
@@ -25,4 +27,68 @@ struct AudioTrack: Hashable, Sendable, Identifiable {
     /// file's authoring default, while `isSelected` reflects a per-user-per-item
     /// override that may have been set in any client.
     let isSelected: Bool
+}
+
+extension AudioTrack {
+    /// Variant-accurate codec + channel layout for the quality badge, e.g.
+    /// "E-AC3 5.1", "DTS-HD MA 7.1", "TrueHD 7.1 Atmos", "AC3 2.0", "FLAC 1.0".
+    /// The codec name distinguishes lossless families (TrueHD / DTS-HD MA /
+    /// DTS-X / FLAC / ALAC / PCM) from lossy ones (AC3 / E-AC3 / DTS / AAC /
+    /// ...) so a knowledgeable reader can infer losslessness from the label.
+    /// Atmos is taken from Plex's `profile` ("dolby ... + dolby atmos"), not
+    /// the channel layout, because Atmos height is object metadata, not
+    /// discrete channels. The layout is the track's own, never assumed.
+    var qualityLabel: String {
+        let p = (profile ?? "").lowercased()
+        var name: String
+        switch codec.lowercased() {
+        case "truehd":            name = "TrueHD"
+        case "eac3", "ec-3":      name = "E-AC3"
+        case "ac3", "ac-3":       name = "AC3"
+        case "dca", "dts":
+            if p.contains("ma")                            { name = "DTS-HD MA" }
+            else if p.contains("dts:x") || p.contains("dtsx") { name = "DTS-X" }
+            else if p.contains("hra")                      { name = "DTS-HD HRA" }
+            else                                           { name = "DTS" }
+        case "flac":              name = "FLAC"
+        case "alac":              name = "ALAC"
+        case "pcm", "lpcm":       name = "PCM"
+        case let c where c.hasPrefix("pcm_"): name = "PCM"
+        case "aac":               name = "AAC"
+        case "opus":              name = "Opus"
+        case "mp3", "mp2":        name = "MP3"
+        case "vorbis":            name = "Vorbis"
+        case "wmapro", "wmav2", "wma": name = "WMA"
+        default:                  name = codec.uppercased()
+        }
+        if let layout = channelLayoutLabel { name += " \(layout)" }
+        if p.contains("atmos") { name += " Atmos" }
+        return name
+    }
+
+    /// Normalized channel layout: drops the surround-placement suffix
+    /// ("5.1(side)" -> "5.1"), maps "stereo"/"mono" to "2.0"/"1.0", and falls
+    /// back to a count-derived layout when Plex supplies no layout string
+    /// (e.g. PCM). nil when neither layout nor channel count is known.
+    private var channelLayoutLabel: String? {
+        if let raw = channelLayout, !raw.isEmpty {
+            let base = raw.lowercased()
+                .split(separator: "(").first
+                .map { $0.trimmingCharacters(in: .whitespaces) } ?? raw.lowercased()
+            switch base {
+            case "mono":   return "1.0"
+            case "stereo": return "2.0"
+            default:       return base   // "5.1", "7.1", "3.0", "4.0", ...
+            }
+        }
+        switch channels {
+        case 1:  return "1.0"
+        case 2:  return "2.0"
+        case 6:  return "5.1"
+        case 7:  return "6.1"
+        case 8:  return "7.1"
+        case let n? where n > 0: return "\(n).0"
+        default: return nil
+        }
+    }
 }

--- a/Rivulet/Models/Media/MediaItemDetail.swift
+++ b/Rivulet/Models/Media/MediaItemDetail.swift
@@ -27,4 +27,8 @@ struct MediaItemDetail: Sendable {
     // Wave 1 additions for the detail view
     let nextEpisode: MediaItem?      // shows only — Plex `OnDeck`, Jellyfin `/Shows/NextUp`
     let collections: [String]        // collection names this item is tagged with
+
+    // Full original-air/release date ("YYYY-MM-DD"). Episodes surface the full
+    // date ("Sep 24, 2019") in the hero metadata row; movies keep year-only.
+    let originallyAvailableAt: String?
 }

--- a/Rivulet/Models/Media/MediaSource.swift
+++ b/Rivulet/Models/Media/MediaSource.swift
@@ -16,6 +16,7 @@ struct MediaSource: Hashable, Sendable, Identifiable {
     let bitrate: Int?              // bits/second
     let fileSize: Int64?           // bytes; nil for transcoded streams
     let fileName: String?          // display name for source picker ("4K HDR", etc.)
+    let videoResolution: String?   // provider-computed label: "4k", "1080", "720", "480", "sd"
 
     let videoTracks: [VideoTrack]  // usually 1, rarely more
     let audioTracks: [AudioTrack]
@@ -39,12 +40,7 @@ extension MediaSource {
         var badges: [String] = []
 
         if let video = videoTracks.first {
-            // Resolution
-            if let height = video.height {
-                if height >= 2000 { badges.append("4K") }
-                else if height >= 1080 { badges.append("HD") }
-                // 720 and below: no badge
-            }
+            if let res = resolutionLabel(video) { badges.append(res) }
 
             // HDR / DV
             switch video.videoRange {
@@ -55,18 +51,43 @@ extension MediaSource {
             }
         }
 
-        if let audio = audioTracks.first {
-            if let layout = audio.channelLayout, !layout.isEmpty {
-                // Plex layouts: "5.1", "7.1", "Atmos", "Stereo".
-                // Drop Stereo — uninteresting in a badge row.
-                if layout.lowercased() != "stereo" {
-                    badges.append(layout)
-                }
-            } else if let channels = audio.channels, channels >= 6 {
-                badges.append("\(channels - 1).1")
-            }
+        // The default audio track (falling back to the first) drives the badge.
+        // Shows codec + channel layout for every track, including stereo/mono.
+        if let audio = audioTracks.first(where: { $0.isDefault }) ?? audioTracks.first {
+            badges.append(audio.qualityLabel)
         }
 
         return badges
+    }
+
+    /// Resolution badge. Prefers the provider-computed `videoResolution`
+    /// ("4k"/"1080"/...), which is correct for cropped widescreen content
+    /// whose pixel height is below the nominal value; falls back to the video
+    /// track's height only when the provider supplies nothing.
+    private func resolutionLabel(_ video: VideoTrack) -> String? {
+        // Interlaced sources carry an "i" suffix (1080i/576i/480i); progressive
+        // gets "p". 4K and 720 have no interlaced broadcast form, so they stay
+        // progressive even if a probe oddly claims otherwise. Absent scanType
+        // means assume progressive (the common case), so we never mislabel.
+        func scan(_ base: String) -> String { base + (video.isInterlaced ? "i" : "p") }
+
+        switch videoResolution?.lowercased() {
+        case "4k", "2160": return "4K"
+        case "1080":       return scan("1080")
+        case "720":        return "720p"
+        case "576":        return scan("576")
+        case "480", "sd":  return scan("480")
+        case .some(let r) where !r.isEmpty: return r.uppercased()  // e.g. "8K"
+        default: break
+        }
+        guard let height = video.height else { return nil }
+        switch height {
+        case 1600...:    return "4K"
+        case 800..<1600: return scan("1080")
+        case 620..<800:  return "720p"
+        case 500..<620:  return scan("576")
+        case 1..<500:    return scan("480")
+        default:         return nil
+        }
     }
 }

--- a/Rivulet/Models/Media/VideoTrack.swift
+++ b/Rivulet/Models/Media/VideoTrack.swift
@@ -18,6 +18,12 @@ struct VideoTrack: Hashable, Sendable, Identifiable {
     let bitrate: Int?
     let videoRange: VideoRange
     let isDefault: Bool
+    let scanType: String?          // Plex "progressive" / "interlaced"; nil if unknown
+
+    /// True when the source is interlaced (1080i/576i/480i). Plex reports the
+    /// scan type per video stream; when it's absent we assume progressive (the
+    /// common case), so we never wrongly tag progressive content as interlaced.
+    var isInterlaced: Bool { scanType?.lowercased() == "interlaced" }
 
     enum VideoRange: Hashable, Sendable {
         case sdr

--- a/Rivulet/Services/MediaProvider/Plex/PlexMediaMapper.swift
+++ b/Rivulet/Services/MediaProvider/Plex/PlexMediaMapper.swift
@@ -91,7 +91,8 @@ enum PlexMediaMapper {
             frameRate: stream.frameRate,
             bitrate: stream.bitrate,
             videoRange: range,
-            isDefault: stream.default ?? false
+            isDefault: stream.default ?? false,
+            scanType: stream.scanType
         )
     }
 
@@ -101,6 +102,7 @@ enum PlexMediaMapper {
             id: "\(stream.id)",
             index: stream.index ?? 0,
             codec: stream.codec ?? "unknown",
+            profile: stream.profile,
             channels: stream.channels,
             channelLayout: stream.audioChannelLayout,
             language: stream.language,
@@ -246,6 +248,7 @@ enum PlexMediaMapper {
             bitrate: media.bitrate.map { $0 * 1000 },     // Plex bitrate is kbps
             fileSize: part.size.map { Int64($0) },
             fileName: part.file,
+            videoResolution: media.videoResolution,
             videoTracks: videoTracks,
             audioTracks: audioTracks,
             subtitleTracks: subtitleTracks,
@@ -333,7 +336,8 @@ enum PlexMediaMapper {
             contentRating: meta.contentRating,
             rating: meta.rating,
             nextEpisode: nextEpisode,
-            collections: collections
+            collections: collections,
+            originallyAvailableAt: meta.originallyAvailableAt
         )
     }
 

--- a/Rivulet/Services/MediaProvider/TMDB/TMDBMediaMapper.swift
+++ b/Rivulet/Services/MediaProvider/TMDB/TMDBMediaMapper.swift
@@ -120,7 +120,8 @@ enum TMDBMediaMapper {
             contentRating: nil,
             rating: tmdb.voteAverage,
             nextEpisode: nil,
-            collections: []
+            collections: [],
+            originallyAvailableAt: nil
         )
     }
 }

--- a/Rivulet/Views/Media/MediaDetailView.swift
+++ b/Rivulet/Views/Media/MediaDetailView.swift
@@ -983,17 +983,49 @@ struct MediaDetailView: View {
         return parts
     }
 
-    /// Year, duration, quality badges row (Apple TV+ style: "2023 · 49 min [4K] [DV] [5.1]")
+    /// Hero metadata date: episodes show the full original air date
+    /// ("Sep 24, 2019"); movies and everything else show the year. Falls back
+    /// to the year when the full date is absent (detail not loaded yet) or
+    /// unparseable.
+    private var heroDateText: String? {
+        if currentItem.kind == .episode,
+           let raw = detail?.originallyAvailableAt,
+           let formatted = Self.formattedAirDate(raw) {
+            return formatted
+        }
+        return currentItem.year.map(String.init)
+    }
+
+    private static func formattedAirDate(_ raw: String) -> String? {
+        guard let date = plexDateParser.date(from: String(raw.prefix(10))) else { return nil }
+        return airDateDisplay.string(from: date)
+    }
+    private static let plexDateParser: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
+    private static let airDateDisplay: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        f.timeStyle = .none
+        return f
+    }()
+
+    /// Date, duration, quality badges row (Apple TV+ style:
+    /// "Sep 24, 2019 · 49 min [4K] [DV] [E-AC3 5.1]")
     private var heroQualityRow: some View {
         HStack(spacing: 8) {
-            // Year · Duration with dot separator
-            let year = currentItem.year
+            // Date · Duration with dot separator
+            let dateText = heroDateText
             let duration = currentItemDurationFormatted
 
-            if let year {
-                Text(String(year))
+            if let dateText {
+                Text(dateText)
             }
-            if year != nil && duration != nil {
+            if dateText != nil && duration != nil {
                 Text("·")
             }
             if let duration {

--- a/RivuletTests/Unit/MediaSourceQualityBadgesTests.swift
+++ b/RivuletTests/Unit/MediaSourceQualityBadgesTests.swift
@@ -14,10 +14,10 @@ final class MediaSourceQualityBadgesTests: XCTestCase {
             width: 3840, height: 2160, frameRate: 24,
             bitrate: 50_000_000,
             videoRange: .dolbyVision(profile: 7),
-            isDefault: true
+            isDefault: true, scanType: "progressive"
         )
         let audio = AudioTrack(
-            id: "a1", index: 0, codec: "eac3",
+            id: "a1", index: 0, codec: "eac3", profile: nil,
             channels: 6, channelLayout: "5.1",
             language: "en", title: nil, extendedTitle: nil,
             bitrate: 640_000, samplingRate: 48_000,
@@ -26,24 +26,26 @@ final class MediaSourceQualityBadgesTests: XCTestCase {
         let source = MediaSource(
             id: "1", container: "mkv", duration: 7200,
             bitrate: 50_000_000, fileSize: nil, fileName: nil,
+            videoResolution: "4k",
             videoTracks: [video], audioTracks: [audio], subtitleTracks: [],
             streamKind: .directPlay, streamURL: nil
         )
         let badges = source.qualityBadges()
         XCTAssertTrue(badges.contains("4K"))
         XCTAssertTrue(badges.contains("DV"))
-        XCTAssertTrue(badges.contains("5.1"))
+        XCTAssertTrue(badges.contains("E-AC3 5.1"))
     }
 
     func test_1080pHDR10_stereoAudio() {
         let video = VideoTrack(
             id: "v1", codec: "hevc", profile: "Main 10", level: nil,
             width: 1920, height: 1080, frameRate: 24,
-            bitrate: nil, videoRange: .hdr10, isDefault: true
+            bitrate: nil, videoRange: .hdr10, isDefault: true,
+            scanType: "progressive"
         )
         let audio = AudioTrack(
-            id: "a1", index: 0, codec: "aac",
-            channels: 2, channelLayout: "Stereo",
+            id: "a1", index: 0, codec: "aac", profile: nil,
+            channels: 2, channelLayout: "stereo",
             language: "en", title: nil, extendedTitle: nil,
             bitrate: 192_000, samplingRate: 48_000,
             isDefault: true, isForced: false, isSelected: true
@@ -51,39 +53,226 @@ final class MediaSourceQualityBadgesTests: XCTestCase {
         let source = MediaSource(
             id: "1", container: "mp4", duration: 7200,
             bitrate: nil, fileSize: nil, fileName: nil,
+            videoResolution: "1080",
             videoTracks: [video], audioTracks: [audio], subtitleTracks: [],
             streamKind: .directPlay, streamURL: nil
         )
         let badges = source.qualityBadges()
-        XCTAssertTrue(badges.contains("HD"))
+        XCTAssertTrue(badges.contains("1080p"))
         XCTAssertTrue(badges.contains("HDR"))
         XCTAssertFalse(badges.contains("4K"))
         XCTAssertFalse(badges.contains("DV"))
-        XCTAssertFalse(badges.contains("Stereo"))
+        // Stereo is now shown (as "2.0"), unlike the pre-954f81a scheme.
+        XCTAssertTrue(badges.contains("AAC 2.0"))
     }
 
-    func test_sdr_noBadges() {
+    func test_truehdAtmos_appendsAtmos() {
+        let video = VideoTrack(
+            id: "v1", codec: "hevc", profile: "Main 10", level: nil,
+            width: 3840, height: 2160, frameRate: 24,
+            bitrate: nil, videoRange: .dolbyVision(profile: 7),
+            isDefault: true, scanType: "progressive"
+        )
+        let audio = AudioTrack(
+            id: "a1", index: 0, codec: "truehd",
+            profile: "dolby truehd + dolby atmos",
+            channels: 8, channelLayout: "7.1",
+            language: "en", title: nil, extendedTitle: nil,
+            bitrate: nil, samplingRate: 48_000,
+            isDefault: true, isForced: false, isSelected: true
+        )
+        let source = MediaSource(
+            id: "1", container: "mkv", duration: 7200,
+            bitrate: nil, fileSize: nil, fileName: nil,
+            videoResolution: "4k",
+            videoTracks: [video], audioTracks: [audio], subtitleTracks: [],
+            streamKind: .directPlay, streamURL: nil
+        )
+        XCTAssertTrue(source.qualityBadges().contains("TrueHD 7.1 Atmos"))
+    }
+
+    func test_dtsHdMa_distinctFromDts() {
+        let video = VideoTrack(
+            id: "v1", codec: "hevc", profile: nil, level: nil,
+            width: 1920, height: 1080, frameRate: 24,
+            bitrate: nil, videoRange: .sdr, isDefault: true,
+            scanType: "progressive"
+        )
+        let audio = AudioTrack(
+            id: "a1", index: 0, codec: "dca", profile: "ma",
+            channels: 8, channelLayout: "7.1",
+            language: "en", title: nil, extendedTitle: nil,
+            bitrate: nil, samplingRate: 48_000,
+            isDefault: true, isForced: false, isSelected: true
+        )
+        let source = MediaSource(
+            id: "1", container: "mkv", duration: 7200,
+            bitrate: nil, fileSize: nil, fileName: nil,
+            videoResolution: "1080",
+            videoTracks: [video], audioTracks: [audio], subtitleTracks: [],
+            streamKind: .directPlay, streamURL: nil
+        )
+        let badges = source.qualityBadges()
+        XCTAssertTrue(badges.contains("DTS-HD MA 7.1"))
+        XCTAssertFalse(badges.contains("DTS 7.1"))
+    }
+
+    func test_sdr_noHDRBadges() {
         let video = VideoTrack(
             id: "v1", codec: "h264", profile: nil, level: nil,
             width: 1280, height: 720, frameRate: 24,
-            bitrate: nil, videoRange: .sdr, isDefault: true
+            bitrate: nil, videoRange: .sdr, isDefault: true,
+            scanType: "progressive"
         )
         let source = MediaSource(
             id: "1", container: "mp4", duration: 7200,
             bitrate: nil, fileSize: nil, fileName: nil,
+            videoResolution: "720",
             videoTracks: [video], audioTracks: [], subtitleTracks: [],
             streamKind: .directPlay, streamURL: nil
         )
         let badges = source.qualityBadges()
+        XCTAssertTrue(badges.contains("720p"))
         XCTAssertFalse(badges.contains("4K"))
         XCTAssertFalse(badges.contains("HDR"))
         XCTAssertFalse(badges.contains("DV"))
+    }
+
+    // MARK: - Interlaced scan-type labelling
+
+    func test_1080i_interlacedSuffix() {
+        let video = VideoTrack(
+            id: "v1", codec: "mpeg2video", profile: nil, level: nil,
+            width: 1920, height: 1080, frameRate: 29.97,
+            bitrate: nil, videoRange: .sdr, isDefault: true,
+            scanType: "interlaced"
+        )
+        let source = MediaSource(
+            id: "1", container: "ts", duration: 3600,
+            bitrate: nil, fileSize: nil, fileName: nil,
+            videoResolution: "1080",
+            videoTracks: [video], audioTracks: [], subtitleTracks: [],
+            streamKind: .directPlay, streamURL: nil
+        )
+        let badges = source.qualityBadges()
+        XCTAssertTrue(badges.contains("1080i"))
+        XCTAssertFalse(badges.contains("1080p"))
+    }
+
+    func test_480i_interlacedSuffix() {
+        let video = VideoTrack(
+            id: "v1", codec: "mpeg2video", profile: nil, level: nil,
+            width: 720, height: 480, frameRate: 29.97,
+            bitrate: nil, videoRange: .sdr, isDefault: true,
+            scanType: "interlaced"
+        )
+        let source = MediaSource(
+            id: "1", container: "mpeg", duration: 3600,
+            bitrate: nil, fileSize: nil, fileName: nil,
+            videoResolution: "480",
+            videoTracks: [video], audioTracks: [], subtitleTracks: [],
+            streamKind: .directPlay, streamURL: nil
+        )
+        XCTAssertTrue(source.qualityBadges().contains("480i"))
+    }
+
+    func test_576i_interlacedSuffix() {
+        let video = VideoTrack(
+            id: "v1", codec: "mpeg2video", profile: nil, level: nil,
+            width: 720, height: 576, frameRate: 25,
+            bitrate: nil, videoRange: .sdr, isDefault: true,
+            scanType: "interlaced"
+        )
+        let source = MediaSource(
+            id: "1", container: "mpeg", duration: 3600,
+            bitrate: nil, fileSize: nil, fileName: nil,
+            videoResolution: "576",
+            videoTracks: [video], audioTracks: [], subtitleTracks: [],
+            streamKind: .directPlay, streamURL: nil
+        )
+        XCTAssertTrue(source.qualityBadges().contains("576i"))
+    }
+
+    func test_720_neverInterlaced() {
+        // 720 has no interlaced broadcast form; stay progressive even if a
+        // probe oddly reports interlaced.
+        let video = VideoTrack(
+            id: "v1", codec: "h264", profile: nil, level: nil,
+            width: 1280, height: 720, frameRate: 59.94,
+            bitrate: nil, videoRange: .sdr, isDefault: true,
+            scanType: "interlaced"
+        )
+        let source = MediaSource(
+            id: "1", container: "ts", duration: 3600,
+            bitrate: nil, fileSize: nil, fileName: nil,
+            videoResolution: "720",
+            videoTracks: [video], audioTracks: [], subtitleTracks: [],
+            streamKind: .directPlay, streamURL: nil
+        )
+        let badges = source.qualityBadges()
+        XCTAssertTrue(badges.contains("720p"))
+        XCTAssertFalse(badges.contains("720i"))
+    }
+
+    func test_4k_neverInterlaced() {
+        let video = VideoTrack(
+            id: "v1", codec: "hevc", profile: "Main 10", level: nil,
+            width: 3840, height: 2160, frameRate: 24,
+            bitrate: nil, videoRange: .sdr, isDefault: true,
+            scanType: "interlaced"
+        )
+        let source = MediaSource(
+            id: "1", container: "mkv", duration: 3600,
+            bitrate: nil, fileSize: nil, fileName: nil,
+            videoResolution: "4k",
+            videoTracks: [video], audioTracks: [], subtitleTracks: [],
+            streamKind: .directPlay, streamURL: nil
+        )
+        XCTAssertTrue(source.qualityBadges().contains("4K"))
+    }
+
+    func test_nilScanType_assumesProgressive() {
+        let video = VideoTrack(
+            id: "v1", codec: "h264", profile: nil, level: nil,
+            width: 1920, height: 1080, frameRate: 24,
+            bitrate: nil, videoRange: .sdr, isDefault: true,
+            scanType: nil
+        )
+        let source = MediaSource(
+            id: "1", container: "mp4", duration: 3600,
+            bitrate: nil, fileSize: nil, fileName: nil,
+            videoResolution: "1080",
+            videoTracks: [video], audioTracks: [], subtitleTracks: [],
+            streamKind: .directPlay, streamURL: nil
+        )
+        let badges = source.qualityBadges()
+        XCTAssertTrue(badges.contains("1080p"))
+        XCTAssertFalse(badges.contains("1080i"))
+    }
+
+    func test_interlacedHeightFallback_whenNoProviderLabel() {
+        // No provider videoResolution → height fallback path must also suffix.
+        let video = VideoTrack(
+            id: "v1", codec: "mpeg2video", profile: nil, level: nil,
+            width: 1920, height: 1080, frameRate: 25,
+            bitrate: nil, videoRange: .sdr, isDefault: true,
+            scanType: "interlaced"
+        )
+        let source = MediaSource(
+            id: "1", container: "ts", duration: 3600,
+            bitrate: nil, fileSize: nil, fileName: nil,
+            videoResolution: nil,
+            videoTracks: [video], audioTracks: [], subtitleTracks: [],
+            streamKind: .directPlay, streamURL: nil
+        )
+        XCTAssertTrue(source.qualityBadges().contains("1080i"))
     }
 
     func test_emptyTracks_returnsEmpty() {
         let source = MediaSource(
             id: "1", container: nil, duration: 0,
             bitrate: nil, fileSize: nil, fileName: nil,
+            videoResolution: nil,
             videoTracks: [], audioTracks: [], subtitleTracks: [],
             streamKind: .directPlay, streamURL: nil
         )

--- a/RivuletTests/Unit/MusicProviderRegistryTests.swift
+++ b/RivuletTests/Unit/MusicProviderRegistryTests.swift
@@ -49,7 +49,8 @@ final class MusicProviderRegistryTests: XCTestCase {
         func recentlyPlayed(limit: Int) async throws -> [MusicItem] { [] }
         func resolveStream(for trackRef: MediaItemRef) async throws -> StreamInfo {
             StreamInfo(source: MediaSource(id: "", container: nil, duration: 0, bitrate: nil,
-                                           fileSize: nil, fileName: nil, videoTracks: [], audioTracks: [],
+                                           fileSize: nil, fileName: nil, videoResolution: nil,
+                                           videoTracks: [], audioTracks: [],
                                            subtitleTracks: [], streamKind: .directPlay, streamURL: nil),
                        playSessionID: nil, trackInfoAvailable: false)
         }


### PR DESCRIPTION
Enriches the hero metadata badge row on the detail page so it reflects the actual variant being played, across every video kind (it rides the shared `MediaDetailView` row).

- **Audio** — codec + channel layout for the default track, e.g. `E-AC3 5.1`, `DTS-HD MA 7.1`, `TrueHD 7.1 Atmos`, `AAC 2.0`, `FLAC 1.0`. The codec name distinguishes lossless families from lossy so the label is self-describing; Atmos is read from Plex's stream `profile` (object metadata), not the channel count. Stereo/mono are shown as `2.0`/`1.0` rather than dropped.
- **Resolution** — derived from Plex's computed `videoResolution` (correct for cropped widescreen whose pixel height is below nominal), falling back to track height. Interlaced sources get an `i` suffix (`1080i`/`576i`/`480i`) from the per-stream scan type; 4K/720 have no interlaced broadcast form and stay progressive; an absent scan type is treated as progressive so nothing is mislabeled.
- **Air date** — episodes show the full original air date (`Sep 24, 2019`); movies keep year-only.

Adds `MediaSource.videoResolution` and `AudioTrack.qualityLabel`; `VideoTrack` carries `scanType`; `MediaItemDetail` carries `originallyAvailableAt`. The quality-badge unit tests are rewritten for the new scheme (including interlaced cases).

Verified on device against a real Plex library. Note for review: this touches `MediaDetailView.swift`, also modified by #158 — the change here is confined to the hero metadata row, so the two should rebase independently.
