### PR TITLE
fix(persistence): recover from corrupt store instead of crashing at launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Launch no longer crashes when the local SwiftData store is corrupt, un-migratable, or unwritable. The store is reset and rebuilt, falling back to an in-memory store as a last resort, with a dismissable on-screen notice when local watch history was reset (audit finding C-1).
+
 ## 1.0.0 (Build 48)
 
 - Added Discover + Watchlist tabs

--- a/Rivulet/ContentView.swift
+++ b/Rivulet/ContentView.swift
@@ -25,6 +25,17 @@ struct ContentView: View {
     @State private var showSplash = true
     #endif
 
+    /// How the SwiftData store was built at launch. Drives the non-fatal
+    /// "local history was reset" notice (audit finding C-1). Defaults to
+    /// `.persistent` so previews/tests need not supply it.
+    private let storeResolution: ModelStoreResolution
+    @State private var showStoreNotice: Bool
+
+    init(storeResolution: ModelStoreResolution = .persistent) {
+        self.storeResolution = storeResolution
+        _showStoreNotice = State(initialValue: storeResolution != .persistent)
+    }
+
     var body: some View {
         TVSidebarView()
             .modifier(AutoPlayLauncherModifier())
@@ -34,7 +45,14 @@ struct ContentView: View {
                         .transition(.opacity)
                 }
             }
+            .overlay(alignment: .top) {
+                if showStoreNotice {
+                    storeNoticeBanner
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                }
+            }
             .animation(.easeOut(duration: 0.4), value: showSplash)
+            .animation(.easeOut(duration: 0.3), value: showStoreNotice)
         .onChange(of: authManager.hasCredentials) { _, hasCredentials in
             splashLog.info("hasCredentials changed to \(hasCredentials)")
             if !hasCredentials {
@@ -101,6 +119,42 @@ struct ContentView: View {
                 Task { await dataStore.refreshLibraries() }
             }
         }
+    }
+
+    /// Non-fatal notice shown when the persistent store had to be reset or fell
+    /// back to memory at launch (audit finding C-1). Dismissable with the remote.
+    private var storeNoticeBanner: some View {
+        let message: String
+        switch storeResolution {
+        case .persistent:
+            message = ""
+        case .recoveredAfterReset:
+            message = "Local watch history was reset after a storage problem. Your Plex account and watched state on the server are unaffected."
+        case .inMemoryFallback:
+            message = "Local storage is unavailable, so watch history won't be saved this session. Your Plex account is unaffected."
+        }
+
+        return Button {
+            showStoreNotice = false
+        } label: {
+            HStack(spacing: 16) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.yellow)
+                Text(message)
+                    .font(.callout)
+                    .multilineTextAlignment(.leading)
+                Spacer(minLength: 24)
+                Text("Dismiss")
+                    .font(.callout.weight(.semibold))
+            }
+            .padding(.horizontal, 28)
+            .padding(.vertical, 18)
+            .frame(maxWidth: .infinity)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 48)
+        .padding(.top, 32)
     }
 
     private var splashOverlay: some View {

--- a/Rivulet/RivuletApp.swift
+++ b/Rivulet/RivuletApp.swift
@@ -83,7 +83,12 @@ struct RivuletApp: App {
         // NowPlayingService.shared.initialize()
     }
 
-    var sharedModelContainer: ModelContainer = {
+    private let modelStore = RivuletApp.buildModelContainer()
+
+    /// Builds the shared container via ``ModelContainerFactory`` so a corrupt or
+    /// un-migratable store degrades gracefully (reset → in-memory) instead of
+    /// crashing at launch. See audit finding C-1.
+    private static func buildModelContainer() -> ModelContainerBuildResult {
         let schema = Schema([
             ServerConfiguration.self,
             PlexServer.self,
@@ -93,26 +98,51 @@ struct RivuletApp: App {
             WatchProgress.self,
             EPGProgram.self,
         ])
-        let modelConfiguration = ModelConfiguration(
-            schema: schema,
-            isStoredInMemoryOnly: false,
-            allowsSave: true
-        )
+
+        // SwiftData's default persistent store lives at
+        // Application Support/default.store.
+        let storeURL = URL.applicationSupportDirectory.appending(path: "default.store")
+
+        let diagnostics: ModelContainerFactory.DiagnosticSink = { message, error in
+            #if !DEBUG
+            SentrySDK.capture(message: message) { scope in
+                scope.setExtra(value: "\(error)", key: "underlyingError")
+            }
+            #else
+            print("[ModelContainer] \(message): \(error)")
+            #endif
+        }
 
         do {
-            return try ModelContainer(for: schema, configurations: [modelConfiguration])
+            return try ModelContainerFactory.build(
+                storeURL: storeURL,
+                makePersistent: { url in
+                    let config = ModelConfiguration(schema: schema, url: url, allowsSave: true)
+                    return try ModelContainer(for: schema, configurations: [config])
+                },
+                makeInMemory: {
+                    let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+                    return try ModelContainer(for: schema, configurations: [config])
+                },
+                removeStoreFiles: ModelContainerFactory.defaultRemoveStoreFiles,
+                diagnostics: diagnostics
+            )
         } catch {
-            fatalError("Could not create ModelContainer: \(error)")
+            // Only reached if even the in-memory store cannot be created — an
+            // unrecoverable runtime environment. There is no usable container to
+            // hand SwiftUI, so this is the one genuinely fatal path.
+            diagnostics("ModelContainer build exhausted all fallbacks", error)
+            fatalError("Could not create any ModelContainer: \(error)")
         }
-    }()
+    }
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(storeResolution: modelStore.resolution)
                 .environment(MediaProviderRegistry.shared)
                 .environment(MusicProviderRegistry.shared)
                 .environment(MetadataSourceRegistry.shared)
         }
-        .modelContainer(sharedModelContainer)
+        .modelContainer(modelStore.container)
     }
 }

