### PR TITLE
Detail page: surface a browsable Extras row with per-extra detail pages

### DIFF
--- a/Rivulet/Models/Media/MediaExtra.swift
+++ b/Rivulet/Models/Media/MediaExtra.swift
@@ -1,0 +1,72 @@
+//
+//  MediaExtra.swift
+//  Rivulet
+//
+//  Agnostic representation of a bonus-feature item attached to a movie,
+//  show, season, or episode. Provider-mapped from `PlexExtra` today;
+//  carries enough to render a 16:9 tile + play through the universal
+//  player by ratingKey.
+//
+
+import Foundation
+
+struct MediaExtra: Identifiable, Hashable, Sendable {
+    /// Provider-native ID (Plex ratingKey).
+    let id: String
+    let title: String
+    let subtype: ExtraSubtype
+    let durationSec: Int?
+    let thumbURL: URL?
+}
+
+/// Canonical Plex extra categories. Render order is the declaration
+/// order below.
+enum ExtraSubtype: Int, CaseIterable, Sendable, Comparable {
+    case trailer
+    case featurette
+    case behindTheScenes
+    case deletedScene
+    case interview
+    case scene
+    case short
+    case unknown
+
+    /// Map Plex's raw `subtype` / `extraType` strings to the enum.
+    /// Plex uses `sceneOrSample` interchangeably with `deletedScene` on
+    /// some library types; both map to `.deletedScene`.
+    static func fromPlex(subtype: String?, extraType: Int?) -> ExtraSubtype {
+        switch subtype {
+        case "trailer": return .trailer
+        case "featurette": return .featurette
+        case "behindTheScenes": return .behindTheScenes
+        case "deletedScene", "sceneOrSample": return .deletedScene
+        case "interview": return .interview
+        case "scene": return .scene
+        case "short": return .short
+        default:
+            // Fallback to extraType when subtype is absent/unrecognised.
+            // Plex uses extraType=1 for trailer; other integer codes are
+            // inconsistent across versions, so don't over-map.
+            if extraType == 1 { return .trailer }
+            return .unknown
+        }
+    }
+
+    static func < (lhs: ExtraSubtype, rhs: ExtraSubtype) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+
+    /// Human-readable label for the type row on an extra's detail page.
+    var displayName: String {
+        switch self {
+        case .trailer:         return "Trailer"
+        case .featurette:      return "Featurette"
+        case .behindTheScenes: return "Behind the Scenes"
+        case .deletedScene:    return "Deleted Scene"
+        case .interview:       return "Interview"
+        case .scene:           return "Scene"
+        case .short:           return "Short"
+        case .unknown:         return "Extra"
+        }
+    }
+}

--- a/Rivulet/Models/Media/MediaItemDetail.swift
+++ b/Rivulet/Models/Media/MediaItemDetail.swift
@@ -21,10 +21,17 @@ struct MediaItemDetail: Sendable {
     let chapters: [MediaChapter]
     let mediaSources: [MediaSource]
     let trailerURL: URL?
+    let extras: [MediaExtra]         // canonical-sorted; trailerURL is derived from the first .trailer
     let contentRating: String?
     let rating: Double?              // normalized 0–10
 
     // Wave 1 additions for the detail view
     let nextEpisode: MediaItem?      // shows only — Plex `OnDeck`, Jellyfin `/Shows/NextUp`
     let collections: [String]        // collection names this item is tagged with
+
+    // Extras: set when this detail represents a Plex clip (trailer,
+    // featurette, behind-the-scenes, etc.). MediaItem.kind is mapped
+    // to `.movie` for extras so the action row works, but the detail
+    // page surfaces the subtype label here instead of "Movie".
+    let extraSubtype: ExtraSubtype?
 }

