### PR TITLE
System subtitle settings for Rivulet Player (claude)

### DIFF
--- a/Rivulet/Services/Plex/Playback/Subtitles/CaptionAppearance.swift
+++ b/Rivulet/Services/Plex/Playback/Subtitles/CaptionAppearance.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import CoreText
 import MediaAccessibility
 
 // MARK: - CaptionStyle
@@ -16,7 +17,11 @@ struct CaptionStyle: Equatable {
     var backgroundOpacity: Double
 
     /// Font size multiplier derived from the system relative-character-size preference.
+    /// Applied on top of the size Apple bases on the presentation (view) height.
     var fontScale: CGFloat
+
+    /// System caption font descriptor. `nil` falls back to the system sans font.
+    var fontDescriptor: CTFontDescriptor?
 
     /// Text edge (shadow/raised/etc.) style.
     var edge: Edge
@@ -29,13 +34,40 @@ struct CaptionStyle: Equatable {
         case uniform
     }
 
+    /// Builds the SwiftUI font for the system caption settings at a concrete point size.
+    /// Uses the configured caption font descriptor when available.
+    func font(ofSize size: CGFloat) -> Font {
+        if let fontDescriptor {
+            return Font(CTFontCreateWithFontDescriptor(fontDescriptor, size, nil))
+        }
+        return .system(size: size, weight: .medium)
+    }
+
     static let `default` = CaptionStyle(
         foreground: .white,
         backgroundColor: .black,
         backgroundOpacity: 0.75,
         fontScale: 1.0,
+        fontDescriptor: nil,
         edge: .dropShadow
     )
+
+    static func == (lhs: CaptionStyle, rhs: CaptionStyle) -> Bool {
+        lhs.foreground == rhs.foreground
+            && lhs.backgroundColor == rhs.backgroundColor
+            && lhs.backgroundOpacity == rhs.backgroundOpacity
+            && lhs.fontScale == rhs.fontScale
+            && lhs.edge == rhs.edge
+            && descriptorsEqual(lhs.fontDescriptor, rhs.fontDescriptor)
+    }
+
+    private static func descriptorsEqual(_ a: CTFontDescriptor?, _ b: CTFontDescriptor?) -> Bool {
+        switch (a, b) {
+        case (nil, nil): return true
+        case let (l?, r?): return CFEqual(l, r)
+        default: return false
+        }
+    }
 }
 
 // MARK: - CaptionAppearance