--- a/Rivulet/Services/Persistence/ModelContainerFactory.swift
+++ b/Rivulet/Services/Persistence/ModelContainerFactory.swift
@@ -1,0 +1,117 @@
+//
+//  ModelContainerFactory.swift
+//  Rivulet
+//
+//  Builds the app's SwiftData ModelContainer with a tiered fallback so a
+//  corrupt, un-migratable, or unwritable on-disk store can never brick launch.
+//  Replaces the previous `fatalError` (audit finding C-1): a single throw at
+//  app-init time turned any store problem into a permanent launch crash that
+//  could only be cleared by reinstalling (losing all watch progress).
+//
+
+import Foundation
+import SwiftData
+
+/// Outcome of building the persistent store, so the UI can surface a non-fatal
+/// notice when local history had to be reset or kept only in memory.
+enum ModelStoreResolution: Equatable {
+    /// The persistent store opened normally on the first attempt.
+    case persistent
+    /// The persistent store was corrupt/un-migratable; the on-disk files were
+    /// deleted and a fresh persistent store was created. Local history was lost.
+    case recoveredAfterReset
+    /// The persistent store could not be opened or recreated; the app is
+    /// running on an in-memory store. Nothing is persisted across launches.
+    case inMemoryFallback
+}
+
+/// Result of a container build: the container plus how it was obtained.
+struct ModelContainerBuildResult {
+    let container: ModelContainer
+    let resolution: ModelStoreResolution
+}
+
+/// Builds a ``ModelContainer`` with graceful degradation.
+///
+/// Pure and side-effect-injected so the fallback logic is unit-testable without
+/// touching real SwiftData internals: the caller supplies the store URL, a
+/// closure that constructs a persistent container (so a test can make it throw),
+/// a closure that constructs an in-memory container, and the file-removal hook.
+enum ModelContainerFactory {
+
+    /// Sink for diagnostics. The app routes this to Sentry; tests capture it.
+    typealias DiagnosticSink = (_ message: String, _ error: Error) -> Void
+
+    /// Builds the container, applying the C-1 tiered fallback.
+    ///
+    /// - Parameters:
+    ///   - storeURL: location of the persistent store file (`.store`). Its
+    ///     `-shm`/`-wal` siblings are derived from it on reset.
+    ///   - makePersistent: constructs a persistent container at `storeURL`.
+    ///     Throws if the store is corrupt/un-migratable/unwritable.
+    ///   - makeInMemory: constructs an in-memory container (last resort).
+    ///   - removeStoreFiles: deletes the store file and its `-shm`/`-wal`
+    ///     siblings. Must not throw for "already absent".
+    ///   - diagnostics: receives a message + error for each recoverable failure.
+    /// - Returns: the container and the resolution describing how it was built.
+    /// - Throws: ``ModelContainerFactoryError/inMemoryFallbackFailed`` only when
+    ///   even the in-memory store cannot be created — an unrecoverable
+    ///   environment, surfaced to the caller rather than crashed on.
+    static func build(
+        storeURL: URL,
+        makePersistent: (URL) throws -> ModelContainer,
+        makeInMemory: () throws -> ModelContainer,
+        removeStoreFiles: (URL) throws -> Void,
+        diagnostics: DiagnosticSink
+    ) throws -> ModelContainerBuildResult {
+        // Tier 1: persistent store as-is.
+        do {
+            let container = try makePersistent(storeURL)
+            return ModelContainerBuildResult(container: container, resolution: .persistent)
+        } catch {
+            diagnostics("ModelContainer persistent open failed; attempting store reset", error)
+        }
+
+        // Tier 2: delete the on-disk store and retry once. A corrupt or
+        // un-migratable store recovers here at the cost of local history.
+        do {
+            try removeStoreFiles(storeURL)
+            let container = try makePersistent(storeURL)
+            return ModelContainerBuildResult(container: container, resolution: .recoveredAfterReset)
+        } catch {
+            diagnostics("ModelContainer reset+retry failed; falling back to in-memory store", error)
+        }
+
+        // Tier 3: in-memory store. The app stays usable for this session even
+        // if the disk is full or unwritable; nothing persists across launches.
+        do {
+            let container = try makeInMemory()
+            return ModelContainerBuildResult(container: container, resolution: .inMemoryFallback)
+        } catch {
+            diagnostics("ModelContainer in-memory fallback failed", error)
+            throw ModelContainerFactoryError.inMemoryFallbackFailed(error)
+        }
+    }
+
+    /// Deletes the SwiftData store file and its write-ahead-log siblings.
+    /// "File does not exist" is treated as success; other I/O errors propagate.
+    static func defaultRemoveStoreFiles(_ storeURL: URL) throws {
+        let manager = FileManager.default
+        for url in storeSiblingURLs(for: storeURL) where manager.fileExists(atPath: url.path) {
+            try manager.removeItem(at: url)
+        }
+    }
+
+    /// The store file plus its `-shm` and `-wal` companions.
+    static func storeSiblingURLs(for storeURL: URL) -> [URL] {
+        let base = storeURL.path
+        return [storeURL,
+                URL(fileURLWithPath: base + "-shm"),
+                URL(fileURLWithPath: base + "-wal")]
+    }
+}
+
+/// Error thrown only when even the in-memory last resort fails.
+enum ModelContainerFactoryError: Error {
+    case inMemoryFallbackFailed(Error)
+}