--- a/Rivulet/Models/Plex/PlexMetadata.swift
+++ b/Rivulet/Models/Plex/PlexMetadata.swift
@@ -68,6 +68,14 @@ struct PlexExtra: Codable, Identifiable, Sendable {
     var thumb: String?
     var duration: Int?
     var extraType: Int?     // 1=trailer
+    var Media: [PlexMedia]?
+
+    /// User-added extras have a local file path under /Volumes/...; Plex's
+    /// IVA-supplied extras stream from /services/iva/assets/... and carry
+    /// no file field.
+    var hasLocalFile: Bool {
+        (Media?.first?.Part?.first?.file?.isEmpty == false)
+    }
 }
 
 /// Container for extras in Plex API response
@@ -146,7 +154,9 @@ struct PlexMetadata: Codable, Identifiable, Hashable, Sendable {
     var ratingKey: String?
     var key: String?
     var guid: String?
-    var type: String?             // "movie", "show", "season", "episode"
+    var type: String?             // "movie", "show", "season", "episode", "clip"
+    var subtype: String?          // clips only: "trailer", "behindTheScenes", etc.
+    var extraType: Int?           // clips only: 1=trailer
 
     // MARK: - Display Info
     var title: String?

--- a/Rivulet/Services/MediaProvider/Plex/PlexMediaMapper.swift
+++ b/Rivulet/Services/MediaProvider/Plex/PlexMediaMapper.swift
@@ -26,6 +26,32 @@ enum PlexMediaMapper {
 
     // MARK: - Kind
 
+    /// Loose title-match used by the header Trailer button to gate on
+    /// "is this trailer actually for the feature?": normalizes case,
+    /// strips leading articles + non-alphanumerics, and checks substring
+    /// either direction so "7 Faces of Dr. Lao (1964) - Theatrical Trailer"
+    /// matches feature "7 Faces of Dr. Lao". Returns false on either-nil.
+    static func titlesMatch(_ a: String?, _ b: String?) -> Bool {
+        guard let a, let b else { return false }
+        let na = normalizedTitle(a)
+        let nb = normalizedTitle(b)
+        guard !na.isEmpty, !nb.isEmpty else { return false }
+        return na.contains(nb) || nb.contains(na)
+    }
+
+    static func normalizedTitle(_ s: String) -> String {
+        var t = s.lowercased()
+        for prefix in ["the ", "a ", "an "] where t.hasPrefix(prefix) {
+            t.removeFirst(prefix.count)
+        }
+        let scalars = t.unicodeScalars.map { sc -> Character in
+            if CharacterSet.alphanumerics.contains(sc) { return Character(sc) }
+            return " "
+        }
+        let compact = String(scalars).split(separator: " ").joined(separator: " ")
+        return compact
+    }
+
     static func kind(_ type: String?) -> MediaKind {
         switch type {
         case "movie": return .movie
@@ -33,6 +59,12 @@ enum PlexMediaMapper {
         case "season": return .season
         case "episode": return .episode
         case "collection": return .collection
+        // Extras come back as type=="clip"; they're single-video items with
+        // their own Media block, indistinguishable from movies for routing /
+        // playback / detail-page rendering. Classifying as .movie lets them
+        // re-use the movie code path everywhere (detail view, action row,
+        // audio/subtitle pickers, WT, etc.) without a new case.
+        case "clip": return .movie
         default: return .unknown
         }
     }
@@ -57,9 +89,15 @@ enum PlexMediaMapper {
     }
 
     static func artwork(_ meta: PlexMetadata, serverURL: String, authToken: String) -> MediaArtwork {
-        MediaArtwork(
+        // For clip-type items (Plex extras: trailers, featurettes, behind-the-
+        // scenes, etc.) Plex has no per-clip `art` field, so `bestArt` falls
+        // back to grandparentArt (the parent movie's backdrop). Source the
+        // extra's backdrop from its own thumb (a frame of the extra video)
+        // so the pushed detail page represents the extra itself.
+        let backdropSource: String? = (meta.type == "clip") ? meta.thumb : meta.bestArt
+        return MediaArtwork(
             poster: artworkURL(meta.thumb ?? meta.bestThumb, serverURL: serverURL, authToken: authToken),
-            backdrop: artworkURL(meta.bestArt, serverURL: serverURL, authToken: authToken),
+            backdrop: artworkURL(backdropSource, serverURL: serverURL, authToken: authToken),
             thumbnail: artworkURL(meta.thumb, serverURL: serverURL, authToken: authToken),
             logo: artworkURL(meta.clearLogoPath, serverURL: serverURL, authToken: authToken)
         )
@@ -305,10 +343,37 @@ enum PlexMediaMapper {
                 mediaSource(media, part, serverURL: serverURL, authToken: authToken)
             }
         }
-        // PlexExtra exposes only `key`/`ratingKey` — no nested Media. The trailer
-        // URL is the extra's playback key, which the player resolves at play time.
-        let trailerURL: URL? = meta.Extras?.Metadata?
-            .first(where: { $0.subtype == "trailer" || $0.type == "clip" })
+        // Plex inlines `Media[].Part[]` on each Extras entry. User-added extras
+        // (files under /Volumes/...) carry a Part.file path; Plex's IVA-supplied
+        // extras stream from /services/iva/assets/... and have no file. We only
+        // surface user-added extras; IVA streams are low quality and not what
+        // we want in the carousel.
+        let localExtras = (meta.Extras?.Metadata ?? []).filter(\.hasLocalFile)
+        let extras: [MediaExtra] = localExtras.compactMap { ex in
+            guard let rk = ex.ratingKey else { return nil }
+            return MediaExtra(
+                id: rk,
+                title: ex.title ?? "",
+                subtype: ExtraSubtype.fromPlex(subtype: ex.subtype, extraType: ex.extraType),
+                durationSec: ex.duration.map { $0 / 1000 },
+                thumbURL: personURL(ex.thumb)
+            )
+        }
+        .sorted { $0.subtype < $1.subtype }
+        // type=="clip" matches every extra (trailers, featurettes, BTS all share
+        // type=clip), so OR-ing it in caused the Trailer button to fall through
+        // to the first non-trailer extra when no trailer was present. Restrict
+        // to the subtype check so the button either points at a real trailer or
+        // doesn't render.
+        //
+        // Disc-rip extras directories often contain trailers for OTHER films
+        // alongside the feature (Kino Lorber, Criterion, etc.), so require the
+        // trailer's title to match the feature item's title before using it for
+        // the header Trailer button. The trailers still appear in the Extras
+        // row regardless; this gate is only for the dedicated action button so
+        // it doesn't promise a feature trailer it can't deliver.
+        let trailerURL: URL? = localExtras
+            .first(where: { $0.subtype == "trailer" && titlesMatch($0.title, meta.title) })
             .flatMap { $0.key }
             .flatMap { URL(string: "\(serverURL)\($0)?X-Plex-Token=\(authToken)") }
 
@@ -318,6 +383,10 @@ enum PlexMediaMapper {
             item($0, providerID: providerID, serverURL: serverURL, authToken: authToken)
         }
         let collections = (meta.Collection ?? []).compactMap(\.tag)
+
+        let extraSubtype: ExtraSubtype? = (meta.type == "clip")
+            ? ExtraSubtype.fromPlex(subtype: meta.subtype, extraType: meta.extraType)
+            : nil
 
         return MediaItemDetail(
             item: item(meta, providerID: providerID, serverURL: serverURL, authToken: authToken),
@@ -330,10 +399,12 @@ enum PlexMediaMapper {
             chapters: chapters,
             mediaSources: mediaSources,
             trailerURL: trailerURL,
+            extras: extras,
             contentRating: meta.contentRating,
             rating: meta.rating,
             nextEpisode: nextEpisode,
-            collections: collections
+            collections: collections,
+            extraSubtype: extraSubtype
         )
     }
 

--- a/Rivulet/Services/MediaProvider/TMDB/TMDBMediaMapper.swift
+++ b/Rivulet/Services/MediaProvider/TMDB/TMDBMediaMapper.swift
@@ -117,10 +117,12 @@ enum TMDBMediaMapper {
             chapters: [],
             mediaSources: [],
             trailerURL: nil,
+            extras: [],
             contentRating: nil,
             rating: tmdb.voteAverage,
             nextEpisode: nil,
-            collections: []
+            collections: [],
+            extraSubtype: nil
         )
     }
 }

--- a/Rivulet/Views/Media/MediaDetailView.swift
+++ b/Rivulet/Views/Media/MediaDetailView.swift
@@ -80,6 +80,8 @@ struct MediaDetailView: View {
 
     // Detail state (replaces fullMetadata)
     @State private var detail: MediaItemDetail?
+    @State private var seasonExtras: [MediaExtra] = []
+    @State private var seasonExtrasSeasonTitle: String?
     @State private var collectionItems: [MediaItem] = []
     @State private var collectionName: String?
     @State private var recommendedItems: [MediaItem] = []
@@ -139,6 +141,7 @@ struct MediaDetailView: View {
     @State private var navigateToSeason: MediaItem?
     @State private var navigateToShow: MediaItem?
     @State private var navigateToEpisode: MediaItem?
+    @State private var navigateToExtraItem: MediaItem?
     @State private var isLoadingNavigation = false
 
     // Unified episode list state (all seasons in one scroll)
@@ -356,6 +359,7 @@ struct MediaDetailView: View {
                 navigateToSeason: $navigateToSeason,
                 navigateToShow: $navigateToShow,
                 navigateToEpisode: $navigateToEpisode,
+                navigateToExtra: $navigateToExtraItem,
                 // Disabled inside `PreviewOverlayHost`-hosted views: the
                 // overlay is presented via UIKit modal, so the SwiftUI
                 // tree has no `NavigationStack` ancestor and these
@@ -407,6 +411,11 @@ struct MediaDetailView: View {
             parentShowLogoPath = nil
             parentShowSummary = nil
             parentShowTagline = nil
+            seasonExtras = []
+            seasonExtrasSeasonTitle = nil
+        }
+        .onChange(of: selectedSeason?.ref.itemID) { _, _ in
+            Task { await loadSeasonExtras(for: selectedSeason) }
         }
         .onChange(of: showExpandedChrome) { _, isVisible in
             let ref = currentItem.ref.itemID
@@ -919,7 +928,8 @@ struct MediaDetailView: View {
                 Text(heroBrandTitle)
                     .font(.system(size: 42, weight: .bold))
                     .foregroundStyle(.primary)
-                    .lineLimit(1)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
         .frame(maxWidth: .infinity, alignment: .center)
@@ -928,10 +938,15 @@ struct MediaDetailView: View {
     // MARK: - Hero Sub-components
 
     private var heroTitleText: some View {
+        // Up to 2 lines (slot is heroLogoSlotHeight = 120pt; 2 lines at
+        // 52pt is too tall, so shrink the font to fit). Long titles like
+        // an Extra's "Theatrical Trailer for SomeMovie" hit this path.
         Text(heroBrandTitle)
             .font(.system(size: 52, weight: .bold))
             .foregroundStyle(.white)
             .shadow(color: .black.opacity(0.5), radius: 10, x: 0, y: 4)
+            .lineLimit(2)
+            .minimumScaleFactor(0.4)
     }
 
     /// Genre tags + content rating badge (Apple TV+ style: "TV Show · Adventure · Sci-Fi [TV-14]")
@@ -964,14 +979,21 @@ struct MediaDetailView: View {
     private var heroMetadataParts: [String] {
         var parts: [String] = []
 
-        // Type label from kind
-        switch currentItem.kind {
-        case .show, .episode, .season:
-            parts.append("TV Show")
-        case .movie:
-            parts.append("Movie")
-        default:
-            break
+        // Type label: extras (Plex clips) override the kind label with
+        // their subtype ("Trailer", "Featurette", etc.) since the mapper
+        // classifies a clip as MediaKind.movie at its boundary so the
+        // action row works.
+        if let subtype = detail?.extraSubtype {
+            parts.append(subtype.displayName)
+        } else {
+            switch currentItem.kind {
+            case .show, .episode, .season:
+                parts.append("TV Show")
+            case .movie:
+                parts.append("Movie")
+            default:
+                break
+            }
         }
 
         // Genres (up to 2 — keeps the row concise alongside the type label and rating badge)
@@ -1756,6 +1778,8 @@ struct MediaDetailView: View {
                 .padding(.horizontal, 48)
                 .allowsHitTesting(!isPreviewCarousel)
                 recommendedRow
+                extrasRow
+                seasonExtrasRow
                 collectionRow
                 castCrewRow
             }
@@ -2577,6 +2601,69 @@ struct MediaDetailView: View {
             ?? episodes.first
     }
 
+    private func loadSeasonExtras(for season: MediaItem?) async {
+        guard currentItem.kind == .show, let season,
+              let prov = provider else {
+            seasonExtras = []
+            seasonExtrasSeasonTitle = nil
+            return
+        }
+        do {
+            let d = try await prov.fullDetail(for: season.ref)
+            seasonExtras = d.extras
+            seasonExtrasSeasonTitle = season.title
+        } catch {
+            print("Failed to load season extras: \(error)")
+            seasonExtras = []
+            seasonExtrasSeasonTitle = nil
+        }
+    }
+
+    /// Push a fresh MediaDetailView for the pressed extra, the way episode /
+    /// season / show tile presses already do. The previous attempt swapped
+    /// displayedItem in place, which on tvOS left the entire below-fold
+    /// hidden (the user saw only the hero backdrop and the Siri Remote
+    /// went unresponsive). Pushing onto the NavigationStack gives the new
+    /// detail page a clean SwiftUI view tree and proper Back semantics
+    /// (Back returns to the parent's detail page, where the extras row
+    /// lives). When the host is the UIKit preview overlay (no
+    /// NavigationStack ancestor), route through onSubItemNavigation
+    /// instead, same pattern as episode-row presses.
+    private func navigateToExtra(_ extra: MediaExtra) {
+        let providerID = currentItem.ref.providerID
+        let stub = MediaItem(
+            ref: MediaItemRef(providerID: providerID, itemID: extra.id),
+            kind: .movie,
+            title: extra.title,
+            sortTitle: nil,
+            overview: nil,
+            year: nil,
+            runtime: extra.durationSec.map { TimeInterval($0) },
+            parentRef: nil,
+            grandparentRef: nil,
+            episodeNumber: nil,
+            seasonNumber: nil,
+            childProgress: nil,
+            userState: MediaUserState(isPlayed: false, viewOffset: 0, isFavorite: false, lastViewedAt: nil),
+            // Backdrop derives from the extra's own thumb (a frame from
+            // its video) rather than the parent's art, so the pushed
+            // detail page represents the extra itself.
+            artwork: MediaArtwork(
+                poster: extra.thumbURL,
+                backdrop: extra.thumbURL,
+                thumbnail: extra.thumbURL,
+                logo: nil
+            ),
+            parentArtwork: nil,
+            grandparentArtwork: nil
+        )
+        if let nav = onSubItemNavigation {
+            nav(stub)
+        } else {
+            navigateToExtraItem = stub
+        }
+    }
+
     private func loadAndPlayTrailer() async {
         // detail?.trailerURL is a playable URL. We need a PlexMetadata for
         // UniversalPlayerView (escape hatch). Extract the ratingKey from the
@@ -2951,6 +3038,33 @@ struct MediaDetailView: View {
                         displayedItem = selected
                     }
                 }
+            )
+            .padding(.top, 32)
+        }
+    }
+
+    @ViewBuilder
+    private var extrasRow: some View {
+        if let extras = detail?.extras, !extras.isEmpty {
+            // Distinguish from the season row when both are visible on a show page.
+            let label = (currentItem.kind == .show && !seasonExtras.isEmpty) ? "Show Extras" : "Extras"
+            ExtrasRow(
+                title: label,
+                extras: extras,
+                onExtraSelected: { extra in navigateToExtra(extra) }
+            )
+            .padding(.top, 32)
+        }
+    }
+
+    @ViewBuilder
+    private var seasonExtrasRow: some View {
+        if currentItem.kind == .show, !seasonExtras.isEmpty {
+            let seasonLabel = seasonExtrasSeasonTitle ?? "Season"
+            ExtrasRow(
+                title: "\(seasonLabel) Extras",
+                extras: seasonExtras,
+                onExtraSelected: { extra in navigateToExtra(extra) }
             )
             .padding(.top, 32)
         }
@@ -3719,6 +3833,131 @@ private struct MediaItemAgnosticPosterCard: View {
     }
 }
 
+// MARK: - Extras Row
+
+private struct ExtrasRow: View {
+    let title: String
+    let extras: [MediaExtra]
+    var onExtraSelected: ((MediaExtra) -> Void)?
+
+    @FocusState private var focusedID: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(title)
+                .font(.system(size: ScaledDimensions.sectionTitleSize, weight: .bold))
+                .foregroundStyle(.white)
+                .padding(.horizontal, ScaledDimensions.rowHorizontalPadding)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(spacing: ScaledDimensions.rowItemSpacing) {
+                    ForEach(extras) { extra in
+                        let isFocused = focusedID == extra.id
+                        Button {
+                            onExtraSelected?(extra)
+                        } label: {
+                            ExtraTileCard(extra: extra)
+                                .hoverEffectDisabled()
+                                .scaleEffect(isFocused ? 1.10 : 1.0)
+                                .animation(.spring(response: 0.3, dampingFraction: 0.8), value: isFocused)
+                        }
+                        .buttonStyle(CardButtonStyle())
+                        .focused($focusedID, equals: extra.id)
+                    }
+                }
+                .padding(.horizontal, ScaledDimensions.rowHorizontalPadding)
+                .padding(.vertical, ScaledDimensions.rowVerticalPadding)
+            }
+            .scrollClipDisabled()
+        }
+        .focusSection()
+    }
+}
+
+private struct ExtraTileCard: View {
+    let extra: MediaExtra
+
+    @Environment(\.uiScale) private var scale
+
+    private var tileWidth: CGFloat { ScaledDimensions.continueWatchingWidth * scale }
+    private var tileHeight: CGFloat { tileWidth * 9 / 16 }
+    private var cornerRadius: CGFloat { ScaledDimensions.posterCornerRadius }
+    private var titleSize: CGFloat { ScaledDimensions.posterTitleSize * scale }
+    private var subtitleSize: CGFloat { ScaledDimensions.posterSubtitleSize * scale }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            CachedAsyncImage(url: extra.thumbURL) { phase in
+                switch phase {
+                case .success(let image):
+                    image.resizable().aspectRatio(contentMode: .fill)
+                case .empty:
+                    Rectangle().fill(Color(white: 0.15))
+                        .overlay { ProgressView().tint(.white.opacity(0.3)) }
+                case .failure:
+                    Rectangle()
+                        .fill(LinearGradient(colors: [Color(white: 0.18), Color(white: 0.12)], startPoint: .top, endPoint: .bottom))
+                        .overlay { Image(systemName: glyphFor(extra.subtype)).foregroundStyle(.white.opacity(0.3)) }
+                }
+            }
+            .frame(width: tileWidth, height: tileHeight)
+            .overlay(alignment: .bottomTrailing) {
+                if let secs = extra.durationSec, secs > 0 {
+                    Text(formatDuration(secs))
+                        .font(.system(size: subtitleSize - 4, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(.black.opacity(0.65), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+                        .padding(8)
+                }
+            }
+            .overlay(alignment: .topLeading) {
+                if let glyph = glyphFor(extra.subtype, optional: true) {
+                    Image(systemName: glyph)
+                        .font(.system(size: titleSize - 6, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .padding(8)
+                        .background(.black.opacity(0.55), in: Circle())
+                        .padding(8)
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+            .hoverEffect(.highlight)
+
+            Text(extra.title)
+                .font(.system(size: titleSize, weight: .medium))
+                .foregroundStyle(.white.opacity(0.85))
+                .fixedSize(horizontal: false, vertical: true)
+                .multilineTextAlignment(.leading)
+                .frame(width: tileWidth, alignment: .leading)
+        }
+    }
+
+    private func glyphFor(_ subtype: ExtraSubtype) -> String {
+        glyphFor(subtype, optional: false) ?? "play.rectangle"
+    }
+
+    private func glyphFor(_ subtype: ExtraSubtype, optional: Bool) -> String? {
+        switch subtype {
+        case .trailer:         return "film"
+        case .featurette:      return "sparkles"
+        case .behindTheScenes: return "camera"
+        case .deletedScene:    return "scissors"
+        case .interview:       return "quote.bubble"
+        case .scene:           return "play.rectangle"
+        case .short:           return "tv"
+        case .unknown:         return optional ? nil : "play.rectangle"
+        }
+    }
+
+    private func formatDuration(_ seconds: Int) -> String {
+        let m = seconds / 60
+        let s = seconds % 60
+        return String(format: "%d:%02d", m, s)
+    }
+}
+
 // MARK: - Navigation Destinations Modifier
 
 /// Conditionally applies .navigationDestination modifiers.
@@ -3727,6 +3966,7 @@ private struct NavigationDestinationsModifier: ViewModifier {
     @Binding var navigateToSeason: MediaItem?
     @Binding var navigateToShow: MediaItem?
     @Binding var navigateToEpisode: MediaItem?
+    @Binding var navigateToExtra: MediaItem?
     let isEnabled: Bool
 
     func body(content: Content) -> some View {
@@ -3740,6 +3980,9 @@ private struct NavigationDestinationsModifier: ViewModifier {
                 }
                 .navigationDestination(item: $navigateToEpisode) { episode in
                     MediaDetailView(item: episode)
+                }
+                .navigationDestination(item: $navigateToExtra) { extra in
+                    MediaDetailView(item: extra)
                 }
         } else {
             content


### PR DESCRIPTION
## Summary

Plex items carry an Extras array — trailers, featurettes, behind-the-scenes, deleted scenes, interviews — that the detail page previously reduced to a single trailer URL. This surfaces the whole list as a first-class browsable row, with each extra opening its own detail page.

## What's included

- **Extras row.** A horizontal row of extra tiles beneath Recommendations. New `MediaExtra` model + `ExtraSubtype` enum (canonical Plex categories, fixed render order); `MediaItemDetail` now carries the full extras array.
- **Pressing a tile opens its detail page.** Matching every other poster in the app (library grids, Recommended, Collections) rather than playing it directly. The extra maps through the normal single-video path (Plex `type=="clip"` classified as `.movie`), so it gets the full action row for free; a fresh detail view is pushed so the below-fold content belongs to the extra.
- **Per-season extras.** On a show page, the selected season's extras render in a second row ("<Season> Extras") beneath the show-level row, which retitles to "Show Extras" when both are visible. Collapses when a season has none.
- **Extra detail page.** Uses the extra's own full title and backdrop, and labels the type by its real subtype ("Trailer", "Featurette", …) instead of "Movie".
- **Library files only.** Drops Plex-supplied IVA (online) extra streams so the row surfaces only real library files.
- **Trailer-button precision.** The header Trailer button derived its URL from the first extra matching `subtype=="trailer"` OR `type=="clip"` — and since every Plex extra is `type=="clip"`, that matched any extra. With the full list now surfaced this would point the button at an arbitrary featurette. Drop the clip clause and gate on a loose title match, so the button points at a real trailer for the feature or doesn't render.

One new file (`MediaExtra.swift`); the rest integrates into the existing detail view and Plex mapper. Verified on device.

Note for review: touches `MediaDetailView.swift` and the Plex mapper, which other open PRs (#158, #168, #172, #173) also modify — the changes here are scoped to the Extras row, the extra-detail path, and the trailer-URL derivation, so they rebase independently.