@@ -44,10 +76,12 @@ enum CaptionAppearance {
 
     /// Clamps a MediaAccessibility relative-character-size value to a usable font scale.
     ///
-    /// The MA API returns a relative adjustment (e.g. -0.5, 0, 0.5). This converts it
-    /// to a multiplicative scale factor in [0.5, 2.0].
+    /// `MACaptionAppearanceGetRelativeCharacterSize` already returns the size as a
+    /// multiplicative scale factor (≈1.0 at the default), NOT an offset — so it is
+    /// used directly. A non-positive value means "unset"; treat that as 1.0.
     static func fontScale(forRelativeSize relative: CGFloat) -> CGFloat {
-        min(max(1.0 + relative, 0.5), 2.0)
+        guard relative > 0 else { return 1.0 }
+        return min(max(relative, 0.5), 2.0)
     }
 
     /// Reads the current system caption style from MediaAccessibility.
@@ -61,16 +95,27 @@ enum CaptionAppearance {
         let fgUnmanaged = MACaptionAppearanceCopyForegroundColor(.user, &behavior)
         let foreground = Color(fgUnmanaged.takeRetainedValue() as CGColor)
 
-        // Background color
-        let bgUnmanaged = MACaptionAppearanceCopyBackgroundColor(.user, &behavior)
-        let bgColor = Color(bgUnmanaged.takeRetainedValue() as CGColor)
-
-        // Background opacity
+        // Background color + opacity — the box drawn directly behind the glyphs.
+        let bgCG = MACaptionAppearanceCopyBackgroundColor(.user, &behavior).takeRetainedValue()
         let bgOpacity = Double(MACaptionAppearanceGetBackgroundOpacity(.user, &behavior))
+
+        // Window color + opacity — the larger region box. Several built-in styles
+        // express their "background" via the window rather than the character
+        // background, so fall back to it when the character background is clear.
+        let windowCG = MACaptionAppearanceCopyWindowColor(.user, &behavior).takeRetainedValue()
+        let windowOpacity = Double(MACaptionAppearanceGetWindowOpacity(.user, &behavior))
+
+        let useWindow = bgOpacity <= 0.01 && windowOpacity > 0.01
+        let backgroundColor = Color(useWindow ? windowCG : bgCG)
+        let backgroundOpacity = useWindow ? windowOpacity : bgOpacity
 
         // Font scale
         let relative = MACaptionAppearanceGetRelativeCharacterSize(.user, &behavior)
         let scale = fontScale(forRelativeSize: relative)
+
+        // Font (system caption font descriptor)
+        let fontDescriptor = MACaptionAppearanceCopyFontDescriptorForStyle(.user, &behavior, .default)
+            .takeRetainedValue()
 
         // Edge style
         let maEdge = MACaptionAppearanceGetTextEdgeStyle(.user, &behavior)
@@ -83,11 +128,20 @@ enum CaptionAppearance {
         default:          edge = .none
         }
 
+        #if DEBUG
+        print("""
+        [CaptionAppearance] relative=\(relative) scale=\(scale) \
+        bgOpacity=\(bgOpacity) windowOpacity=\(windowOpacity) \
+        usingWindow=\(useWindow) effectiveBgOpacity=\(backgroundOpacity) edge=\(edge)
+        """)
+        #endif
+
         return CaptionStyle(
             foreground: foreground,
-            backgroundColor: bgColor,
-            backgroundOpacity: bgOpacity,
+            backgroundColor: backgroundColor,
+            backgroundOpacity: backgroundOpacity,
             fontScale: scale,
+            fontDescriptor: fontDescriptor,
             edge: edge
         )
     }

--- a/Rivulet/Services/Plex/Playback/Subtitles/SubtitleOverlayView.swift
+++ b/Rivulet/Services/Plex/Playback/Subtitles/SubtitleOverlayView.swift
@@ -89,10 +89,10 @@ private struct SubtitleTextView: View {
         // The system background box is applied for every edge style (it stays
         // invisible when the system background opacity is 0 — honoring "no box").
         styledText
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
+            .padding(.horizontal, 4)
+            .padding(.vertical, 2)
             .background(
-                RoundedRectangle(cornerRadius: 4)
+                RoundedRectangle(cornerRadius: 6)
                     .fill(style.backgroundColor.opacity(style.backgroundOpacity))
             )
     }

--- a/Rivulet/Services/Plex/Playback/Subtitles/SubtitleOverlayView.swift
+++ b/Rivulet/Services/Plex/Playback/Subtitles/SubtitleOverlayView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import CoreGraphics
+import UIKit
 
 /// Overlay view that displays current subtitle cues
 struct SubtitleOverlayView: View {
@@ -14,6 +15,20 @@ struct SubtitleOverlayView: View {
 
     /// Vertical offset from bottom (for player controls)
     var bottomOffset: CGFloat = 100
+
+    /// Current system caption appearance. Replaced wholesale when the user
+    /// changes caption settings (via CaptionAppearance.changedNotification).
+    @State private var captionStyle: CaptionStyle = CaptionAppearance.current()
+
+    /// Base caption point size at the system's default size preference (tvOS points).
+    /// The system size preference (`fontScale`) multiplies this — e.g. "extra small"
+    /// scales it down, "extra large" up. Anchored to a fixed point size rather than a
+    /// fraction of the overlay height, which is not a reliable 1080-point surface.
+    private static let baseFontSize: CGFloat = 42
+
+    private var captionFont: Font {
+        captionStyle.font(ofSize: Self.baseFontSize * captionStyle.fontScale)
+    }
 
     var body: some View {
         GeometryReader { geometry in
@@ -37,7 +52,7 @@ struct SubtitleOverlayView: View {
                     if !subtitleManager.currentCues.isEmpty {
                         VStack(spacing: 4) {
                             ForEach(subtitleManager.currentCues) { cue in
-                                SubtitleTextView(text: cue.text)
+                                SubtitleTextView(text: cue.text, font: captionFont, style: captionStyle)
                             }
                         }
                         .padding(.horizontal, 60)
@@ -48,30 +63,75 @@ struct SubtitleOverlayView: View {
             }
         }
         .allowsHitTesting(false)  // Don't interfere with player controls
+        .onAppear { captionStyle = CaptionAppearance.current() }
+        .onReceive(NotificationCenter.default.publisher(for: CaptionAppearance.changedNotification)) { _ in
+            captionStyle = CaptionAppearance.current()
+        }
+        // Settings can change while the app is suspended; re-read on foreground.
+        .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
+            captionStyle = CaptionAppearance.current()
+        }
     }
 }
 
-/// Individual subtitle text with styling
+/// Individual subtitle text styled from the system caption appearance settings.
 private struct SubtitleTextView: View {
     let text: String
 
+    /// Resolved caption font (system font descriptor at the size Apple bases on the
+    /// presentation height, scaled by the system size preference).
+    let font: Font
+
+    /// System caption appearance (foreground/background/edge).
+    let style: CaptionStyle
+
     var body: some View {
-        Text(text)
-            .font(.system(size: subtitleFontSize, weight: .medium))
-            .foregroundColor(.white)
-            .multilineTextAlignment(.center)
-            .lineLimit(4)
-            .padding(.horizontal, 16)
-            .padding(.vertical, 8)
+        // The system background box is applied for every edge style (it stays
+        // invisible when the system background opacity is 0 — honoring "no box").
+        styledText
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
             .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(Color.black.opacity(0.75))
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(style.backgroundColor.opacity(style.backgroundOpacity))
             )
-            .shadow(color: .black.opacity(0.5), radius: 4, x: 0, y: 2)
     }
 
-    private var subtitleFontSize: CGFloat {
-        return 42
+    /// The text with its system edge treatment (outline / drop shadow / plain).
+    @ViewBuilder
+    private var styledText: some View {
+        switch style.edge {
+        case .uniform:
+            // 8-direction black outline (no per-character stroke on tvOS).
+            let offsets: [(CGFloat, CGFloat)] = [
+                (-2, -2), ( 0, -2), ( 2, -2),
+                (-2,  0),           ( 2,  0),
+                (-2,  2), ( 0,  2), ( 2,  2)
+            ]
+            ZStack {
+                ForEach(Array(offsets.enumerated()), id: \.offset) { _, delta in
+                    base
+                        .foregroundColor(.black)
+                        .offset(x: delta.0, y: delta.1)
+                }
+                base.foregroundColor(style.foreground)
+            }
+
+        case .dropShadow:
+            base
+                .foregroundColor(style.foreground)
+                .shadow(color: .black.opacity(0.85), radius: 3, x: 0, y: 1)
+
+        default:
+            base.foregroundColor(style.foreground)
+        }
+    }
+
+    private var base: some View {
+        Text(text)
+            .font(font)
+            .multilineTextAlignment(.center)
+            .lineLimit(4)
     }
 }
 


### PR DESCRIPTION
Done via claude.

Rivulet Player now gets its font/size/background/colour/outline settings from the Apple TV system settings.

Also adjusted background to be tighter around the text to be closer to the native apple subtitles.