--- a/Rivulet/Views/TVNavigation/NavigationEnvironment.swift
+++ b/Rivulet/Views/TVNavigation/NavigationEnvironment.swift
@@ -35,9 +35,15 @@ enum SidebarTab: Hashable {
 /// the root page. A dedicated flag lets us hide the tab bar and block tab
 /// switches while in a Settings sub-page without that race.
 @MainActor
-class NestedNavigationState: ObservableObject {
+final class NestedNavigationState: ObservableObject {
     @Published var isNested: Bool = false
     @Published var isSettingsSubPage: Bool = false
+
+    /// Nonisolated so the value can be constructed for the SwiftUI environment
+    /// default (`EnvironmentKey.defaultValue`, a nonisolated static) without a
+    /// main-actor hop. Only initialises literal-defaulted stored properties; all
+    /// subsequent state access remains main-actor isolated.
+    nonisolated init() {}
 }
 
 /// Environment key for nested navigation state

--- a/RivuletTests/Unit/Services/ModelContainerFactoryTests.swift
+++ b/RivuletTests/Unit/Services/ModelContainerFactoryTests.swift
@@ -1,0 +1,169 @@
+//
+//  ModelContainerFactoryTests.swift
+//  RivuletTests
+//
+//  Reproduces audit finding C-1: a corrupt / un-migratable / unwritable
+//  SwiftData store must NOT crash at launch. These tests drive the tiered
+//  fallback in ModelContainerFactory through injected closures.
+//
+
+import XCTest
+import SwiftData
+@testable import Rivulet
+
+final class ModelContainerFactoryTests: XCTestCase {
+
+    /// A trivial standalone schema so the factory tests don't depend on the
+    /// app's full model graph.
+    @Model
+    final class Probe {
+        var value: Int
+        init(value: Int) { self.value = value }
+    }
+
+    private func memorySchema() -> Schema { Schema([Probe.self]) }
+
+    private func makeInMemoryContainer() throws -> ModelContainer {
+        let config = ModelConfiguration(schema: memorySchema(), isStoredInMemoryOnly: true)
+        return try ModelContainer(for: memorySchema(), configurations: [config])
+    }
+
+    private let dummyURL = URL(fileURLWithPath: "/tmp/rivulet-probe.store")
+
+    struct OpenError: Error {}
+    struct RemoveError: Error {}
+
+    // MARK: - Tier 1
+
+    func test_persistentOpensFirstTry_returnsPersistent() throws {
+        var persistentCalls = 0
+        let result = try ModelContainerFactory.build(
+            storeURL: dummyURL,
+            makePersistent: { _ in
+                persistentCalls += 1
+                return try self.makeInMemoryContainer()
+            },
+            makeInMemory: { XCTFail("in-memory should not be reached"); return try self.makeInMemoryContainer() },
+            removeStoreFiles: { _ in XCTFail("store should not be reset") },
+            diagnostics: { _, _ in XCTFail("no diagnostics on the happy path") }
+        )
+        XCTAssertEqual(result.resolution, .persistent)
+        XCTAssertEqual(persistentCalls, 1)
+    }
+
+    // MARK: - Tier 2
+
+    func test_corruptStore_resetAndRetry_recoversWithoutCrash() throws {
+        var persistentCalls = 0
+        var removeCalled = false
+        var diagnostics: [String] = []
+
+        let result = try ModelContainerFactory.build(
+            storeURL: dummyURL,
+            makePersistent: { _ in
+                persistentCalls += 1
+                // First open fails (corrupt store); after reset it succeeds.
+                if persistentCalls == 1 { throw OpenError() }
+                return try self.makeInMemoryContainer()
+            },
+            makeInMemory: { XCTFail("in-memory should not be reached"); return try self.makeInMemoryContainer() },
+            removeStoreFiles: { url in
+                removeCalled = true
+                XCTAssertEqual(url, self.dummyURL)
+            },
+            diagnostics: { message, _ in diagnostics.append(message) }
+        )
+
+        XCTAssertEqual(result.resolution, .recoveredAfterReset)
+        XCTAssertEqual(persistentCalls, 2, "should retry exactly once after reset")
+        XCTAssertTrue(removeCalled, "store files must be deleted before retry")
+        XCTAssertEqual(diagnostics.count, 1, "the first failure should be reported once")
+    }
+
+    // MARK: - Tier 3
+
+    func test_persistentUnrecoverable_fallsBackToInMemory() throws {
+        var persistentCalls = 0
+        var inMemoryCalled = false
+        var diagnostics: [String] = []
+
+        let result = try ModelContainerFactory.build(
+            storeURL: dummyURL,
+            makePersistent: { _ in
+                persistentCalls += 1
+                throw OpenError()
+            },
+            makeInMemory: {
+                inMemoryCalled = true
+                return try self.makeInMemoryContainer()
+            },
+            removeStoreFiles: { _ in },
+            diagnostics: { message, _ in diagnostics.append(message) }
+        )
+
+        XCTAssertEqual(result.resolution, .inMemoryFallback)
+        XCTAssertEqual(persistentCalls, 2, "tries original then once after reset")
+        XCTAssertTrue(inMemoryCalled)
+        XCTAssertEqual(diagnostics.count, 2, "both persistent failures reported")
+    }
+
+    func test_resetThrows_stillFallsBackToInMemory() throws {
+        var inMemoryCalled = false
+        let result = try ModelContainerFactory.build(
+            storeURL: dummyURL,
+            makePersistent: { _ in throw OpenError() },
+            makeInMemory: {
+                inMemoryCalled = true
+                return try self.makeInMemoryContainer()
+            },
+            removeStoreFiles: { _ in throw RemoveError() },
+            diagnostics: { _, _ in }
+        )
+        XCTAssertEqual(result.resolution, .inMemoryFallback)
+        XCTAssertTrue(inMemoryCalled)
+    }
+
+    func test_everythingFails_throwsInsteadOfCrashing() {
+        XCTAssertThrowsError(
+            try ModelContainerFactory.build(
+                storeURL: dummyURL,
+                makePersistent: { _ in throw OpenError() },
+                makeInMemory: { throw OpenError() },
+                removeStoreFiles: { _ in },
+                diagnostics: { _, _ in }
+            )
+        ) { error in
+            guard case ModelContainerFactoryError.inMemoryFallbackFailed = error else {
+                return XCTFail("expected inMemoryFallbackFailed, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Store file removal
+
+    func test_defaultRemoveStoreFiles_deletesStoreAndWalSiblings() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appending(path: "rivulet-c1-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let storeURL = dir.appending(path: "default.store")
+        let siblings = ModelContainerFactory.storeSiblingURLs(for: storeURL)
+        for url in siblings {
+            try Data("x".utf8).write(to: url)
+            XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+        }
+
+        try ModelContainerFactory.defaultRemoveStoreFiles(storeURL)
+
+        for url in siblings {
+            XCTAssertFalse(FileManager.default.fileExists(atPath: url.path), "\(url.lastPathComponent) should be deleted")
+        }
+    }
+
+    func test_defaultRemoveStoreFiles_isNoOpWhenAbsent() throws {
+        let storeURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appending(path: "rivulet-absent-\(UUID().uuidString).store")
+        XCTAssertNoThrow(try ModelContainerFactory.defaultRemoveStoreFiles(storeURL))
+    }
+}


### PR DESCRIPTION
## What was broken

`RivuletApp.sharedModelContainer` built the SwiftData `ModelContainer` with a single `try ModelContainer(...)` whose only `catch` was `fatalError("Could not create ModelContainer: ...")`. This runs at launch in the `@main App`. A corrupt store, full disk, or failed migration made init throw, turning every launch into a permanent crash with no path to the UI to reset — unusable until the app was reinstalled, which loses all local watch progress. This is audit finding **C-1**.

## What this fixes

Replaces the `fatalError` with a tiered fallback in a new testable `ModelContainerFactory`:

1. Open the persistent store as-is.
2. On failure: log to Sentry, delete `default.store` and its `-shm`/`-wal` siblings, retry once.
3. Still failing: fall back to an in-memory store so the app stays usable for the session.

`fatalError` now only fires if even the in-memory store cannot be created. `ContentView` shows a dismissable non-fatal banner when local history was reset or kept only in memory. The `@Model` types stay registered (hide path), so no drop-entities migration (C-2) is needed.

## Test plan

- `xcodebuild build -scheme Rivulet -destination 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation)'` passes.
- New `ModelContainerFactoryTests` (7 cases) cover all three tiers, the reset-throws path, the exhausted-throws path, and store-file removal. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
