### PR TITLE
Live TV overhaul

### DIFF
--- a/Rivulet/Info.plist
+++ b/Rivulet/Info.plist
@@ -15,11 +15,21 @@
 			</array>
 		</dict>
 	</array>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<!-- Users connect to their own media servers (a Plex server, or an IPTV/M3U
+	     provider they subscribe to). These are commonly reached over HTTP on a local
+	     network or a self-hosted box without a TLS certificate, so arbitrary loads are
+	     required to support user-supplied endpoints. -->
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
 	</dict>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Rivulet connects to media servers on your local network, such as your Plex server, to stream your library.</string>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>com.rivulet.viewMedia</string>

--- a/Rivulet/Info.plist
+++ b/Rivulet/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>AVInitialRouteSharingPolicy</key>
+	<string>LongFormAudio</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -13,31 +15,20 @@
 			</array>
 		</dict>
 	</array>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
-	<!-- Users connect to their own media servers (a Plex server, or an IPTV/M3U
-	     provider they subscribe to). These are commonly reached over HTTP on a local
-	     network or a self-hosted box without a TLS certificate, so arbitrary loads are
-	     required to support user-supplied endpoints. -->
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
-		<key>NSAllowsLocalNetworking</key>
-		<true/>
 	</dict>
-	<key>NSLocalNetworkUsageDescription</key>
-	<string>Rivulet connects to media servers on your local network, such as your Plex server, to stream your library.</string>
-	<key>AVInitialRouteSharingPolicy</key>
-	<string>LongFormAudio</string>
-	<key>UIBackgroundModes</key>
-	<array>
-		<string>audio</string>
-	</array>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>com.rivulet.viewMedia</string>
 		<string>com.rivulet.playMedia</string>
+	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+		<string>picture-in-picture</string>
 	</array>
 </dict>
 </plist>

--- a/Rivulet/Models/Plex/PlexLiveTVModels.swift
+++ b/Rivulet/Models/Plex/PlexLiveTVModels.swift
@@ -121,6 +121,8 @@ nonisolated struct PlexLiveTVProgram: Codable, Identifiable, Sendable {
     let summary: String?
     let thumb: String?
     let art: String?
+    let grandparentThumb: String?
+    let grandparentArt: String?
     let year: Int?
     let originallyAvailableAt: String?
     let beginsAt: Int?           // Unix timestamp
@@ -265,13 +267,18 @@ extension PlexLiveTVChannel {
             URLQueryItem(name: "segmentFormat", value: "mpegts"),
             URLQueryItem(name: "segmentContainer", value: "mpegts"),
 
-            // Playback mode - for Live TV we need transcode, not direct play
+            // Playback mode - DIRECT STREAM: the server remuxes the tuner feed
+            // (no re-encode; the codec lists below declare the raw broadcast
+            // codecs as acceptable) and AetherEngine demuxes it client-side.
+            // directPlay stays off — the universal endpoint refuses to build a
+            // session when it decides direct play.
             URLQueryItem(name: "directPlay", value: "0"),
             URLQueryItem(name: "directStream", value: "1"),
             URLQueryItem(name: "directStreamAudio", value: "1"),
 
-            // Video settings - Apple TV 4K supports up to 4K HEVC/H.264
-            URLQueryItem(name: "videoCodec", value: "h264,hevc"),
+            // Video settings - include mpeg2video so DVB broadcasts direct-play
+            // instead of forcing a video transcode (Aether software-decodes it)
+            URLQueryItem(name: "videoCodec", value: "h264,hevc,mpeg2video"),
             URLQueryItem(name: "videoResolution", value: "1920x1080"),
             URLQueryItem(name: "maxVideoBitrate", value: "20000"),
             URLQueryItem(name: "videoQuality", value: "100"),
@@ -279,8 +286,8 @@ extension PlexLiveTVChannel {
             // HLS segment settings
             URLQueryItem(name: "segmentDuration", value: "6"),
 
-            // Audio settings - support common formats
-            URLQueryItem(name: "audioCodec", value: "aac,ac3,eac3"),
+            // Audio settings - include mp2/mp3 (common on DVB) for direct play
+            URLQueryItem(name: "audioCodec", value: "aac,ac3,eac3,mp2,mp3"),
             URLQueryItem(name: "audioBitrate", value: "384"),
             URLQueryItem(name: "audioChannels", value: "6"),
 
@@ -342,9 +349,11 @@ extension PlexLiveTVChannel {
         // Each profile directive is separated by "+"
         // These are URL-encoded when added to the query string
         let profiles = [
-            // Direct play profiles - what we can play without transcoding
-            "add-direct-play-profile(type=videoProfile&protocol=http&container=mpegts&videoCodec=h264,hevc&audioCodec=aac,ac3,eac3)",
-            "add-direct-play-profile(type=videoProfile&protocol=hls&container=mpegts&videoCodec=h264,hevc&audioCodec=aac,ac3,eac3)",
+            // Direct play profiles - what we can play without transcoding.
+            // AetherEngine demuxes MPEG-TS and software-decodes MPEG-2, so
+            // declare the raw DVB codecs too and let Plex skip the transcoder.
+            "add-direct-play-profile(type=videoProfile&protocol=http&container=mpegts&videoCodec=h264,hevc,mpeg2video&audioCodec=aac,ac3,eac3,mp2,mp3)",
+            "add-direct-play-profile(type=videoProfile&protocol=hls&container=mpegts&videoCodec=h264,hevc,mpeg2video&audioCodec=aac,ac3,eac3,mp2,mp3)",
 
             // Transcode target - how to transcode if needed
             "add-transcode-target(type=videoProfile&context=streaming&protocol=hls&container=mpegts&videoCodec=h264,hevc&audioCodec=aac,ac3,eac3&replace=true)",
@@ -459,13 +468,22 @@ extension PlexLiveTVChannel {
 }
 
 extension PlexLiveTVProgram {
-    /// Convert to UnifiedProgram
-    func toUnifiedProgram(unifiedChannelId: String) -> UnifiedProgram? {
+    /// Convert to UnifiedProgram. Plex EPG supplies two images we map to the
+    /// guide's artwork slots: `thumb` (2:3 poster) and `art` (16:9 background).
+    /// Both are resolved to full URLs (absolute passthrough, or Plex server path
+    /// + token) so they work the same as the XMLTV `posterURL` / `landscapeURL`.
+    func toUnifiedProgram(unifiedChannelId: String, serverURL: String, authToken: String) -> UnifiedProgram? {
         guard let start = startDate, let end = endDate else {
             return nil
         }
 
         let programId = "\(unifiedChannelId):\(beginsAt ?? 0)"
+
+        // Prefer the programme's own artwork, falling back to the show's
+        // (grandparent) poster/art, which Plex often populates when the
+        // per-episode image is missing.
+        let poster = Self.plexImageURL(thumb ?? grandparentThumb, serverURL: serverURL, authToken: authToken)
+        let background = Self.plexImageURL(art ?? grandparentArt, serverURL: serverURL, authToken: authToken)
 
         return UnifiedProgram(
             id: programId,
@@ -476,9 +494,21 @@ extension PlexLiveTVProgram {
             startTime: start,
             endTime: end,
             category: category,
-            iconURL: thumb.flatMap { URL(string: $0) },
+            iconURL: poster,          // keep icon = poster for existing callers
+            posterURL: poster,        // 2:3 poster (Plex `thumb`)
+            landscapeURL: background, // 16:9 background (Plex `art`)
             episodeNumber: nil,
             isNew: premiere ?? false
         )
+    }
+
+    /// Resolve a Plex image path to a full URL: external http(s) URLs pass
+    /// through; Plex server paths get the server prefix + auth token.
+    private static func plexImageURL(_ path: String?, serverURL: String, authToken: String) -> URL? {
+        guard let path, !path.isEmpty else { return nil }
+        if path.hasPrefix("http://") || path.hasPrefix("https://") {
+            return URL(string: path)
+        }
+        return URL(string: "\(serverURL)\(path)?X-Plex-Token=\(authToken)")
     }
 }

--- a/Rivulet/RivuletApp.swift
+++ b/Rivulet/RivuletApp.swift
@@ -69,6 +69,11 @@ struct RivuletApp: App {
         // window is clean. Trade-off: a crash in the first ~3s is not captured
         // (rare; acceptable given the launch-perf + log-noise win).
         Task.detached(priority: .utility) {
+            // No DSN configured (Secrets.swift is local-only) — skip Sentry
+            // entirely rather than initializing a dead SDK. SentryBridge stays
+            // inactive so breadcrumb/capture calls no-op instead of spamming
+            // "SDK is disabled" fatals.
+            guard !Secrets.sentryDSN.isEmpty else { return }
             try? await Task.sleep(for: .seconds(3))
             SentrySDK.start { options in
                 options.dsn = Secrets.sentryDSN
@@ -114,6 +119,7 @@ struct RivuletApp: App {
                     return SentryEventRedaction.redact(event)
                 }
             }
+            SentryBridge.isActive = true
 
             // Seed the App Hang triage scope so the very first hang event after
             // launch already carries a screen tag. Updated thereafter via

--- a/Rivulet/Services/Diagnostics/SentryBridge.swift
+++ b/Rivulet/Services/Diagnostics/SentryBridge.swift
@@ -17,14 +17,24 @@ import Sentry
 // from any thread, so binding it to the main actor buys nothing and costs a hop
 // on the error path, which is exactly where we least want to perturb timing.
 nonisolated enum SentryBridge {
+    /// Set to true by RivuletApp right after SentrySDK.start. When the SDK was
+    /// never started (no DSN configured), every call must stay clear of
+    /// SentrySDK entirely: a disabled SDK logs a fatal line per call AND lazily
+    /// initializes its DependencyContainer, which touches UIApplication off the
+    /// main thread (Main Thread Checker violation). Written once at startup
+    /// before any meaningful traffic, so the unsynchronized access is benign.
+    nonisolated(unsafe) static var isActive = false
+
     static func addBreadcrumb(_ crumb: Breadcrumb) {
         #if !DEBUG
+        guard isActive else { return }
         SentrySDK.addBreadcrumb(crumb)
         #endif
     }
 
     static func capture(error: Error, configure: ((Scope) -> Void)? = nil) {
         #if !DEBUG
+        guard isActive else { return }
         if let configure {
             SentrySDK.capture(error: error) { configure($0) }
         } else {
@@ -35,12 +45,14 @@ nonisolated enum SentryBridge {
 
     static func capture(event: Event) {
         #if !DEBUG
+        guard isActive else { return }
         SentrySDK.capture(event: event)
         #endif
     }
 
     static func configureScope(_ configure: @escaping (Scope) -> Void) {
         #if !DEBUG
+        guard isActive else { return }
         SentrySDK.configureScope(configure)
         #endif
     }

--- a/Rivulet/Services/IPTV/M3UParser.swift
+++ b/Rivulet/Services/IPTV/M3UParser.swift
@@ -38,36 +38,12 @@ actor M3UParser {
     /// - Parameter url: URL to the M3U playlist
     /// - Returns: Array of parsed channels
     func parse(from url: URL) async throws -> [ParsedChannel] {
-        let (data, _) = try await fetchWithHTTPSUpgrade(url: url)
+        // Fetch the URL exactly as supplied — http stays http (no https rewrite).
+        let (data, _) = try await fetchData(from: url)
         return try parse(data: data)
     }
 
     // MARK: - Private Networking
-
-    /// Fetch data from URL, attempting HTTPS upgrade for HTTP URLs
-    /// - Parameter url: The URL to fetch from
-    /// - Returns: The fetched data and response
-    private func fetchWithHTTPSUpgrade(url: URL) async throws -> (Data, URLResponse) {
-        // If already HTTPS or not HTTP, use as-is
-        guard url.scheme == "http",
-              var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
-            return try await fetchData(from: url)
-        }
-
-        // Try HTTPS first with a short timeout
-        components.scheme = "https"
-        if let httpsURL = components.url {
-            do {
-                return try await fetchData(from: httpsURL, timeout: 3.0)
-            } catch {
-                // HTTPS failed, fall back to HTTP
-                print("📺 M3UParser: HTTPS failed for \(httpsURL.host ?? "unknown"), falling back to HTTP")
-            }
-        }
-
-        // Fall back to original HTTP URL
-        return try await fetchData(from: url)
-    }
 
     /// Fetch data from a URL with optional custom timeout
     private func fetchData(from url: URL, timeout: TimeInterval? = nil) async throws -> (Data, URLResponse) {

--- a/Rivulet/Services/IPTV/XMLTVParser.swift
+++ b/Rivulet/Services/IPTV/XMLTVParser.swift
@@ -29,6 +29,10 @@ actor XMLTVParser {
         let description: String?
         let category: String?
         let icon: String?
+        /// Programme icon closest to 2:3 (portrait), for the guide poster.
+        let posterIcon: String?
+        /// Programme icon closest to 16:9 (landscape), for the guide background.
+        let landscapeIcon: String?
         let episodeNum: String?
         let isNew: Bool
     }
@@ -44,34 +48,12 @@ actor XMLTVParser {
 
     /// Parse XMLTV data from a URL
     func parse(from url: URL) async throws -> ParseResult {
-        let (data, _) = try await fetchWithHTTPSUpgrade(url: url)
+        // Fetch the URL exactly as supplied — http stays http (no https rewrite).
+        let (data, _) = try await fetchData(from: url)
         return try parse(data: data)
     }
 
     // MARK: - Private Networking
-
-    /// Fetch data from URL, attempting HTTPS upgrade for HTTP URLs
-    private func fetchWithHTTPSUpgrade(url: URL) async throws -> (Data, URLResponse) {
-        // If already HTTPS or not HTTP, use as-is
-        guard url.scheme == "http",
-              var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
-            return try await fetchData(from: url)
-        }
-
-        // Try HTTPS first with a short timeout
-        components.scheme = "https"
-        if let httpsURL = components.url {
-            do {
-                return try await fetchData(from: httpsURL, timeout: 3.0)
-            } catch {
-                // HTTPS failed, fall back to HTTP
-                print("📺 XMLTVParser: HTTPS failed for \(httpsURL.host ?? "unknown"), falling back to HTTP")
-            }
-        }
-
-        // Fall back to original HTTP URL
-        return try await fetchData(from: url)
-    }
 
     /// Fetch data from a URL with optional custom timeout
     private func fetchData(from url: URL, timeout: TimeInterval? = nil) async throws -> (Data, URLResponse) {
@@ -136,6 +118,9 @@ private class XMLTVInternalParser: NSObject, XMLParserDelegate {
     private var currentDescription: String = ""
     private var currentCategory: String = ""
     private var currentProgramIcon: String?
+    /// All <icon> elements seen for the current programme, with dimensions when
+    /// supplied, so we can pick a 2:3 poster and a 16:9 background.
+    private var currentProgramIcons: [(url: String, w: Int?, h: Int?)] = []
     private var currentEpisodeNum: String = ""
     private var currentIsNew: Bool = false
 
@@ -175,6 +160,7 @@ private class XMLTVInternalParser: NSObject, XMLParserDelegate {
             currentDescription = ""
             currentCategory = ""
             currentProgramIcon = nil
+            currentProgramIcons = []
             currentEpisodeNum = ""
             currentIsNew = false
 
@@ -182,8 +168,11 @@ private class XMLTVInternalParser: NSObject, XMLParserDelegate {
             let src = attributeDict["src"]
             if currentChannelId != nil {
                 currentIconURL = src
-            } else if currentProgramChannelId != nil {
-                currentProgramIcon = src
+            } else if currentProgramChannelId != nil, let src {
+                if currentProgramIcon == nil { currentProgramIcon = src }
+                currentProgramIcons.append((url: src,
+                                            w: attributeDict["width"].flatMap { Int($0) },
+                                            h: attributeDict["height"].flatMap { Int($0) }))
             }
 
         case "new":
@@ -245,6 +234,8 @@ private class XMLTVInternalParser: NSObject, XMLParserDelegate {
                     description: currentDescription.isEmpty ? nil : currentDescription,
                     category: currentCategory.isEmpty ? nil : currentCategory,
                     icon: currentProgramIcon,
+                    posterIcon: Self.posterIcon(from: currentProgramIcons),
+                    landscapeIcon: Self.landscapeIcon(from: currentProgramIcons),
                     episodeNum: currentEpisodeNum.isEmpty ? nil : currentEpisodeNum,
                     isNew: currentIsNew
                 )
@@ -265,6 +256,35 @@ private class XMLTVInternalParser: NSObject, XMLParserDelegate {
 
     func parser(_ parser: XMLParser, parseErrorOccurred parseError: Error) {
         self.parseError = parseError
+    }
+
+    /// Programme poster: the icon closest to 2:3 (portrait) when dimensions are
+    /// given, otherwise the first icon so the poster always has something to
+    /// show (it's fit into a 2:3 frame, so any aspect is fine).
+    static func posterIcon(from icons: [(url: String, w: Int?, h: Int?)]) -> String? {
+        guard !icons.isEmpty else { return nil }
+        let sized = icons.compactMap { icon -> (url: String, ratio: Double)? in
+            guard let w = icon.w, let h = icon.h, h > 0 else { return nil }
+            return (icon.url, Double(w) / Double(h))
+        }
+        if let best = sized.min(by: { abs($0.ratio - 2.0 / 3.0) < abs($1.ratio - 2.0 / 3.0) }) {
+            return best.url
+        }
+        return icons.first?.url
+    }
+
+    /// Programme background: ONLY an icon that is genuinely landscape (declared
+    /// dimensions with aspect ratio ≥ 1.3). Icons without dimensions, or
+    /// square/portrait ones (e.g. a channel logo used as the programme icon),
+    /// are never treated as a background — so the backdrop stays empty (stock
+    /// background) rather than showing a stretched logo.
+    static func landscapeIcon(from icons: [(url: String, w: Int?, h: Int?)]) -> String? {
+        let landscape = icons.compactMap { icon -> (url: String, ratio: Double)? in
+            guard let w = icon.w, let h = icon.h, h > 0 else { return nil }
+            let ratio = Double(w) / Double(h)
+            return ratio >= 1.3 ? (icon.url, ratio) : nil
+        }
+        return landscape.min(by: { abs($0.ratio - 16.0 / 9.0) < abs($1.ratio - 16.0 / 9.0) })?.url
     }
 
     // MARK: - Helpers
@@ -340,6 +360,8 @@ extension XMLTVParser.ParsedProgram {
             endTime: stop,
             category: category,
             iconURL: icon.flatMap { URL(string: $0) },
+            posterURL: posterIcon.flatMap { URL(string: $0) },
+            landscapeURL: landscapeIcon.flatMap { URL(string: $0) },
             episodeNumber: episodeNum,
             isNew: isNew
         )

--- a/Rivulet/Services/LiveTV/IPTVProvider.swift
+++ b/Rivulet/Services/LiveTV/IPTVProvider.swift
@@ -34,6 +34,11 @@ actor IPTVProvider: LiveTVProvider {
     // Cached data
     private var cachedChannels: [UnifiedChannel] = []
     private var cachedEPG: [String: [UnifiedProgram]] = [:]
+
+    /// Channel logos parsed from XMLTV `<channel><icon>`, keyed by unified
+    /// channel id. Surfaced via `channelLogosFromEPG()` so the data store can
+    /// fill in artwork the M3U playlist didn't provide.
+    private var cachedChannelLogos: [String: URL] = [:]
     private var lastChannelFetch: Date?
     private var lastEPGFetch: Date?
 
@@ -230,12 +235,27 @@ actor IPTVProvider: LiveTVProvider {
             unifiedEPG[unifiedChannelId] = unifiedPrograms
         }
 
+        // Capture channel logos from the XMLTV `<channel><icon>` elements,
+        // mapped onto our unified channel ids. These let the guide show channel
+        // artwork even when the M3U playlist had no `tvg-logo`.
+        var channelLogos: [String: URL] = [:]
+        for (xmltvChannelId, parsedChannel) in parseResult.channels {
+            guard let unifiedChannelId = tvgIdToUnifiedId[xmltvChannelId],
+                  let iconString = parsedChannel.iconURL,
+                  let iconURL = URL(string: iconString) else { continue }
+            channelLogos[unifiedChannelId] = iconURL
+        }
+
         // Update cache
         cachedEPG = unifiedEPG
+        cachedChannelLogos = channelLogos
         lastEPGFetch = Date()
 
         return filterEPG(unifiedEPG, channels: channels, startDate: startDate, endDate: endDate)
     }
+
+    /// Channel logos discovered in the XMLTV data (keyed by unified channel id).
+    func channelLogosFromEPG() async -> [String: URL] { cachedChannelLogos }
 
     func getCurrentProgram(for channel: UnifiedChannel) async -> UnifiedProgram? {
         guard let programs = cachedEPG[channel.id] else {

--- a/Rivulet/Services/LiveTV/LiveTVDataStore.swift
+++ b/Rivulet/Services/LiveTV/LiveTVDataStore.swift
@@ -465,6 +465,10 @@ class LiveTVDataStore: ObservableObject {
             acc[entry.key] = entry.value.displayName
         }
 
+        // Snapshot providers so we can gather XMLTV channel logos after the EPG
+        // fetch without touching the @MainActor providers dictionary post-suspension.
+        let providerList = Array(providers.values)
+
         epgLoadTask = Task {
             var allEPG: [String: [UnifiedProgram]] = [:]
             var issues: [EPGFetchIssue] = []
@@ -501,6 +505,13 @@ class LiveTVDataStore: ObservableObject {
                             allEPG[channelId] = programs
                         }
                     case .failure(let error):
+                        // A superseding loadEPG cancels this task, which
+                        // surfaces as NSURLError -999 / CancellationError in
+                        // the fetch. That's not a source failure — don't show
+                        // it in the guide banner.
+                        if error is CancellationError || (error as NSError).code == NSURLErrorCancelled {
+                            continue
+                        }
                         print("📺 LiveTVDataStore: ⚠️ EPG load failed for \(sourceId): \(error)")
                         let sourceName = sourceNames[sourceId] ?? sourceId
                         issues.append(EPGFetchIssue(
@@ -512,14 +523,55 @@ class LiveTVDataStore: ObservableObject {
                 }
             }
 
+            // Gather channel logos discovered in the XMLTV data so the guide can
+            // show channel artwork even when the M3U had no `tvg-logo`.
+            var xmltvLogos: [String: URL] = [:]
+            for provider in providerList {
+                let logos = await provider.channelLogosFromEPG()
+                xmltvLogos.merge(logos) { existing, _ in existing }
+            }
+
+            // A cancelled (superseded) task must NOT publish: its empty/partial
+            // results would clobber whatever the newer loadEPG task wrote.
+            guard !Task.isCancelled else { return }
+
+            let finalEPG = allEPG
+            let finalIssues = issues
+            let finalLogos = xmltvLogos
             await MainActor.run {
-                self.epg = allEPG
+                self.epg = finalEPG
                 self.isLoadingEPG = false
-                self.epgIssues = issues
+                self.epgIssues = finalIssues
+                self.applyXMLTVChannelLogos(finalLogos)
             }
         }
 
         await epgLoadTask?.value
+    }
+
+    /// Fills in channel artwork from XMLTV `<channel><icon>` logos for any
+    /// channel that didn't get a logo from its M3U `tvg-logo`.
+    private func applyXMLTVChannelLogos(_ logos: [String: URL]) {
+        guard !logos.isEmpty else { return }
+        var didChange = false
+        let updated = channels.map { channel -> UnifiedChannel in
+            guard channel.logoURL == nil, let logo = logos[channel.id] else { return channel }
+            didChange = true
+            return UnifiedChannel(
+                id: channel.id,
+                sourceType: channel.sourceType,
+                sourceId: channel.sourceId,
+                channelNumber: channel.channelNumber,
+                name: channel.name,
+                callSign: channel.callSign,
+                logoURL: logo,
+                streamURL: channel.streamURL,
+                tvgId: channel.tvgId,
+                groupTitle: channel.groupTitle,
+                isHD: channel.isHD
+            )
+        }
+        if didChange { channels = updated }
     }
 
     /// Converts a thrown EPG fetch error into a short, user-readable phrase
@@ -682,6 +734,17 @@ class LiveTVDataStore: ObservableObject {
     // MARK: - Stream URL
 
     /// Build the stream URL for a channel
+    /// Resolve a PLAYABLE stream URL, performing any provider-side session
+    /// setup first (Plex cloud-EPG/DVB channels need a tune before the
+    /// transcoder will serve them). Prefer this over `buildStreamURL(for:)`
+    /// at playback time; the sync variant remains for availability checks.
+    func resolveStreamURL(for channel: UnifiedChannel) async -> URL? {
+        guard let provider = providers[channel.sourceId] else {
+            return channel.streamURL
+        }
+        return await provider.resolveStreamURL(for: channel)
+    }
+
     func buildStreamURL(for channel: UnifiedChannel) -> URL? {
         guard let provider = providers[channel.sourceId] else {
             // No provider found - fallback to channel's embedded stream URL

--- a/Rivulet/Services/LiveTV/LiveTVProvider.swift
+++ b/Rivulet/Services/LiveTV/LiveTVProvider.swift
@@ -93,6 +93,10 @@ struct UnifiedProgram: Identifiable, Hashable, Sendable {
     let endTime: Date
     let category: String?
     let iconURL: URL?
+    /// Preferred 2:3 (portrait) artwork for the guide poster, if the EPG offers one.
+    let posterURL: URL?
+    /// Preferred 16:9 (landscape) artwork for the guide background, if offered.
+    let landscapeURL: URL?
     let episodeNumber: String?
     let isNew: Bool
 
@@ -106,6 +110,8 @@ struct UnifiedProgram: Identifiable, Hashable, Sendable {
         endTime: Date,
         category: String? = nil,
         iconURL: URL? = nil,
+        posterURL: URL? = nil,
+        landscapeURL: URL? = nil,
         episodeNumber: String? = nil,
         isNew: Bool = false
     ) {
@@ -118,6 +124,8 @@ struct UnifiedProgram: Identifiable, Hashable, Sendable {
         self.endTime = endTime
         self.category = category
         self.iconURL = iconURL
+        self.posterURL = posterURL
+        self.landscapeURL = landscapeURL
         self.episodeNumber = episodeNumber
         self.isNew = isNew
     }
@@ -185,6 +193,26 @@ protocol LiveTVProvider: Sendable {
 
     /// Build the stream URL for a channel (may add auth tokens, etc.)
     func buildStreamURL(for channel: UnifiedChannel) -> URL?
+
+    /// Resolve a PLAYABLE stream URL, performing any server-side session setup
+    /// first (e.g. the Plex Live TV tune step for cloud-EPG/DVB DVRs). Defaults
+    /// to `buildStreamURL(for:)` for providers with directly playable URLs.
+    func resolveStreamURL(for channel: UnifiedChannel) async -> URL?
+
+    /// Channel logos discovered in the EPG/XMLTV data, keyed by unified channel
+    /// id. Used to fill in channel artwork when the playlist (M3U) didn't supply
+    /// a `tvg-logo`. Defaults to empty for sources without XMLTV channel icons.
+    func channelLogosFromEPG() async -> [String: URL]
+}
+
+extension LiveTVProvider {
+    /// Default: no XMLTV channel logos available.
+    func channelLogosFromEPG() async -> [String: URL] { [:] }
+
+    /// Default: the built URL is directly playable.
+    func resolveStreamURL(for channel: UnifiedChannel) async -> URL? {
+        buildStreamURL(for: channel)
+    }
 }
 
 // MARK: - Provider Errors

--- a/Rivulet/Services/LiveTV/PlexLiveTVProvider.swift
+++ b/Rivulet/Services/LiveTV/PlexLiveTVProvider.swift
@@ -441,7 +441,6 @@ actor PlexLiveTVProvider: LiveTVProvider {
                 with: "start.ts"
             )
             if let tsURL = components.url {
-                print("📺 PlexLiveTVProvider: playing tuned session as continuous HTTP TS, directPlay allowed (\(String(tune.sessionUUID.prefix(8)))…)")
                 return tsURL
             }
             return base

--- a/Rivulet/Services/LiveTV/PlexLiveTVProvider.swift
+++ b/Rivulet/Services/LiveTV/PlexLiveTVProvider.swift
@@ -251,7 +251,7 @@ actor PlexLiveTVProvider: LiveTVProvider {
             matchedChannels += 1
 
             let unifiedPrograms = programs.compactMap { plexProgram -> UnifiedProgram? in
-                let result = plexProgram.toUnifiedProgram(unifiedChannelId: unifiedChannelId)
+                let result = plexProgram.toUnifiedProgram(unifiedChannelId: unifiedChannelId, serverURL: serverURL, authToken: authToken)
                 if result == nil {
                     print("📺 PlexLiveTVProvider: ⚠️ Failed to convert program '\(plexProgram.title)' - beginsAt: \(plexProgram.beginsAt as Any), endsAt: \(plexProgram.endsAt as Any)")
                 }
@@ -366,6 +366,95 @@ actor PlexLiveTVProvider: LiveTVProvider {
         SentryBridge.addBreadcrumb(breadcrumb)
 
         return newURL
+    }
+
+    /// Resolve a playable URL. Plex live channels go THROUGH Plex, but as a
+    /// continuous HTTP MPEG-TS stream — not HLS:
+    ///   1. POST /livetv/dvrs/{dvr}/channels/{id}/tune → livetv session uuid
+    ///   2. GET /video/:/transcode/universal/start.ts?protocol=http&
+    ///      container=mpegts&directPlay=1&directStream=1&
+    ///      path=/livetv/sessions/{uuid}&…
+    /// directPlay=1 asks the server to pass the RAW tuner TS straight through;
+    /// directStream=1 is its own fallback (remux, no re-encode — the client
+    /// profile declares the raw broadcast codecs). "Continuous" refers to the
+    /// HTTP delivery, NOT scan type: the video inside may be interlaced, which
+    /// AetherEngine deinterlaces (bwdif) after demuxing client-side — along
+    /// with the odd subtitle tracks (DVB/teletext). HDHomeRun direct URLs pass
+    /// through untouched (raw TS → same engine path).
+    func resolveStreamURL(for channel: UnifiedChannel) async -> URL? {
+        guard let base = buildStreamURL(for: channel) else { return nil }
+
+        guard var components = URLComponents(url: base, resolvingAgainstBaseURL: false),
+              var queryItems = components.queryItems,
+              let pathIndex = queryItems.firstIndex(where: { $0.name == "path" }),
+              let epgPath = queryItems[pathIndex].value,
+              epgPath.hasPrefix("/tv.plex.providers.epg") else {
+            return base  // Direct URL or non-EPG path — playable as-is.
+        }
+
+        // epgPath = /tv.plex.providers.epg.cloud:157/metadata/<channelId>
+        let parts = epgPath.split(separator: "/")
+        guard parts.count >= 3,
+              let dvrKey = parts[0].split(separator: ":").last.map(String.init) else {
+            return base
+        }
+        let channelId = String(parts[2])
+
+        do {
+            let tune = try await networkManager.tuneLiveTVChannel(
+                serverURL: serverURL,
+                authToken: authToken,
+                dvrKey: dvrKey,
+                channelIdentifier: channelId
+            )
+
+            let breadcrumb = Breadcrumb(level: .info, category: "plex_livetv")
+            breadcrumb.message = "Tuned live channel to /livetv/sessions"
+            breadcrumb.data = [
+                "channel_name": channel.name,
+                "channel_id": channel.id,
+                "dvr_key": dvrKey,
+                "session_uuid": String(tune.sessionUUID.prefix(8))
+            ]
+            SentryBridge.addBreadcrumb(breadcrumb)
+
+            // Continuous HTTP MPEG-TS of the tuned session. Reuse the baked
+            // URL's full client profile (that's what tells the server it can
+            // pass through / remux instead of transcode), swap the endpoint to
+            // start.ts, and flip protocol to http (one stream, no HLS).
+            // directPlay=1 → raw tuner TS when the server allows it, with
+            // directStream=1 (remux) as the server's own fallback. Unlike the
+            // HLS endpoint, direct play is safe here: continuous HTTP has no
+            // segment session to refuse to build.
+            queryItems[pathIndex] = URLQueryItem(name: "path", value: "/livetv/sessions/\(tune.sessionUUID)")
+            queryItems = queryItems.map { item in
+                switch item.name {
+                case "protocol":   return URLQueryItem(name: "protocol", value: "http")
+                case "directPlay": return URLQueryItem(name: "directPlay", value: "1")
+                case "directStream": return URLQueryItem(name: "directStream", value: "1")
+                default:           return item
+                }
+            }
+            components.queryItems = queryItems
+            components.path = components.path.replacingOccurrences(
+                of: "start.m3u8",
+                with: "start.ts"
+            )
+            if let tsURL = components.url {
+                print("📺 PlexLiveTVProvider: playing tuned session as continuous HTTP TS, directPlay allowed (\(String(tune.sessionUUID.prefix(8)))…)")
+                return tsURL
+            }
+            return base
+        } catch {
+            SentryBridge.capture(error: error) { scope in
+                scope.setTag(value: "plex_livetv", key: "component")
+                scope.setExtra(value: channel.name, key: "channel_name")
+                scope.setExtra(value: dvrKey, key: "dvr_key")
+                scope.setExtra(value: "tune_failed", key: "operation")
+            }
+            // Fall back to the untuned URL — some PMS setups accept it.
+            return base
+        }
     }
 
     // MARK: - Private Methods

--- a/Rivulet/Services/Plex/Playback/AetherPlayer.swift
+++ b/Rivulet/Services/Plex/Playback/AetherPlayer.swift
@@ -362,6 +362,81 @@ final class AetherPlayer: PlayerProtocol {
         )
     }
 
+    /// Live TV load. Sets `isLive` so the engine treats the source as live
+    /// (seek becomes a no-op, live-edge/reconnect behavior). HLS sources use
+    /// `nativeRemoteHLS` so AVPlayer plays the remote playlist directly (no
+    /// demuxer probe / loopback — "HLS straight to AVPlayer"); everything else
+    /// (raw MPEG-TS, etc.) goes through the engine's demux/remux to a loopback
+    /// HLS stream. Either way the engine publishes `currentAVPlayer` for the
+    /// AVKit OSD. No start position (live).
+    /// `forceEngineDemux` disables the native-HLS shortcut so the engine's own
+    /// demuxer opens the playlist instead — used as a fallback when AVPlayer's
+    /// native path fails against a server (e.g. a Plex transcode session that
+    /// rejects AVPlayer's request pattern).
+    func loadLive(url: URL, headers: [String: String]?, forceEngineDemux: Bool = false) async throws {
+        let isHLS = Self.isHLSURL(url) && !forceEngineDemux
+        let options = LoadOptions(
+            suppressDisplayCriteria: false,
+            httpHeaders: headers ?? [:],
+            // Same rich config as VOD, plus the live-specific flags.
+            matchContentEnabled: true,
+            panelIsInHDRMode: Self.panelIsInHDRMode(),
+            audioBridgeMode: .lossless,
+            isLive: true,
+            // ~30-minute DVR rewind window (engine retains it disk-backed).
+            dvrWindowSeconds: 1800,
+            nativeRemoteHLS: isHLS,
+            preserveASSMarkup: true,
+            probesize: 5 * 1024 * 1024,
+            maxAnalyzeDuration: 5_000_000,
+            // Honor the user's saved audio/subtitle language preferences, same
+            // as VOD, so the right tracks are picked on the first frame.
+            preferredAudioLanguages: Self.livePreferredAudioLanguages(),
+            preferredSubtitleLanguages: Self.livePreferredSubtitleLanguages()
+        )
+        do {
+            // Broadcast H.264 routinely mis-signals interlaced content as
+            // progressive (codecpar fieldOrder=0; MBAFF is only flagged
+            // per-frame), which routes it down the engine's NATIVE path with
+            // no deinterlacer — visible combing. Force the software path for
+            // live demux sessions: bwdif deinterlaces genuinely interlaced
+            // frames and passes true progressive through untouched, so a
+            // correctly-signalled progressive channel only pays a SW decode.
+            // (Engine flag is labeled test-only but is the exact switch for
+            // this; reset immediately after dispatch. Not applied to the
+            // native-HLS shortcut, which never enters the demux dispatch.)
+            if !isHLS { AetherEngine.setForceSoftwarePathForTesting(true) }
+            defer { if !isHLS { AetherEngine.setForceSoftwarePathForTesting(false) } }
+            try await engine.load(url: url, startPosition: nil, options: options)
+        } catch {
+            let pe = PlayerError.loadFailed(String(describing: error))
+            errorSubject.send(pe)
+            throw pe
+        }
+    }
+
+    private static func isHLSURL(_ url: URL) -> Bool {
+        if url.pathExtension.lowercased() == "m3u8" { return true }
+        let text = url.absoluteString.lowercased()
+        return text.contains(".m3u8") || text.contains("format=hls")
+    }
+
+    /// The user's saved audio-language intent (ISO code), if any.
+    private static func livePreferredAudioLanguages() -> [String] {
+        let lang = TrackIntentStore.effectiveAudioIntent.language
+        return lang.isEmpty ? [] : [lang]
+    }
+
+    /// The user's saved subtitle-language intent (ISO code) when subtitles
+    /// are enabled; empty (subtitles off) otherwise.
+    private static func livePreferredSubtitleLanguages() -> [String] {
+        if case .track(let language, _, _, _) = TrackIntentStore.subtitleIntent ?? .off,
+           !language.isEmpty {
+            return [language]
+        }
+        return []
+    }
+
     func load(
         url: URL,
         headers: [String: String]?,

--- a/Rivulet/Services/Plex/PlexNetworkManager.swift
+++ b/Rivulet/Services/Plex/PlexNetworkManager.swift
@@ -1133,40 +1133,18 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
         }
     }
 
-    /// Remove item from the Continue Watching hub without touching its
-    /// watch state (progress/viewCount stay intact — the item is only
-    /// hidden from the hub, matching official Plex clients).
+    /// Remove item from continue watching by marking as unwatched
     func removeFromContinueWatching(
         serverURL: String,
         authToken: String,
         ratingKey: String
     ) async throws {
-        guard var components = URLComponents(string: "\(serverURL)/actions/removeFromContinueWatching") else {
-            throw PlexAPIError.invalidURL
-        }
-
-        components.queryItems = [
-            URLQueryItem(name: "ratingKey", value: ratingKey)
-        ]
-
-        guard let url = components.url else {
-            throw PlexAPIError.invalidURL
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "PUT"
-        for (key, value) in plexHeaders(authToken: authToken) {
-            request.addValue(value, forHTTPHeaderField: key)
-        }
-
-        let (_, response) = try await session.data(for: request)
-        guard let httpResponse = response as? HTTPURLResponse,
-              (200...299).contains(httpResponse.statusCode) else {
-            if let httpResponse = response as? HTTPURLResponse {
-                throw PlexAPIError.httpError(statusCode: httpResponse.statusCode, data: nil)
-            }
-            throw PlexAPIError.invalidResponse
-        }
+        // Mark as unwatched clears all progress and removes from "Continue Watching"
+        try await markUnwatched(
+            serverURL: serverURL,
+            authToken: authToken,
+            ratingKey: ratingKey
+        )
     }
 
     // MARK: - Playlists
@@ -2040,34 +2018,10 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
             return []
         }
 
-        // Get HDHomeRun device URI for stream URLs
-        var hdhrStreamURLs: [String: String] = [:]
-        let hasHDHomeRunDevice = dvr.Device?.first?.uri != nil
-        if let device = dvr.Device?.first, let deviceURI = device.uri {
-            // Log HDHomeRun device discovery (GitHub #64 - DVB diagnostics)
-            let hdhrBreadcrumb = Breadcrumb(level: .info, category: "plex_livetv")
-            hdhrBreadcrumb.message = "Fetching HDHomeRun stream URLs"
-            hdhrBreadcrumb.data = [
-                "device_uri_host": URL(string: deviceURI)?.host ?? "unknown",
-                "dvr_make": dvr.make ?? "unknown",
-                "dvr_model": dvr.model ?? "unknown"
-            ]
-            SentryBridge.addBreadcrumb(hdhrBreadcrumb)
-
-            hdhrStreamURLs = await fetchHDHomeRunLineup(deviceURI: deviceURI)
-        } else {
-            // No HDHomeRun device - likely a DVB tuner (GitHub #64)
-            let dvbBreadcrumb = Breadcrumb(level: .info, category: "plex_livetv")
-            dvbBreadcrumb.message = "No HDHomeRun device found - will use Plex transcode URLs"
-            dvbBreadcrumb.data = [
-                "dvr_make": dvr.make ?? "unknown",
-                "dvr_model": dvr.model ?? "unknown",
-                "dvr_friendly_name": dvr.friendlyName ?? "unknown",
-                "has_device_array": dvr.Device != nil,
-                "device_count": dvr.Device?.count ?? 0
-            ]
-            SentryBridge.addBreadcrumb(dvbBreadcrumb)
-        }
+        // ALL Plex Live TV plays through the Plex server (tune → session).
+        // No direct tuner (HDHomeRun) handoff: raw tuner URLs are LAN-only
+        // and bypass the server's session/tuner management entirely.
+        print("🌐 PlexNetwork: DVR \(dvrKey) make=\(dvr.make ?? "?") model=\(dvr.model ?? "?") — all channels play through Plex")
 
         // Extract provider path using DVR key (e.g., tv.plex.providers.epg.xmltv:28)
         let providerPath = extractProviderPath(from: lineup, dvrKey: dvrKey)
@@ -2134,12 +2088,15 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
                 let channelTitle = media.channelTitle ?? "Channel \(channelId)"
                 let channelNumber = media.channelVcn ?? channelId
 
-                // Get stream URL from HDHomeRun lineup (keyed by channel number)
-                let streamURL = hdhrStreamURLs[channelNumber] ?? hdhrStreamURLs[channelId]
-
                 let channel = PlexLiveTVChannel(
                     ratingKey: channelId,
-                    key: "/tv.plex.providers.epg.xmltv:\(dvrKey)/metadata/\(channelId)",
+                    // Use the DVR's ACTUAL EPG provider (extracted from its
+                    // lineup, e.g. tv.plex.providers.epg.cloud:157). The
+                    // provider was previously hardcoded as epg.xmltv, which
+                    // 400s the transcode start on DVRs using Plex's cloud EPG
+                    // — the tune path pointed at a provider that doesn't exist
+                    // on the server.
+                    key: "/\(providerPath)/metadata/\(channelId)",
                     guid: nil,
                     type: "channel",
                     title: channelTitle,
@@ -2153,23 +2110,20 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
                     channelThumb: media.channelThumb,
                     channelTitle: channelTitle,
                     channelNumber: channelNumber,
-                    streamURL: streamURL
+                    // No direct tuner handoff — all Plex Live TV plays through
+                    // the server (tune → /livetv/sessions).
+                    streamURL: nil
                 )
 
                 channels.append(channel)
             }
         }
 
-        // Log channel breakdown for DVB debugging (GitHub #64)
-        let channelsWithStreamURL = channels.filter { $0.streamURL != nil }.count
-        let channelsNeedingTranscode = channels.count - channelsWithStreamURL
+        print("🌐 PlexNetwork: Live TV channels: \(channels.count) total, all via Plex tune")
         let summaryBreadcrumb = Breadcrumb(level: .info, category: "plex_livetv")
         summaryBreadcrumb.message = "Live TV channel fetch completed"
         summaryBreadcrumb.data = [
             "total_channels": channels.count,
-            "channels_with_hdhr_url": channelsWithStreamURL,
-            "channels_needing_transcode": channelsNeedingTranscode,
-            "has_hdhr_device": hasHDHomeRunDevice,
             "server_host": URL(string: serverURL)?.host ?? "unknown"
         ]
         SentryBridge.addBreadcrumb(summaryBreadcrumb)
@@ -2177,70 +2131,106 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
         return channels
     }
 
-    /// Fetch stream URLs from HDHomeRun device lineup
-    /// Returns a dictionary mapping channel number to stream URL
-    private func fetchHDHomeRunLineup(deviceURI: String) async -> [String: String] {
-        guard let lineupURL = URL(string: "\(deviceURI)/lineup.json") else {
-            print("🌐 PlexNetwork: Invalid HDHomeRun lineup URL")
-            return [:]
+    /// Tune a Plex Live TV channel and return the live session UUID.
+    ///
+    /// Cloud-EPG / DVB DVRs require this tune step before the universal
+    /// transcoder can open the stream: pointing `path` at the EPG channel
+    /// metadata returns HTTP 400. The correct flow (matching Plex's own
+    /// clients) is:
+    ///   POST /livetv/dvrs/{dvrKey}/channels/{channelId}/tune
+    ///   → MediaSubscription → MediaGrabOperation → Video → Media[0].uuid
+    ///   → play with path=/livetv/sessions/{uuid}
+    func tuneLiveTVChannel(
+        serverURL: String,
+        authToken: String,
+        dvrKey: String,
+        channelIdentifier: String
+    ) async throws -> PlexLiveTVTuneResult {
+        // Strip any scheme-style prefix (e.g. "id://") from the identifier.
+        let channelId = channelIdentifier.contains("://")
+            ? String(channelIdentifier.split(separator: "/").last ?? "")
+            : channelIdentifier
+
+        guard !channelId.isEmpty,
+              let url = URL(string: "\(serverURL)/livetv/dvrs/\(dvrKey)/channels/\(channelId)/tune") else {
+            throw PlexAPIError.invalidURL
         }
 
-        nonisolated struct HDHomeRunChannel: Codable {
-            let GuideNumber: String?
-            let GuideName: String?
-            let URL: String?
-        }
+        var headers = plexHeaders(authToken: authToken)
+        headers["Accept"] = "application/json"
+        let data = try await requestData(url, method: "POST", headers: headers)
 
-        do {
-            let (data, response) = try await session.data(from: lineupURL)
-
-            // Validate HTTP response before attempting JSON decode
-            if let httpResponse = response as? HTTPURLResponse, !(200...299).contains(httpResponse.statusCode) {
-                print("🌐 PlexNetwork: HDHomeRun lineup returned HTTP \(httpResponse.statusCode)")
-                return [:]
+        // The response shape varies between PMS versions and EPG providers:
+        // XML <Video> can surface in JSON as "Video" OR "Metadata", and the
+        // nesting under MediaGrabOperation isn't stable. Rather than pinning a
+        // Codable shape, walk the tree for the first Media entry carrying a
+        // uuid — that's the livetv session id in every observed variant.
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let mediaContainer = root["MediaContainer"] as? [String: Any] else {
+            print("🌐 PlexNetwork: tune response was not JSON (dvr=\(dvrKey), channel=\(channelId))")
+            if let head = String(data: data.prefix(400), encoding: .utf8) {
+                print("🌐 PlexNetwork: tune response head: \(head)")
             }
+            throw PlexAPIError.parsingError
+        }
 
-            let channels = try JSONDecoder().decode([HDHomeRunChannel].self, from: data)
-
-            var urlMap: [String: String] = [:]
-            for channel in channels {
-                if let number = channel.GuideNumber, let url = channel.URL {
-                    urlMap[number] = url
+        func firstMediaUUID(in node: Any) -> String? {
+            if let dict = node as? [String: Any] {
+                if let mediaArray = dict["Media"] as? [[String: Any]] {
+                    for media in mediaArray {
+                        if let uuid = media["uuid"] as? String, !uuid.isEmpty { return uuid }
+                    }
+                } else if let media = dict["Media"] as? [String: Any],
+                          let uuid = media["uuid"] as? String, !uuid.isEmpty {
+                    return uuid
+                }
+                for value in dict.values {
+                    if let uuid = firstMediaUUID(in: value) { return uuid }
+                }
+            } else if let array = node as? [Any] {
+                for value in array {
+                    if let uuid = firstMediaUUID(in: value) { return uuid }
                 }
             }
-
-            // Log HDHomeRun lineup success (GitHub #64 - DVB diagnostics)
-            let breadcrumb = Breadcrumb(level: .info, category: "plex_livetv")
-            breadcrumb.message = "HDHomeRun lineup fetched successfully"
-            breadcrumb.data = [
-                "device_host": lineupURL.host ?? "unknown",
-                "total_channels": channels.count,
-                "channels_with_urls": urlMap.count
-            ]
-            SentryBridge.addBreadcrumb(breadcrumb)
-
-            return urlMap
-        } catch {
-            print("🌐 PlexNetwork: Failed to fetch HDHomeRun lineup: \(error)")
-
-            // Log HDHomeRun lineup failure (GitHub #64 - DVB diagnostics)
-            let breadcrumb = Breadcrumb(level: .error, category: "plex_livetv")
-            breadcrumb.message = "HDHomeRun lineup fetch failed"
-            breadcrumb.data = [
-                "device_host": lineupURL.host ?? "unknown",
-                "error": error.localizedDescription
-            ]
-            SentryBridge.addBreadcrumb(breadcrumb)
-
-            // Capture error event for HDHomeRun failures
-            SentryBridge.capture(error: error) { scope in
-                scope.setTag(value: "plex_livetv", key: "component")
-                scope.setTag(value: "hdhr_lineup_fetch", key: "operation")
-                scope.setExtra(value: lineupURL.host ?? "unknown", key: "device_host")
-            }
-
-            return [:]
+            return nil
         }
+
+        // The Part key inside the grab is the DIRECT-PLAY stream: the DVR's
+        // own HLS of the raw broadcast (/livetv/sessions/<uuid>/<tuner>/index.m3u8),
+        // served without the universal transcoder.
+        func firstPartKey(in node: Any) -> String? {
+            if let dict = node as? [String: Any] {
+                let parts: [[String: Any]]
+                if let arr = dict["Part"] as? [[String: Any]] { parts = arr }
+                else if let one = dict["Part"] as? [String: Any] { parts = [one] }
+                else { parts = [] }
+                for part in parts {
+                    if let key = part["key"] as? String, key.contains("/livetv/sessions/") {
+                        return key
+                    }
+                }
+                for value in dict.values {
+                    if let key = firstPartKey(in: value) { return key }
+                }
+            } else if let array = node as? [Any] {
+                for value in array {
+                    if let key = firstPartKey(in: value) { return key }
+                }
+            }
+            return nil
+        }
+
+        guard let uuid = firstMediaUUID(in: mediaContainer) else {
+            print("🌐 PlexNetwork: tune succeeded but no Media uuid found (dvr=\(dvrKey), channel=\(channelId)); MediaContainer keys=\(mediaContainer.keys.sorted().joined(separator: ","))")
+            if let head = String(data: data.prefix(800), encoding: .utf8) {
+                print("🌐 PlexNetwork: tune response head: \(head)")
+            }
+            throw PlexAPIError.invalidResponse
+        }
+
+        let partKey = firstPartKey(in: mediaContainer)
+        print("🌐 PlexNetwork: tuned dvr=\(dvrKey) channel=\(channelId) → livetv session \(uuid) partKey=\(partKey ?? "none")")
+        return PlexLiveTVTuneResult(sessionUUID: uuid, partKey: partKey)
     }
 
     /// Extract provider path from DVR key and lineup URL for EPG access
@@ -2337,6 +2327,8 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
             let summary: String?
             let thumb: String?
             let art: String?
+            let grandparentThumb: String?
+            let grandparentArt: String?
             let year: Int?
             let originallyAvailableAt: String?
             let Media: [GridEPGMedia]?
@@ -2385,6 +2377,8 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
                     summary: program.summary,
                     thumb: program.thumb,
                     art: program.art,
+                    grandparentThumb: program.grandparentThumb,
+                    grandparentArt: program.grandparentArt,
                     year: program.year,
                     originallyAvailableAt: program.originallyAvailableAt,
                     beginsAt: media.beginsAt,
@@ -2743,6 +2737,19 @@ extension PlexNetworkManager: URLSessionDelegate {
             completionHandler(.performDefaultHandling, nil)
         }
     }
+}
+
+// MARK: - Live TV Tune Result
+
+/// Result of tuning a Plex Live TV channel.
+nonisolated struct PlexLiveTVTuneResult: Sendable {
+    /// The livetv session uuid (usable as path=/livetv/sessions/<uuid> on the
+    /// universal transcoder).
+    let sessionUUID: String
+    /// The grab's Part key — the DVR's own HLS of the RAW broadcast
+    /// (/livetv/sessions/<uuid>/<tuner>/index.m3u8). Fetching this directly is
+    /// true direct play: no universal transcoder involved.
+    let partKey: String?
 }
 
 // MARK: - API Errors

--- a/Rivulet/Services/Plex/PlexNetworkManager.swift
+++ b/Rivulet/Services/Plex/PlexNetworkManager.swift
@@ -1133,18 +1133,40 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
         }
     }
 
-    /// Remove item from continue watching by marking as unwatched
+    /// Remove item from the Continue Watching hub without touching its
+    /// watch state (progress/viewCount stay intact — the item is only
+    /// hidden from the hub, matching official Plex clients).
     func removeFromContinueWatching(
         serverURL: String,
         authToken: String,
         ratingKey: String
     ) async throws {
-        // Mark as unwatched clears all progress and removes from "Continue Watching"
-        try await markUnwatched(
-            serverURL: serverURL,
-            authToken: authToken,
-            ratingKey: ratingKey
-        )
+        guard var components = URLComponents(string: "\(serverURL)/actions/removeFromContinueWatching") else {
+            throw PlexAPIError.invalidURL
+        }
+
+        components.queryItems = [
+            URLQueryItem(name: "ratingKey", value: ratingKey)
+        ]
+
+        guard let url = components.url else {
+            throw PlexAPIError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        for (key, value) in plexHeaders(authToken: authToken) {
+            request.addValue(value, forHTTPHeaderField: key)
+        }
+
+        let (_, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            if let httpResponse = response as? HTTPURLResponse {
+                throw PlexAPIError.httpError(statusCode: httpResponse.statusCode, data: nil)
+            }
+            throw PlexAPIError.invalidResponse
+        }
     }
 
     // MARK: - Playlists
@@ -2021,7 +2043,6 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
         // ALL Plex Live TV plays through the Plex server (tune → session).
         // No direct tuner (HDHomeRun) handoff: raw tuner URLs are LAN-only
         // and bypass the server's session/tuner management entirely.
-        print("🌐 PlexNetwork: DVR \(dvrKey) make=\(dvr.make ?? "?") model=\(dvr.model ?? "?") — all channels play through Plex")
 
         // Extract provider path using DVR key (e.g., tv.plex.providers.epg.xmltv:28)
         let providerPath = extractProviderPath(from: lineup, dvrKey: dvrKey)
@@ -2119,7 +2140,6 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
             }
         }
 
-        print("🌐 PlexNetwork: Live TV channels: \(channels.count) total, all via Plex tune")
         let summaryBreadcrumb = Breadcrumb(level: .info, category: "plex_livetv")
         summaryBreadcrumb.message = "Live TV channel fetch completed"
         summaryBreadcrumb.data = [
@@ -2167,10 +2187,14 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
         // uuid — that's the livetv session id in every observed variant.
         guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let mediaContainer = root["MediaContainer"] as? [String: Any] else {
-            print("🌐 PlexNetwork: tune response was not JSON (dvr=\(dvrKey), channel=\(channelId))")
-            if let head = String(data: data.prefix(400), encoding: .utf8) {
-                print("🌐 PlexNetwork: tune response head: \(head)")
-            }
+            let breadcrumb = Breadcrumb(level: .warning, category: "plex_livetv")
+            breadcrumb.message = "Tune response was not JSON"
+            breadcrumb.data = [
+                "dvr": dvrKey,
+                "channel": channelId,
+                "response_head": String(data: data.prefix(400), encoding: .utf8) ?? "n/a"
+            ]
+            SentryBridge.addBreadcrumb(breadcrumb)
             throw PlexAPIError.parsingError
         }
 
@@ -2221,15 +2245,19 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
         }
 
         guard let uuid = firstMediaUUID(in: mediaContainer) else {
-            print("🌐 PlexNetwork: tune succeeded but no Media uuid found (dvr=\(dvrKey), channel=\(channelId)); MediaContainer keys=\(mediaContainer.keys.sorted().joined(separator: ","))")
-            if let head = String(data: data.prefix(800), encoding: .utf8) {
-                print("🌐 PlexNetwork: tune response head: \(head)")
-            }
+            let breadcrumb = Breadcrumb(level: .warning, category: "plex_livetv")
+            breadcrumb.message = "Tune succeeded but no Media uuid found"
+            breadcrumb.data = [
+                "dvr": dvrKey,
+                "channel": channelId,
+                "media_container_keys": mediaContainer.keys.sorted().joined(separator: ","),
+                "response_head": String(data: data.prefix(800), encoding: .utf8) ?? "n/a"
+            ]
+            SentryBridge.addBreadcrumb(breadcrumb)
             throw PlexAPIError.invalidResponse
         }
 
         let partKey = firstPartKey(in: mediaContainer)
-        print("🌐 PlexNetwork: tuned dvr=\(dvrKey) channel=\(channelId) → livetv session \(uuid) partKey=\(partKey ?? "none")")
         return PlexLiveTVTuneResult(sessionUUID: uuid, partKey: partKey)
     }
 

--- a/Rivulet/Views/LiveTV/EPGGuideView.swift
+++ b/Rivulet/Views/LiveTV/EPGGuideView.swift
@@ -1,0 +1,1035 @@
+//
+//  EPGGuideView.swift
+//  Rivulet
+//
+//  UHF-style Live TV guide ported from the PlexGuide (Flume) project.
+//
+//  High-performance EPG grid backed by a UIKit `UICollectionView` with a custom
+//  layout: virtualized (fast with large lineups), a sticky channel column
+//  (pinned left, scrolls vertically), a sticky time ruler (pinned top, scrolls
+//  horizontally), a single "now" line, and a fade where cells pass under the
+//  column. Adapted to Rivulet's `UnifiedChannel` / `UnifiedProgram` data and
+//  Rivulet's player (selection is handed back to SwiftUI via `onSelect`).
+//
+
+import SwiftUI
+import UIKit
+
+// MARK: - Theme
+
+/// Colors and layout metrics for the guide, matching the PlexGuide look.
+enum EPGTheme {
+    // MARK: Colors
+    static let background = Color(red: 0.10, green: 0.10, blue: 0.115)
+    static let surface = Color(red: 0.21, green: 0.21, blue: 0.23)
+    /// Channel column box: lighter than the background, darker than guide cells.
+    static let columnFill = Color(red: 0.17, green: 0.17, blue: 0.19)
+    /// Shared corner radius for every guide box (timeline, date, logo, cells)
+    /// and the rounded clip where cells tuck under the column / ruler.
+    static let columnCorner: CGFloat = 8
+    static let textPrimary = Color.white
+    static let textSecondary = Color.white.opacity(0.55)
+
+    // MARK: Guide layout metrics (in points)
+    /// Horizontal density of the timeline. Tuned so ~4 hours of programming is
+    /// visible at once.
+    static let pointsPerMinute: CGFloat = 7.5
+    /// Width of the sticky channel column on the left.
+    static let channelColumnWidth: CGFloat = 129
+    /// Height of each channel row.
+    static let rowHeight: CGFloat = 94
+    /// Height of the sticky timeline header.
+    static let timelineHeight: CGFloat = 54
+    /// Height of the slim rounded boxes inside the timeline / date row.
+    static let timelineBoxHeight: CGFloat = 34
+    /// Height of the fixed info bar (top layer) the grid scrolls beneath.
+    static let infoBarHeight: CGFloat = 300
+    /// Gap between the info bar and the time ruler.
+    static let rulerGap: CGFloat = 0
+    /// Extra gap between the time ruler and the first row.
+    static let gridTopGap: CGFloat = 0
+    /// Screen Y where the time ruler / corner pin.
+    static var rulerTop: CGFloat { infoBarHeight + rulerGap }
+    /// Top content inset of the grid (first row rests below the ruler + fade).
+    static var gridTopInset: CGFloat { rulerTop + timelineHeight + gridTopGap }
+    /// Vertical gap between rows / horizontal gap between cells.
+    static let cellSpacing: CGFloat = 4
+    /// How far the guide timeline spans, starting at the current half hour.
+    static let timelineSpanHours: Int = 24
+}
+
+// MARK: - Program helpers
+
+private extension UnifiedProgram {
+    var start: Date { startTime }
+    var stop: Date { endTime }
+    func isLive(at date: Date = Date()) -> Bool { date >= startTime && date < endTime }
+}
+
+// MARK: - SwiftUI wrapper
+
+struct EPGGuide: UIViewRepresentable {
+    let channels: [UnifiedChannel]
+    let programsByChannel: [String: [UnifiedProgram]]
+    let timelineStart: Date
+    let totalMinutes: Int
+    let now: Date
+    /// When true the grid releases focus (e.g. an overlay is presented).
+    var menuActive: Bool = false
+    var onFocus: (UnifiedChannel?, UnifiedProgram?) -> Void
+    var onSelect: (UnifiedChannel, UnifiedProgram?) -> Void
+    /// Transparent overlay mode: see-through cells over an ambient backdrop.
+    var transparent: Bool = true
+    /// Space reserved above the time ruler (the info bar lives there).
+    var topInset: CGFloat? = nil
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    func makeUIView(context: Context) -> EPGContainerView {
+        let layout = EPGLayout()
+        // The info bar's height insets the WHOLE collection view down, so a
+        // focused cell can never be obscured by the info bar (the focus engine
+        // keeps cells within the CV's bounds).
+        let infoBarInset = topInset ?? (transparent ? 0 : EPGTheme.infoBarHeight)
+        layout.topOffset = 0
+        let cv = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        cv.backgroundColor = .clear
+        cv.contentInsetAdjustmentBehavior = .never
+        cv.contentInset = UIEdgeInsets(top: layout.gridTopInset,
+                                       left: EPGTheme.channelColumnWidth,
+                                       bottom: 120, right: 60)
+        cv.showsVerticalScrollIndicator = false
+        cv.showsHorizontalScrollIndicator = false
+        cv.bounces = false
+        cv.remembersLastFocusedIndexPath = true
+        cv.dataSource = context.coordinator
+        cv.delegate = context.coordinator
+        cv.register(ProgramCellView.self, forCellWithReuseIdentifier: ProgramCellView.reuseID)
+        cv.register(ChannelColumnView.self,
+                    forSupplementaryViewOfKind: EPGLayout.kindChannel,
+                    withReuseIdentifier: ChannelColumnView.reuseID)
+        cv.register(TimeRulerView.self,
+                    forSupplementaryViewOfKind: EPGLayout.kindTime,
+                    withReuseIdentifier: TimeRulerView.reuseID)
+        cv.register(CornerView.self,
+                    forSupplementaryViewOfKind: EPGLayout.kindCorner,
+                    withReuseIdentifier: CornerView.reuseID)
+
+        context.coordinator.collectionView = cv
+        context.coordinator.apply(self, to: layout)
+
+        // Play/Pause jumps back to the now-airing programme.
+        let jump = UITapGestureRecognizer(target: context.coordinator,
+                                          action: #selector(Coordinator.jumpToNow))
+        jump.allowedPressTypes = [NSNumber(value: UIPress.PressType.playPause.rawValue)]
+        cv.addGestureRecognizer(jump)
+
+        let container = EPGContainerView()
+        container.contentTopInset = infoBarInset
+        container.install(collectionView: cv)
+        container.setTransparent(transparent)
+        return container
+    }
+
+    func updateUIView(_ uiView: EPGContainerView, context: Context) {
+        context.coordinator.parent = self
+        guard let cv = context.coordinator.collectionView,
+              let layout = cv.collectionViewLayout as? EPGLayout else { return }
+        cv.isUserInteractionEnabled = !menuActive
+        let dataChanged = context.coordinator.apply(self, to: layout)
+        if dataChanged {
+            cv.reloadData()
+            if transparent, !context.coordinator.didRestScroll {
+                context.coordinator.didRestScroll = true
+                cv.contentOffset = CGPoint(x: -EPGTheme.channelColumnWidth, y: -layout.gridTopInset)
+            }
+        } else {
+            // Likely just `now` advanced — move the now-line without a reload.
+            layout.invalidateLayout()
+        }
+    }
+
+    // MARK: Coordinator
+
+    final class Coordinator: NSObject, UICollectionViewDataSource, UICollectionViewDelegate {
+        var parent: EPGGuide
+        weak var collectionView: UICollectionView?
+        private(set) var sections: [UnifiedChannel] = []
+        private(set) var programs: [[UnifiedProgram]] = []
+        private var lastSignature: Int = 0
+        private var currentSection = 0
+        private var pendingFocus: IndexPath?
+        var didRestScroll = false
+        /// The committed horizontal offset. The timeline only moves sideways on a
+        /// deliberate left/right move (or drag); during channel changes and when
+        /// focus enters the grid the offset is pinned here, so a programme wider
+        /// than the screen can't drag the guide away from the current time.
+        private var lockedX: CGFloat = 0
+        private var lockedXInitialized = false
+        /// While `Date() < freeScrollUntil` the timeline may scroll horizontally.
+        private var freeScrollUntil: Date = .distantPast
+        private(set) var currentFocusedIsLive = false
+
+        init(_ parent: EPGGuide) { self.parent = parent }
+
+        /// Pushes data into the layout. Returns true if channels/programs changed.
+        @discardableResult
+        func apply(_ p: EPGGuide, to layout: EPGLayout) -> Bool {
+            let ppm = EPGTheme.pointsPerMinute
+            let total = Double(p.totalMinutes)
+            var rows: [[EPGLayout.Span]] = []
+            var progs: [[UnifiedProgram]] = []
+            var chans: [UnifiedChannel] = []
+
+            for channel in p.channels {
+                let minStart = -Double(EPGTheme.channelColumnWidth) / Double(ppm)
+                let ranges = (p.programsByChannel[channel.id] ?? []).compactMap { program -> (cs: Double, ce: Double, prog: UnifiedProgram)? in
+                    let startMin = program.start.timeIntervalSince(p.timelineStart) / 60
+                    let endMin = program.stop.timeIntervalSince(p.timelineStart) / 60
+                    guard endMin > 0, startMin < total else { return nil }
+                    return (max(minStart, startMin), min(total, endMin), program)
+                }.sorted { $0.cs < $1.cs }
+
+                var spans: [EPGLayout.Span] = []
+                var rowProgs: [UnifiedProgram] = []
+                for (idx, r) in ranges.enumerated() {
+                    let x = CGFloat(r.cs) * ppm
+                    var w = CGFloat(r.ce - r.cs) * ppm
+                    if idx + 1 < ranges.count {
+                        w = min(w, CGFloat(ranges[idx + 1].cs) * ppm - x)
+                    }
+                    spans.append(EPGLayout.Span(x: x, width: max(w, 2)))
+                    rowProgs.append(r.prog)
+                }
+                rows.append(spans)
+                progs.append(rowProgs)
+                chans.append(channel)
+            }
+
+            // Signature to detect data changes. Includes logoURL so a late
+            // channel-logo patch triggers a reload, and per-channel programme
+            // counts so EPG arriving AFTER the channels (Rivulet loads them
+            // separately) reloads the grid and the rows populate.
+            var sig = Hasher()
+            sig.combine(p.channels.count)
+            for c in p.channels {
+                sig.combine(c.id)
+                sig.combine(c.logoURL)
+                sig.combine(p.programsByChannel[c.id]?.count ?? 0)
+            }
+            sig.combine(p.timelineStart)
+            let signature = sig.finalize()
+            let changed = signature != lastSignature
+            lastSignature = signature
+
+            sections = chans
+            programs = progs
+            layout.configure(rows: rows,
+                             channelCount: chans.count,
+                             totalMinutes: p.totalMinutes,
+                             timelineStart: p.timelineStart,
+                             now: p.now)
+            return changed
+        }
+
+        func numberOfSections(in collectionView: UICollectionView) -> Int { programs.count }
+
+        func collectionView(_ cv: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+            programs[safe: section]?.count ?? 0
+        }
+
+        func collectionView(_ cv: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+            let cell = cv.dequeueReusableCell(withReuseIdentifier: ProgramCellView.reuseID, for: indexPath) as! ProgramCellView
+            cell.transparent = parent.transparent
+            if let program = programs[safe: indexPath.section]?[safe: indexPath.item] {
+                cell.configure(program)
+            }
+            return cell
+        }
+
+        func collectionView(_ cv: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+            switch kind {
+            case EPGLayout.kindChannel:
+                let v = cv.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: ChannelColumnView.reuseID, for: indexPath) as! ChannelColumnView
+                if let channel = sections[safe: indexPath.section] { v.configure(channel, transparent: parent.transparent) }
+                return v
+            case EPGLayout.kindTime:
+                let v = cv.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: TimeRulerView.reuseID, for: indexPath) as! TimeRulerView
+                v.configure(start: parent.timelineStart, totalMinutes: parent.totalMinutes, transparent: parent.transparent)
+                return v
+            default:
+                let v = cv.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: CornerView.reuseID, for: indexPath) as! CornerView
+                v.configure(date: parent.timelineStart, transparent: parent.transparent)
+                return v
+            }
+        }
+
+        // Focus → update the info bar; hold the timeline's horizontal position
+        // across channel changes so wide programmes don't drag the guide sideways.
+        func collectionView(_ cv: UICollectionView, didUpdateFocusIn context: UICollectionViewFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+            guard let ip = context.nextFocusedIndexPath,
+                  let channel = sections[safe: ip.section],
+                  let program = programs[safe: ip.section]?[safe: ip.item] else { return }
+            let now = parent.now
+            currentSection = ip.section
+            currentFocusedIsLive = program.isLive(at: now)
+            parent.onFocus(channel, program)
+
+            let prev = context.previouslyFocusedIndexPath
+            let sameChannel = (prev != nil && prev!.section == ip.section)
+            if sameChannel {
+                freeScrollUntil = Date().addingTimeInterval(0.6)
+            } else {
+                freeScrollUntil = .distantPast
+                if let layout = cv.collectionViewLayout as? EPGLayout {
+                    let inset = layout.rulerBottomInset
+                    let rowH = EPGTheme.rowHeight
+                    let margin = rowH
+                    let rowTop = CGFloat(ip.section) * rowH
+                    let rowBottom = rowTop + rowH
+                    let visibleTop = cv.contentOffset.y + inset
+                    let visibleBottom = cv.contentOffset.y + cv.bounds.height - cv.contentInset.bottom
+                    var targetY = cv.contentOffset.y
+                    if rowTop - margin < visibleTop {
+                        targetY = rowTop - inset - margin
+                    } else if rowBottom + margin > visibleBottom {
+                        let rows = ((rowBottom + margin - visibleBottom) / rowH).rounded(.up)
+                        targetY = cv.contentOffset.y + rows * rowH
+                    }
+                    targetY = max(targetY, -cv.contentInset.top)
+                    if abs(targetY - cv.contentOffset.y) > 0.5 || abs(lockedX - cv.contentOffset.x) > 0.5 {
+                        cv.setContentOffset(CGPoint(x: lockedX, y: targetY), animated: true)
+                    }
+                }
+            }
+        }
+
+        // Snap horizontal scrolling so a full 30-min cell sits next to the date.
+        func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint,
+                                       targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+            targetContentOffset.pointee.x = Coordinator.snappedX(for: targetContentOffset.pointee.x)
+            if let layout = collectionView?.collectionViewLayout as? EPGLayout {
+                let inset = layout.rulerBottomInset
+                let rowH = EPGTheme.rowHeight
+                let y = targetContentOffset.pointee.y
+                targetContentOffset.pointee.y = (((y + inset) / rowH).rounded() * rowH) - inset
+            }
+        }
+
+        /// Offset whose left grid edge lands on a 30-minute boundary.
+        static func snappedX(for x: CGFloat) -> CGFloat {
+            let slot = 30 * EPGTheme.pointsPerMinute
+            let colW = EPGTheme.channelColumnWidth
+            let snappedLeft = ((x + colW) / slot).rounded() * slot
+            return snappedLeft - colW
+        }
+
+        // Update the date box as the visible time crosses into another day.
+        func scrollViewDidScroll(_ scrollView: UIScrollView) {
+            guard let cv = collectionView else { return }
+            if !lockedXInitialized { lockedX = cv.contentOffset.x; lockedXInitialized = true }
+            if cv.isDragging || cv.isDecelerating || Date() < freeScrollUntil {
+                lockedX = cv.contentOffset.x
+            } else if abs(cv.contentOffset.x - lockedX) > 0.5 {
+                cv.contentOffset.x = lockedX
+            }
+            let minutesIn = (cv.contentOffset.x + EPGTheme.channelColumnWidth) / EPGTheme.pointsPerMinute
+            let leftDate = parent.timelineStart.addingTimeInterval(Double(minutesIn) * 60)
+            if let corner = cv.supplementaryView(forElementKind: EPGLayout.kindCorner,
+                                                 at: IndexPath(item: 0, section: 0)) as? CornerView {
+                corner.configure(date: leftDate, transparent: parent.transparent)
+            }
+        }
+
+        func collectionView(_ cv: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+            guard let channel = sections[safe: indexPath.section] else { return }
+            let now = parent.now
+            let row = programs[safe: indexPath.section] ?? []
+            let current = row.first { $0.isLive(at: now) } ?? row.last { $0.start <= now }
+            // Hand selection back to SwiftUI, which launches Rivulet's player.
+            parent.onSelect(channel, current)
+        }
+
+        // Play/Pause → move focus to the now-playing programme in the current row.
+        @objc func jumpToNow() {
+            guard let cv = collectionView,
+                  currentSection < programs.count else { return }
+            let row = programs[currentSection]
+            let now = parent.now
+            let item = row.firstIndex { $0.isLive(at: now) }
+                ?? row.lastIndex { $0.start <= now }
+                ?? 0
+            guard !row.isEmpty else { return }
+            pendingFocus = IndexPath(item: item, section: currentSection)
+            cv.setNeedsFocusUpdate()
+            cv.updateFocusIfNeeded()
+        }
+
+        func indexPathForPreferredFocusedView(in collectionView: UICollectionView) -> IndexPath? {
+            defer { pendingFocus = nil }
+            return pendingFocus
+        }
+    }
+}
+
+// Note: `Array.subscript(safe:)` is defined in MultiStreamViewModel.swift and
+// reused here.
+
+// MARK: - Container (collection view + fade under the column)
+
+final class EPGContainerView: UIView {
+    private var collectionView: UICollectionView?
+    private let timeFade = CAGradientLayer()
+    private let bottomFade = CAGradientLayer()
+    private let rightFade = CAGradientLayer()
+    /// The grid starts this far below the top, so the info bar above it can never
+    /// obscure a focused cell.
+    var contentTopInset: CGFloat = 0 { didSet { setNeedsLayout() } }
+
+    /// Transparent overlay mode hides the page-coloured fades (they'd dim video).
+    func setTransparent(_ t: Bool) {
+        timeFade.isHidden = t
+        bottomFade.isHidden = t
+        rightFade.isHidden = t
+    }
+
+    func install(collectionView cv: UICollectionView) {
+        self.collectionView = cv
+        addSubview(cv)
+
+        let bg = UIColor(EPGTheme.background)
+
+        timeFade.colors = [bg.cgColor, bg.withAlphaComponent(0).cgColor]
+        timeFade.startPoint = CGPoint(x: 0.5, y: 0)
+        timeFade.endPoint = CGPoint(x: 0.5, y: 1)
+        layer.addSublayer(timeFade)
+
+        bottomFade.colors = [bg.withAlphaComponent(0).cgColor, bg.cgColor]
+        bottomFade.startPoint = CGPoint(x: 0.5, y: 0)
+        bottomFade.endPoint = CGPoint(x: 0.5, y: 1)
+        layer.addSublayer(bottomFade)
+
+        rightFade.colors = [bg.withAlphaComponent(0).cgColor, bg.cgColor]
+        rightFade.startPoint = CGPoint(x: 0, y: 0.5)
+        rightFade.endPoint = CGPoint(x: 1, y: 0.5)
+        layer.addSublayer(rightFade)
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        collectionView?.frame = CGRect(x: 0, y: contentTopInset,
+                                       width: bounds.width,
+                                       height: max(bounds.height - contentTopInset, 0))
+        let top = EPGTheme.rulerTop + EPGTheme.timelineHeight
+        timeFade.frame = CGRect(x: 0, y: top, width: bounds.width, height: 16)
+        bottomFade.frame = CGRect(x: 0, y: bounds.height - 70, width: bounds.width, height: 70)
+        rightFade.frame = CGRect(x: bounds.width - 48, y: top, width: 48, height: bounds.height - top)
+    }
+}
+
+// MARK: - Custom layout
+
+/// Cell attributes that also carry how far to push the title in so it stays
+/// visible when the cell is partly tucked under the column / off the left edge.
+final class EPGCellAttributes: UICollectionViewLayoutAttributes {
+    var titleInset: CGFloat = 0
+    var leftClip: CGFloat = 0
+    var topClip: CGFloat = 0
+    var pastWidth: CGFloat = 0
+
+    override func copy(with zone: NSZone? = nil) -> Any {
+        let c = super.copy(with: zone) as! EPGCellAttributes
+        c.titleInset = titleInset
+        c.leftClip = leftClip
+        c.topClip = topClip
+        c.pastWidth = pastWidth
+        return c
+    }
+    override func isEqual(_ object: Any?) -> Bool {
+        guard let o = object as? EPGCellAttributes else { return false }
+        return super.isEqual(object) && o.titleInset == titleInset
+            && o.leftClip == leftClip && o.topClip == topClip
+            && o.pastWidth == pastWidth
+    }
+}
+
+final class EPGLayout: UICollectionViewLayout {
+    struct Span { let x: CGFloat; let width: CGFloat }
+
+    override class var layoutAttributesClass: AnyClass { EPGCellAttributes.self }
+
+    static let kindChannel = "channel"
+    static let kindTime = "time"
+    static let kindCorner = "corner"
+
+    private var rows: [[Span]] = []
+    private var channelCount = 0
+    private var totalMinutes = 0
+    private var timelineStart = Date()
+    private var now = Date()
+
+    private let colW = EPGTheme.channelColumnWidth
+    private let rowH = EPGTheme.rowHeight
+    private let headerH = EPGTheme.timelineHeight
+    var topOffset: CGFloat = EPGTheme.infoBarHeight
+    private var rulerTop: CGFloat { topOffset + EPGTheme.rulerGap }
+    var gridTopInset: CGFloat { rulerTop + EPGTheme.timelineHeight + EPGTheme.gridTopGap }
+    var rulerBottomInset: CGFloat { rulerTop + headerH }
+    private let ppm = EPGTheme.pointsPerMinute
+    private let gap = EPGTheme.cellSpacing
+
+    override init() {
+        super.init()
+    }
+    required init?(coder: NSCoder) { fatalError() }
+
+    func configure(rows: [[Span]], channelCount: Int, totalMinutes: Int,
+                   timelineStart: Date, now: Date) {
+        self.rows = rows
+        self.channelCount = channelCount
+        self.totalMinutes = totalMinutes
+        self.timelineStart = timelineStart
+        self.now = now
+        invalidateLayout()
+    }
+
+    private var contentWidth: CGFloat { CGFloat(totalMinutes) * ppm }
+    private var contentHeight: CGFloat { CGFloat(channelCount) * rowH }
+
+    override var collectionViewContentSize: CGSize {
+        CGSize(width: contentWidth, height: contentHeight)
+    }
+
+    override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool { true }
+
+    override func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
+        guard let span = rows[safe: indexPath.section]?[safe: indexPath.item] else { return nil }
+        let frameX = span.x + gap
+        let frameY = CGFloat(indexPath.section) * rowH + gap
+        let width = max(span.width - gap * 2, 1)
+        let height = rowH - gap * 2
+        let a = EPGCellAttributes(forCellWith: indexPath)
+        a.frame = CGRect(x: frameX, y: frameY, width: width, height: height)
+        a.zIndex = 0
+        let nowX = CGFloat(now.timeIntervalSince(timelineStart) / 60) * ppm
+        a.pastWidth = min(max(nowX - frameX, 0), width)
+        if let off = collectionView?.contentOffset {
+            let visibleLeft = off.x + colW + gap
+            let raw = visibleLeft - frameX
+            a.titleInset = min(max(0, raw), max(0, width - 120))
+            a.leftClip = min(max(0, raw), width)
+            let visibleTop = off.y + rulerTop + headerH + gap
+            a.topClip = min(max(0, visibleTop - frameY), height)
+        }
+        return a
+    }
+
+    override func layoutAttributesForSupplementaryView(ofKind elementKind: String, at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
+        guard let cv = collectionView else { return nil }
+        let off = cv.contentOffset
+        let a = EPGCellAttributes(forSupplementaryViewOfKind: elementKind, with: indexPath)
+        switch elementKind {
+        case Self.kindChannel:
+            let slotTop = CGFloat(indexPath.section) * rowH
+            a.frame = CGRect(x: off.x, y: slotTop, width: colW, height: rowH)
+            a.zIndex = 10
+            let visibleTop = off.y + rulerTop + headerH + gap
+            a.topClip = min(max(0, visibleTop - slotTop), rowH)
+        case Self.kindTime:
+            a.frame = CGRect(x: 0, y: off.y + rulerTop, width: contentWidth, height: headerH)
+            a.zIndex = 12
+            a.leftClip = max(0, colW + off.x)
+        case Self.kindCorner:
+            a.frame = CGRect(x: off.x, y: off.y + rulerTop, width: colW, height: headerH)
+            a.zIndex = 20
+        default:
+            return nil
+        }
+        return a
+    }
+
+    override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
+        guard channelCount > 0 else { return nil }
+        var result: [UICollectionViewLayoutAttributes] = []
+
+        let first = max(0, Int(rect.minY / rowH))
+        let last = min(channelCount - 1, Int(rect.maxY / rowH))
+        if last >= first {
+            for s in first...last {
+                for (i, span) in (rows[safe: s] ?? []).enumerated() where span.x <= rect.maxX && (span.x + span.width) >= rect.minX {
+                    if let a = layoutAttributesForItem(at: IndexPath(item: i, section: s)) { result.append(a) }
+                }
+                if let c = layoutAttributesForSupplementaryView(ofKind: Self.kindChannel, at: IndexPath(item: 0, section: s)) {
+                    result.append(c)
+                }
+            }
+        }
+        if let t = layoutAttributesForSupplementaryView(ofKind: Self.kindTime, at: IndexPath(item: 0, section: 0)) { result.append(t) }
+        if let cor = layoutAttributesForSupplementaryView(ofKind: Self.kindCorner, at: IndexPath(item: 0, section: 0)) { result.append(cor) }
+        return result
+    }
+}
+
+// MARK: - Cells
+
+final class ProgramCellView: UICollectionViewCell {
+    static let reuseID = "ProgramCellView"
+    private let titleLabel = UILabel()
+    private let subtitleLabel = UILabel()
+    private let stack = UIStackView()
+    private let card = UIView()
+    private var stackLeading: NSLayoutConstraint!
+    private let baseLeading: CGFloat = 14
+
+    /// Hide text below this width so short programmes stay blank (no overlap).
+    private let minTextWidth: CGFloat = 96
+
+    /// When true (overlay), cells are see-through over the video.
+    var transparent = false
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        card.backgroundColor = .clear
+        card.layer.cornerRadius = EPGTheme.columnCorner
+        card.layer.cornerCurve = .continuous
+        card.clipsToBounds = true
+        card.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(card)
+
+        elapsedLayer.backgroundColor = UIColor(white: 1, alpha: 0.07).cgColor
+        elapsedLayer.isHidden = true
+        card.layer.insertSublayer(elapsedLayer, at: 0)
+
+        titleLabel.font = .systemFont(ofSize: 23, weight: .semibold)
+        titleLabel.textColor = UIColor(EPGTheme.textPrimary)
+        titleLabel.numberOfLines = 1
+        titleLabel.lineBreakMode = .byTruncatingTail
+        subtitleLabel.font = .systemFont(ofSize: 19, weight: .regular)
+        subtitleLabel.textColor = UIColor(EPGTheme.textSecondary)
+        subtitleLabel.numberOfLines = 1
+        subtitleLabel.lineBreakMode = .byTruncatingTail
+
+        stack.axis = .vertical
+        stack.spacing = 2
+        stack.alignment = .leading
+        stack.addArrangedSubview(titleLabel)
+        stack.addArrangedSubview(subtitleLabel)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(stack)
+
+        stackLeading = stack.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: baseLeading)
+        NSLayoutConstraint.activate([
+            card.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            card.topAnchor.constraint(equalTo: contentView.topAnchor),
+            card.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            card.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            stackLeading,
+            stack.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -10),
+            stack.centerYAnchor.constraint(equalTo: card.centerYAnchor),
+        ])
+    }
+    required init?(coder: NSCoder) { fatalError() }
+
+    private let elapsedLayer = CALayer()
+    private var pastWidth: CGFloat = 0
+
+    override func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
+        super.apply(layoutAttributes)
+        let attrs = layoutAttributes as? EPGCellAttributes
+        stackLeading.constant = baseLeading + (attrs?.titleInset ?? 0)
+        leftClip = attrs?.leftClip ?? 0
+        topClip = attrs?.topClip ?? 0
+        pastWidth = attrs?.pastWidth ?? 0
+        applyClip()
+        applyElapsed()
+    }
+
+    private func applyElapsed() {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        let w = min(pastWidth, bounds.width)
+        elapsedLayer.frame = CGRect(x: 0, y: 0, width: max(w, 0), height: bounds.height)
+        elapsedLayer.isHidden = w <= 0.5
+        CATransaction.commit()
+    }
+
+    private var leftClip: CGFloat = 0
+    private var topClip: CGFloat = 0
+    private let clipMask = CAShapeLayer()
+    private func applyClip() {
+        guard transparent, bounds.width > 0, bounds.height > 0,
+              (leftClip > 0 || topClip > 0) else {
+            contentView.layer.mask = nil
+            return
+        }
+        let rect = CGRect(x: leftClip, y: topClip,
+                          width: max(bounds.width - leftClip, 0),
+                          height: max(bounds.height - topClip, 0))
+        var corners: UIRectCorner = []
+        if leftClip > 0 { corners.formUnion([.topLeft, .bottomLeft]) }
+        if topClip > 0 { corners.formUnion([.topLeft, .topRight]) }
+        let r = EPGTheme.columnCorner
+        clipMask.path = UIBezierPath(roundedRect: rect, byRoundingCorners: corners,
+                                     cornerRadii: CGSize(width: r, height: r)).cgPath
+        contentView.layer.mask = clipMask
+    }
+
+    func configure(_ program: UnifiedProgram) {
+        titleLabel.text = program.title
+        let sub = program.subtitle
+        subtitleLabel.text = sub
+        subtitleLabel.isHidden = (sub?.isEmpty ?? true)
+        applyFocus(false)
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        stack.isHidden = bounds.width < minTextWidth
+        applyClip()
+        applyElapsed()
+    }
+
+    override var canBecomeFocused: Bool { true }
+
+    override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+        let focused = (context.nextFocusedView == self)
+        coordinator.addCoordinatedAnimations({ self.applyFocus(focused) })
+    }
+
+    private func applyFocus(_ focused: Bool) {
+        card.backgroundColor = focused ? UIColor(white: 0.96, alpha: 1) : UIColor(white: 0, alpha: 0.32)
+        titleLabel.textColor = focused ? UIColor(white: 0.08, alpha: 1) : .white
+        subtitleLabel.textColor = focused ? UIColor(white: 0.08, alpha: 0.6) : UIColor(white: 1, alpha: 0.7)
+    }
+}
+
+final class ChannelColumnView: UICollectionReusableView {
+    static let reuseID = "ChannelColumnView"
+    private let occluder = UIView()   // opaque; rounded only on the right
+    private let box = UIView()        // coloured logo box; rounded all corners
+    private let logo = UIImageView()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        occluder.backgroundColor = UIColor(EPGTheme.background)
+        occluder.layer.cornerRadius = EPGTheme.columnCorner
+        occluder.layer.cornerCurve = .continuous
+        occluder.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMaxXMaxYCorner]
+        occluder.layer.masksToBounds = true
+        occluder.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(occluder)
+
+        box.backgroundColor = UIColor(EPGTheme.columnFill)
+        box.layer.cornerRadius = EPGTheme.columnCorner
+        box.layer.cornerCurve = .continuous
+        box.layer.masksToBounds = true
+        box.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(box)
+
+        logo.contentMode = .scaleAspectFit
+        logo.translatesAutoresizingMaskIntoConstraints = false
+        box.addSubview(logo)
+
+        let gap = EPGTheme.cellSpacing
+        NSLayoutConstraint.activate([
+            occluder.topAnchor.constraint(equalTo: topAnchor),
+            occluder.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -gap),
+            occluder.leadingAnchor.constraint(equalTo: leadingAnchor),
+            occluder.trailingAnchor.constraint(equalTo: trailingAnchor),
+
+            box.topAnchor.constraint(equalTo: topAnchor, constant: gap),
+            box.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -gap),
+            box.leadingAnchor.constraint(equalTo: leadingAnchor, constant: gap),
+            box.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -gap),
+
+            logo.centerXAnchor.constraint(equalTo: box.centerXAnchor),
+            logo.centerYAnchor.constraint(equalTo: box.centerYAnchor),
+            logo.widthAnchor.constraint(equalToConstant: 86),
+            logo.heightAnchor.constraint(equalToConstant: 62),
+        ])
+    }
+    required init?(coder: NSCoder) { fatalError() }
+
+    func configure(_ channel: UnifiedChannel, transparent: Bool = false) {
+        occluder.backgroundColor = transparent ? .clear : UIColor(EPGTheme.background)
+        box.backgroundColor = transparent ? UIColor(white: 0, alpha: 0.28) : UIColor(EPGTheme.columnFill)
+        logo.image = nil
+        if let url = channel.logoURL {
+            EPGLogoCache.shared.load(url) { [weak self] image in self?.logo.image = image }
+        }
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        logo.image = nil
+    }
+
+    private var topClip: CGFloat = 0
+    private let clipMask = CAShapeLayer()
+    override func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
+        super.apply(layoutAttributes)
+        topClip = (layoutAttributes as? EPGCellAttributes)?.topClip ?? 0
+        applyClip()
+    }
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        applyClip()
+    }
+    private func applyClip() {
+        let gap = EPGTheme.cellSpacing
+        guard topClip > gap, bounds.height > 0 else { layer.mask = nil; return }
+        let rect = CGRect(x: gap, y: topClip,
+                          width: max(bounds.width - gap * 2, 0),
+                          height: max(bounds.height - gap - topClip, 0))
+        let r = EPGTheme.columnCorner
+        clipMask.path = UIBezierPath(roundedRect: rect, byRoundingCorners: [.topLeft, .topRight],
+                                     cornerRadii: CGSize(width: r, height: r)).cgPath
+        layer.mask = clipMask
+    }
+}
+
+final class TimeRulerView: UICollectionReusableView {
+    static let reuseID = "TimeRulerView"
+    private var boxes: [UIView] = []
+    private var start = Date()
+    private var totalMinutes = 0
+    private var transparent = false
+
+    func configure(start: Date, totalMinutes: Int, transparent: Bool = false) {
+        backgroundColor = transparent ? .clear : UIColor(EPGTheme.background)
+        guard start != self.start || totalMinutes != self.totalMinutes || transparent != self.transparent else { return }
+        self.start = start
+        self.totalMinutes = totalMinutes
+        self.transparent = transparent
+        boxes.forEach { $0.removeFromSuperview() }
+        boxes.removeAll()
+
+        let ppm = EPGTheme.pointsPerMinute
+        let gap = EPGTheme.cellSpacing
+        let slot = 30
+        let fill = transparent ? UIColor(white: 0, alpha: 0.28) : UIColor(EPGTheme.columnFill)
+        let boxH = EPGTheme.timelineBoxHeight
+        var minute = 0
+        while minute < totalMinutes {
+            let box = UIView()
+            box.backgroundColor = fill
+            box.layer.cornerRadius = EPGTheme.columnCorner
+            box.layer.cornerCurve = .continuous
+            box.frame = CGRect(x: CGFloat(minute) * ppm + gap,
+                               y: EPGTheme.timelineHeight - gap - boxH,
+                               width: CGFloat(slot) * ppm - gap * 2, height: boxH)
+            let label = UILabel()
+            label.font = .systemFont(ofSize: 18, weight: .semibold)
+            label.textColor = .white
+            label.text = start.addingTimeInterval(Double(minute) * 60)
+                .formatted(.dateTime.hour().minute())
+            label.translatesAutoresizingMaskIntoConstraints = false
+            box.addSubview(label)
+            NSLayoutConstraint.activate([
+                label.leadingAnchor.constraint(equalTo: box.leadingAnchor, constant: 16),
+                label.centerYAnchor.constraint(equalTo: box.centerYAnchor),
+            ])
+            addSubview(box)
+            boxes.append(box)
+            minute += slot
+        }
+    }
+
+    private var leftClip: CGFloat = 0
+    override func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
+        super.apply(layoutAttributes)
+        leftClip = (layoutAttributes as? EPGCellAttributes)?.leftClip ?? 0
+        applyClip()
+    }
+    override func layoutSubviews() { super.layoutSubviews(); applyClip() }
+    private func applyClip() {
+        guard leftClip > 0, bounds.width > leftClip else { layer.mask = nil; return }
+        let m = CALayer()
+        m.backgroundColor = UIColor.white.cgColor
+        m.frame = CGRect(x: leftClip, y: 0, width: bounds.width - leftClip, height: bounds.height)
+        layer.mask = m
+    }
+}
+
+final class CornerView: UICollectionReusableView {
+    static let reuseID = "CornerView"
+    private let box = UIView()
+    private let label = UILabel()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .clear
+        box.layer.cornerRadius = EPGTheme.columnCorner
+        box.layer.cornerCurve = .continuous
+        box.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(box)
+        label.font = .systemFont(ofSize: 20, weight: .bold)
+        label.textColor = .white
+        label.translatesAutoresizingMaskIntoConstraints = false
+        box.addSubview(label)
+
+        let gap = EPGTheme.cellSpacing
+        let boxH = EPGTheme.timelineBoxHeight
+        NSLayoutConstraint.activate([
+            box.leadingAnchor.constraint(equalTo: leadingAnchor, constant: gap),
+            box.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -gap),
+            box.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -gap),
+            box.heightAnchor.constraint(equalToConstant: boxH),
+            label.leadingAnchor.constraint(equalTo: box.leadingAnchor, constant: 14),
+            label.centerYAnchor.constraint(equalTo: box.centerYAnchor),
+        ])
+    }
+    required init?(coder: NSCoder) { fatalError() }
+
+    /// Shows "TODAY" when the timeline starts today, otherwise the weekday.
+    func configure(date d: Date, transparent: Bool = false) {
+        box.backgroundColor = transparent ? UIColor(white: 0, alpha: 0.28) : UIColor(EPGTheme.columnFill)
+        if Calendar.current.isDateInToday(d) {
+            label.text = "TODAY"
+        } else {
+            label.text = d.formatted(.dateTime.weekday(.abbreviated)).uppercased()
+        }
+    }
+}
+
+// MARK: - Logo cache
+
+final class EPGLogoCache {
+    static let shared = EPGLogoCache()
+    private let cache = NSCache<NSURL, UIImage>()
+
+    func load(_ url: URL, completion: @escaping (UIImage?) -> Void) {
+        if let cached = cache.object(forKey: url as NSURL) { completion(cached); return }
+        URLSession.shared.dataTask(with: url) { [weak self] data, _, _ in
+            guard let data, let image = UIImage(data: data) else { return }
+            self?.cache.setObject(image, forKey: url as NSURL)
+            DispatchQueue.main.async { completion(image) }
+        }.resume()
+    }
+}
+
+// MARK: - Info bar
+
+/// Plex-style guide header: a poster + details on the left, scrolling beneath
+/// the grid. Uses the focused programme's icon (from XMLTV) or the channel logo.
+struct GuideInfoBar: View {
+    let channel: UnifiedChannel?
+    let program: UnifiedProgram?
+
+    /// Programme artwork for the poster, prioritising a 2:3 portrait image and
+    /// falling back to any programme icon. The channel logo is handled
+    /// separately so it can be letterboxed into a 2:3 frame.
+    private var programImageURL: URL? {
+        program?.posterURL ?? program?.iconURL ?? program?.landscapeURL
+    }
+
+    var body: some View {
+        content
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    /// Fixed poster height; width follows the image's own aspect ratio so a
+    /// 2:3 poster shows 2:3 and a 16:9 fallback shows 16:9 (never cropped).
+    private let posterHeight: CGFloat = 252
+
+    private var content: some View {
+        HStack(alignment: .top, spacing: 30) {
+            poster
+
+            VStack(alignment: .leading, spacing: 10) {
+                if let channel {
+                    Text(channelLine(channel))
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundStyle(EPGTheme.textSecondary)
+                }
+                Text(program?.title ?? "Select a programme")
+                    .font(.system(size: 44, weight: .bold))
+                    .foregroundStyle(EPGTheme.textPrimary)
+                    .lineLimit(1)
+                if let program {
+                    Text(timeRange(program))
+                        .font(.system(size: 22, weight: .medium))
+                        .foregroundStyle(EPGTheme.textSecondary)
+                }
+                if let desc = program?.description, !desc.isEmpty {
+                    Text(desc)
+                        .font(.system(size: 22))
+                        .foregroundStyle(EPGTheme.textSecondary)
+                        .lineLimit(3)
+                        .frame(maxWidth: 820, alignment: .leading)
+                }
+                Spacer(minLength: 0)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.leading, EPGTheme.cellSpacing)
+        .padding(.trailing, 48)
+        .padding(.top, 39)
+        .padding(.bottom, 9)
+    }
+
+    /// 2:3 poster box width.
+    private var posterWidth: CGFloat { posterHeight * 2.0 / 3.0 }
+
+    /// Fixed 2:3 poster slot. Everything (programme artwork, the logo fallback,
+    /// the placeholder) is aspect-fit into the same frame, so the layout never
+    /// jumps when an image finishes loading, and nothing is stretched or cropped
+    /// (wider images get transparent bars).
+    @ViewBuilder private var poster: some View {
+        ZStack {
+            EPGTheme.surface            // blank grey 2:3 card behind the artwork
+            posterContent
+        }
+        .frame(width: posterWidth, height: posterHeight)
+        .clipShape(RoundedRectangle(cornerRadius: EPGTheme.columnCorner))
+        .shadow(color: .black.opacity(0.4), radius: 8, y: 3)
+    }
+
+    @ViewBuilder private var posterContent: some View {
+        if let url = programImageURL {
+            CachedAsyncImage(url: url) { phase in
+                switch phase {
+                case .success(let image):
+                    image.resizable().aspectRatio(contentMode: .fit)
+                default:
+                    logoInset
+                }
+            }
+        } else {
+            logoInset
+        }
+    }
+
+    /// Channel logo (or a glyph) inset on the blank grey card with padding, fit
+    /// without stretching or cropping.
+    @ViewBuilder private var logoInset: some View {
+        if let logo = channel?.logoURL {
+            CachedAsyncImage(url: logo) { phase in
+                switch phase {
+                case .success(let image):
+                    image.resizable().aspectRatio(contentMode: .fit).padding(24)
+                default:
+                    placeholderGlyph
+                }
+            }
+        } else {
+            placeholderGlyph
+        }
+    }
+
+    /// Placeholder glyph, shown while loading or when no artwork/logo exists.
+    private var placeholderGlyph: some View {
+        Image(systemName: "tv").font(.system(size: 40)).foregroundStyle(EPGTheme.textSecondary)
+    }
+
+    private func channelLine(_ channel: UnifiedChannel) -> String {
+        if let number = channel.channelNumber { return "\(number) · \(channel.name)" }
+        return channel.name
+    }
+
+    private func timeRange(_ program: UnifiedProgram) -> String {
+        let f = Date.FormatStyle.dateTime.hour().minute()
+        return "\(program.startTime.formatted(f)) — \(program.endTime.formatted(f))"
+    }
+}

--- a/Rivulet/Views/LiveTV/GuideLayoutView.swift
+++ b/Rivulet/Views/LiveTV/GuideLayoutView.swift
@@ -2,15 +2,22 @@
 //  GuideLayoutView.swift
 //  Rivulet
 //
+//  UHF-style Live TV guide host. Three layers: the UIKit-backed EPG grid
+//  (bottom, virtualized, with its own pinned channel column + time ruler +
+//  now-line), the info bar on top, and the fullscreen / PiP player overlay.
+//  The grid is `EPGGuide` (see EPGGuideView.swift), ported from PlexGuide and
+//  fed by Rivulet's `LiveTVDataStore`.
+//
 
 import SwiftUI
+import Combine
+import UIKit
 
-
-/// Display mode for Live TV player in guide view
+/// Display mode for the Live TV player in the guide.
 enum LiveTVDisplayMode: Equatable {
     case hidden      // No player visible
     case fullscreen  // Player is fullscreen overlay
-    case pip         // Player is in PIP (small, top-right)
+    case pip         // Player is in PiP (small, top-right)
 }
 
 struct GuideLayoutView: View {
@@ -19,564 +26,396 @@ struct GuideLayoutView: View {
 
     @StateObject private var dataStore = LiveTVDataStore.shared
 
-    /// Channels filtered by source (if specified)
-    private var channels: [UnifiedChannel] {
+    /// Selected category tab. nil = "All Channels"; otherwise an M3U group title.
+    @State private var selectedGroup: String?
+    @FocusState private var focusedCategory: String?
+
+    /// Channels for the current source, before category filtering.
+    private var sourceChannels: [UnifiedChannel] {
         if let sourceId = sourceIdFilter {
             return dataStore.channels.filter { $0.sourceId == sourceId }
         }
         return dataStore.channels
     }
 
-    // PIP state management
+    /// Distinct, sorted M3U group titles used as category tabs.
+    private var groupTitles: [String] {
+        let groups = sourceChannels.compactMap {
+            $0.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
+        }.filter { !$0.isEmpty }
+        return Array(Set(groups)).sorted()
+    }
+
+    /// Channels shown in the grid: source-filtered, then category-filtered.
+    private var channels: [UnifiedChannel] {
+        guard let group = selectedGroup else { return sourceChannels }
+        return sourceChannels.filter {
+            $0.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines) == group
+        }
+    }
+
+    /// Programmes keyed by channel id (the EPGGuide indexes by `channel.id`).
+    /// Channels with no matched guide data get placeholder 4-hour blocks so
+    /// their rows still render focusable cells — without them the row has
+    /// nothing to land on and the channel can't be selected at all.
+    private var programsByChannel: [String: [UnifiedProgram]] {
+        var epg = dataStore.epg
+        for channel in channels where (epg[channel.id]?.isEmpty ?? true) {
+            epg[channel.id] = Self.placeholderPrograms(channelId: channel.id, from: timelineStart)
+        }
+        return epg
+    }
+
+    /// 4-hour "No guide data available." blocks spanning the visible timeline.
+    /// Block boundaries are derived from the (fixed) timeline start, so ids
+    /// stay stable across the 30s `now` ticks and don't churn the grid.
+    private static func placeholderPrograms(channelId: String, from start: Date) -> [UnifiedProgram] {
+        let blockSeconds: TimeInterval = 4 * 3600
+        let span = TimeInterval(EPGTheme.timelineSpanHours * 3600)
+        var programs: [UnifiedProgram] = []
+        var blockStart = start
+        while blockStart < start.addingTimeInterval(span) {
+            let blockEnd = blockStart.addingTimeInterval(blockSeconds)
+            programs.append(UnifiedProgram(
+                id: "\(channelId):placeholder:\(Int(blockStart.timeIntervalSince1970))",
+                channelId: channelId,
+                title: "No guide data available.",
+                startTime: blockStart,
+                endTime: blockEnd
+            ))
+            blockStart = blockEnd
+        }
+        return programs
+    }
+
+    private var totalMinutes: Int { EPGTheme.timelineSpanHours * 60 }
+
+    /// Height of the category tab bar between the info bar and the time ruler.
+    private let categoryBarHeight: CGFloat = 64
+
+    // Player state
     @State private var activeChannel: UnifiedChannel?
     @State private var playerSessionId = UUID()
     @State private var displayMode: LiveTVDisplayMode = .hidden
-    @State private var debugId = String(UUID().uuidString.prefix(8))
 
-    @State private var guideStartTime = Date()
-    @State private var focusedRow = 0
-    @State private var focusedColumn = 0
-    @State private var timeOffset = 0  // In 30-min increments for scrolling ahead
-    @FocusState private var hasFocus: Bool
+    // Guide state
+    @State private var timelineStart = Date()
+    @State private var now = Date()
+    @State private var focusedChannel: UnifiedChannel?
+    @State private var focusedProgram: UnifiedProgram?
+
+    private let tick = Timer.publish(every: 30, on: .main, in: .common).autoconnect()
 
     var body: some View {
         GeometryReader { geo in
             ZStack(alignment: .topLeading) {
-                // Background
-                Rectangle().fill(.background).ignoresSafeArea()
+                // No custom base: when the focused programme has no artwork the
+                // stock system background (the same one Settings uses) shows
+                // through. When artwork exists, `ambiance` paints it on top.
+                ambiance
 
-                // Guide content - always rendered but visually hidden when fullscreen
                 if channels.isEmpty {
                     ProgressView()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
-                    guideView(size: geo.size)
+                    guideContent
                         .opacity(displayMode == .fullscreen ? 0 : 1)
                         .disabled(displayMode == .fullscreen)
                 }
 
-                // Player layer - present when activeChannel exists
+                // EPG failure banner — surfaced so an empty guide doesn't look
+                // like a Rivulet bug when the cause is a broken third-party EPG.
+                if !dataStore.epgIssues.isEmpty, displayMode != .fullscreen {
+                    EPGIssueBanner(issues: dataStore.epgIssues)
+                        .padding(.horizontal, 40)
+                        .padding(.top, 16)
+                        .frame(maxWidth: .infinity, alignment: .top)
+                        .allowsHitTesting(false)
+                }
+
+                // Player layer — present when a channel is active.
                 if let channel = activeChannel {
                     liveTVPlayerLayer(channel: channel, screenSize: geo.size)
                         .zIndex(displayMode == .fullscreen ? 100 : 10)
                 }
             }
         }
-        .onAppear {
-            setupStartTime()
-        }
+        .ignoresSafeArea(edges: [.bottom, .trailing])
+        .onAppear(perform: setupStartTime)
         .task {
             if dataStore.channels.isEmpty { await dataStore.loadChannels() }
-            if dataStore.epg.isEmpty { await dataStore.loadEPG(startDate: Date(), hours: 6) }
+            if dataStore.epg.isEmpty {
+                await dataStore.loadEPG(startDate: Date(), hours: EPGTheme.timelineSpanHours)
+            }
+            seedFocus()
         }
-        // Animation disabled for instant PIP transitions
-        .onChange(of: displayMode) { oldMode, newMode in
-            if oldMode == .fullscreen && newMode == .pip {
-                // Transitioning to PIP - focus guide immediately (no animation delay)
-                DispatchQueue.main.async {
-                    hasFocus = true
-                }
-            } else if oldMode == .pip && newMode == .fullscreen {
-                // Returning to fullscreen - clear guide focus
-                hasFocus = false
-            } else if newMode == .hidden {
-                // Player dismissed - focus guide
-                hasFocus = true
+        .onChange(of: channels.count) { _, _ in seedFocus() }
+        .onReceive(tick) { t in now = t }
+    }
+
+    // MARK: - Guide (grid + info bar)
+
+    private var guideContent: some View {
+        ZStack(alignment: .topLeading) {
+            EPGGuide(
+                channels: channels,
+                programsByChannel: programsByChannel,
+                timelineStart: timelineStart,
+                totalMinutes: totalMinutes,
+                now: now,
+                menuActive: displayMode == .fullscreen,
+                onFocus: { channel, program in
+                    focusedChannel = channel
+                    focusedProgram = program
+                },
+                onSelect: { channel, _ in selectChannel(channel) },
+                transparent: true,                 // dark see-through boxes + rounded clipping
+                // Reserve the info bar + category bar above the ruler.
+                topInset: EPGTheme.infoBarHeight + categoryBarHeight
+            )
+
+            VStack(alignment: .leading, spacing: 0) {
+                GuideInfoBar(channel: focusedChannel, program: focusedProgram)
+                    .frame(height: EPGTheme.infoBarHeight)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .allowsHitTesting(false)
+
+                categoryBar
+                    .frame(height: categoryBarHeight)
             }
         }
     }
 
-    // MARK: - PIP Player Layer
+    // MARK: - Category bar ("All Channels" + M3U group titles)
 
-    /// PIP sizing constants
+    @ViewBuilder private var categoryBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 14) {
+                categoryButton(title: "All Channels", group: nil)
+                ForEach(groupTitles, id: \.self) { group in
+                    categoryButton(title: group, group: group)
+                }
+            }
+            .padding(.leading, EPGTheme.cellSpacing)
+            .padding(.trailing, 60)
+            .padding(.vertical, 10)
+        }
+        .focusSection()
+    }
+
+    private func categoryButton(title: String, group: String?) -> some View {
+        let selected = (selectedGroup == group)
+        let focused = (focusedCategory == title)
+        // White pill when it's the active filter, grey pill when focused,
+        // nothing otherwise. The system focus effect is disabled so the pill
+        // is the only focus indicator.
+        let pillColor: Color = selected ? Color.white
+            : (focused ? Color.white.opacity(0.22) : Color.clear)
+        let textColor: Color = selected ? EPGTheme.background
+            : (focused ? Color.white : EPGTheme.textSecondary)
+        return Button {
+            if selectedGroup != group {
+                selectedGroup = group
+                focusedChannel = nil        // reseed focus onto the filtered lineup
+                seedFocus()
+            }
+        } label: {
+            Text(title)
+                .font(.system(size: 24, weight: .semibold))
+                .foregroundStyle(textColor)
+                .padding(.horizontal, 22)
+                .padding(.vertical, 8)
+                .background(Capsule().fill(pillColor))
+        }
+        .buttonStyle(CategoryTabButtonStyle())
+        .focusEffectDisabled()
+        .focused($focusedCategory, equals: title)
+        .animation(.easeInOut(duration: 0.15), value: focused)
+        .animation(.easeInOut(duration: 0.15), value: selected)
+    }
+
+    /// The focused programme's image, strong at the top and dimming to a faint
+    /// ambiance over the grid.
+    /// The guide backdrop: a 16:9 landscape programme image that is DISTINCT from
+    /// the poster artwork. If the programme's only image is a single reused one
+    /// (e.g. a channel logo serving as the programme icon), there's no real
+    /// backdrop and the stock settings background shows instead.
+    private var guideBackdropURL: URL? {
+        guard let prog = focusedProgram, let landscape = prog.landscapeURL else { return nil }
+        let posterSource = prog.posterURL ?? prog.iconURL ?? prog.landscapeURL
+        return landscape != posterSource ? landscape : nil
+    }
+
+    /// A constant full-screen layer. The backdrop image is drawn INSIDE it as an
+    /// overlay, so toggling the image (as focus moves between programmes with and
+    /// without a backdrop) never changes this layer's geometry — which is what
+    /// was nudging the grid. Only a genuine 16:9 image distinct from the poster
+    /// is used; otherwise the stock settings background shows through the clear.
+    private var ambiance: some View {
+        GeometryReader { geo in
+            if let url = guideBackdropURL {
+                ZStack(alignment: .topTrailing) {
+                    // Vibrant wash: the SOURCE image itself, blurred + stretched
+                    // to fill the whole guide, so its real colours bleed across
+                    // and down the screen. A left + bottom scrim keeps the
+                    // metadata column and grid readable.
+                    backdropImage(url)
+                        .frame(width: geo.size.width, height: geo.size.height)
+                        .clipped()
+                        .blur(radius: 70, opaque: true)
+                        .overlay(
+                            LinearGradient(
+                                colors: [Color.black.opacity(0.72), Color.black.opacity(0.05)],
+                                startPoint: .leading, endPoint: .trailing)
+                        )
+                        .overlay(
+                            LinearGradient(
+                                colors: [Color.clear, Color.black.opacity(0.65)],
+                                startPoint: .top, endPoint: .bottom)
+                        )
+
+                    // Crisp image in the top-right quarter; its left + bottom
+                    // edges fade into the blurred wash.
+                    backdropImage(url)
+                        .frame(width: geo.size.width * 0.5, height: geo.size.height * 0.55)
+                        .clipped()
+                        .mask(
+                            LinearGradient(colors: [.clear, .white],
+                                           startPoint: .leading, endPoint: .trailing)
+                        )
+                        .mask(
+                            LinearGradient(stops: [
+                                .init(color: .white, location: 0.0),
+                                .init(color: .white, location: 0.45),
+                                .init(color: .clear, location: 1.0)
+                            ], startPoint: .top, endPoint: .bottom)
+                        )
+                }
+                .frame(width: geo.size.width, height: geo.size.height, alignment: .topTrailing)
+            }
+        }
+        .ignoresSafeArea()
+    }
+
+    @ViewBuilder private func backdropImage(_ url: URL) -> some View {
+        CachedAsyncImage(url: url) { phase in
+            switch phase {
+            case .success(let img): img.resizable().scaledToFill()
+            default: Color.clear
+            }
+        }
+    }
+
+    // MARK: - Player layer (fullscreen + PiP)
+
     private var pipScale: CGFloat { 0.28 }
     private var pipMargin: CGFloat { 60 }
 
     @ViewBuilder
     private func liveTVPlayerLayer(channel: UnifiedChannel, screenSize: CGSize) -> some View {
-        let isPIP = displayMode == .pip
-        // Keep PiP at exact 16:9 with integral 16px width steps to avoid
-        // fractional scaling artifacts (can appear as a bottom strip).
-        let rawPipWidth = screenSize.width * pipScale
-        let pipWidth = max(16, floor(rawPipWidth / 16.0) * 16.0)
-        let pipHeight = pipWidth * 9.0 / 16.0
-        let pipSize = CGSize(width: pipWidth, height: pipHeight)
-        let targetSize = isPIP ? pipSize : screenSize
-        let targetCenter = CGPoint(
-            x: isPIP ? (screenSize.width - pipMargin - targetSize.width / 2) : (screenSize.width / 2),
-            y: isPIP ? (pipMargin + targetSize.height / 2) : (screenSize.height / 2)
-        )
-
-        LiveTVPlayerView(
+        let player = LiveTVPlayerView(
             channel: channel,
             onDismiss: {
                 displayMode = .hidden
                 activeChannel = nil
                 playerSessionId = UUID()
-                hasFocus = false
-                DispatchQueue.main.async {
-                    hasFocus = true
-                }
             },
             onEnterPIP: {
-                // Instant transition to PIP - no animation
                 var transaction = Transaction()
                 transaction.animation = nil
                 withTransaction(transaction) {
                     displayMode = .pip
                 }
             },
-            isInteractive: displayMode == .fullscreen  // Disable focus capture in PIP mode
+            isInteractive: displayMode == .fullscreen  // Disable focus capture in PiP mode
         )
         // Force a fresh player session when changing channels or after exit/reopen.
         .id("\(playerSessionId.uuidString)-\(channel.id)")
-        .frame(width: targetSize.width, height: targetSize.height)
-        // Keep player frame changes immediate to avoid transient scale/zoom artifacts.
         .transaction { transaction in
             transaction.animation = nil
         }
         .animation(nil, value: displayMode)
-        .clipShape(RoundedRectangle(cornerRadius: isPIP ? 14 : 0, style: .continuous))
-        .shadow(color: isPIP ? .black.opacity(0.5) : .clear, radius: 20, x: 0, y: 10)
-        .position(x: targetCenter.x, y: targetCenter.y)
-        .allowsHitTesting(displayMode == .fullscreen)
-    }
 
-    private func setupStartTime() {
-        let now = Date()
-        let cal = Calendar.current
-        let min = cal.component(.minute, from: now)
-        guideStartTime = cal.date(bySettingHour: cal.component(.hour, from: now),
-                                   minute: (min / 30) * 30, second: 0, of: now) ?? now
-    }
-
-    // MARK: - Main Guide View
-
-    private func guideView(size: CGSize) -> some View {
-        let channelWidth: CGFloat = 280
-        let rowHeight: CGFloat = 110
-        let headerHeight: CGFloat = 52
-        let gridWidth = size.width - channelWidth
-        let pxPerMin = gridWidth / 180  // Show 3 hours
-        let visibleStart = guideStartTime.addingTimeInterval(Double(timeOffset * 30 * 60))
-        let visibleEnd = visibleStart.addingTimeInterval(180 * 60)
-
-        return Button {
-            selectFocusedChannel(trigger: "button")
-        } label: {
-            VStack(spacing: 0) {
-                // EPG failure banner — surfaced so an empty guide doesn't look
-                // like a Rivulet bug when the real cause is a broken third-party
-                // EPG URL (404/DNS/timeout/etc).
-                if !dataStore.epgIssues.isEmpty {
-                    EPGIssueBanner(issues: dataStore.epgIssues)
-                        .padding(.horizontal, 40)
-                        .padding(.top, 16)
-                        .padding(.bottom, 8)
-                }
-
-                // Header row with time slots
-                HStack(spacing: 0) {
-                    Color(white: 0.08)
-                        .frame(width: channelWidth, height: headerHeight)
-                    TimeHeaderView(startTime: visibleStart, width: gridWidth,
-                                  height: headerHeight, pxPerMin: pxPerMin)
-                }
-
-                // Divider between header and channel list
-                Rectangle()
-                    .fill(Color.white.opacity(0.15))
-                    .frame(height: 1)
-
-                // Scrollable channel list
-                ScrollViewReader { proxy in
-                        ScrollView(.vertical, showsIndicators: false) {
-                            ZStack(alignment: .topLeading) {
-                                // Use LazyVStack to avoid rendering all channels at once
-                                // This prevents memory pressure and focus system overload on older devices
-                                LazyVStack(spacing: 0, pinnedViews: []) {
-                                    ForEach(Array(channels.enumerated()), id: \.element.id) { idx, ch in
-                                        HStack(spacing: 0) {
-                                            ChannelCell(channel: ch, isSelected: idx == focusedRow,
-                                                       width: channelWidth, height: rowHeight)
-                                            ProgramRowView(
-                                                programs: dataStore.getPrograms(for: ch, startDate: visibleStart, endDate: visibleEnd),
-                                                startTime: visibleStart,
-                                                width: gridWidth,
-                                                height: rowHeight,
-                                                pxPerMin: pxPerMin,
-                                                isRowFocused: idx == focusedRow,
-                                                focusedCol: idx == focusedRow ? focusedColumn : nil
-                                            )
-                                        }
-                                        .id(idx)
-                                    }
-                                }
-
-                                // Time line overlay (inside scroll content)
-                                TimeLineView(now: Date(), startTime: visibleStart, endTime: visibleEnd,
-                                            headerHeight: 0, pxPerMin: pxPerMin,
-                                            totalHeight: CGFloat(channels.count) * rowHeight)
-                                    .offset(x: channelWidth)
-                                    .allowsHitTesting(false)
-                            }
-                        }
-                        .onChange(of: focusedRow) { _, row in
-                            withAnimation(.easeOut(duration: 0.15)) {
-                                proxy.scrollTo(row, anchor: .center)
-                            }
-                        }
-                    }
-                    .frame(maxHeight: .infinity)
-            }
-        }
-        .buttonStyle(GuideButtonStyle())
-        // Fallback for cases where tvOS focus remains visible but primary Button action
-        // is not delivered after overlay dismissal.
-        .simultaneousGesture(TapGesture().onEnded {
-            selectFocusedChannel(trigger: "tap_fallback")
-        })
-        .focused($hasFocus)
-        .focusSection()  // Prevent focus from escaping to sidebar trigger
-        .focusable(displayMode != .fullscreen)  // Disable focus when player is fullscreen
-        .onAppear { hasFocus = true }
-        .onChange(of: channels.count) { _, count in
-            if count > 0, focusedRow >= count {
-                focusedRow = max(0, count - 1)
-            } else {
-            }
-        }
-        .onMoveCommand { dir in
-            guard displayMode != .fullscreen else { return }  // Don't handle when player is fullscreen
-            handleNav(dir)
-        }
-        .onExitCommand {
-            guard displayMode != .fullscreen else { return }  // Don't handle when player is fullscreen
-            hasFocus = false
+        if displayMode == .pip {
+            // PiP: a small 16:9 box pinned top-right. Integral 16px width steps
+            // avoid fractional scaling artifacts (a thin bottom strip).
+            let pipWidth = max(16, floor((screenSize.width * pipScale) / 16.0) * 16.0)
+            let pipHeight = pipWidth * 9.0 / 16.0
+            player
+                .frame(width: pipWidth, height: pipHeight)
+                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                .shadow(color: .black.opacity(0.5), radius: 20, x: 0, y: 10)
+                .position(x: screenSize.width - pipMargin - pipWidth / 2,
+                          y: pipMargin + pipHeight / 2)
+                .allowsHitTesting(false)
+        } else {
+            // Fullscreen: fill the true screen and ignore the guide's safe-area
+            // inset. Sizing to the GeometryReader's (inset) size is what made the
+            // player render as a centered box instead of edge-to-edge.
+            player
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .ignoresSafeArea()
+                .allowsHitTesting(true)
         }
     }
 
-    // MARK: - Channel Selection
-
-    private func selectFocusedChannel(trigger: String) {
-        if displayMode == .fullscreen {
-            return
-        }
-
-        guard focusedRow < channels.count else {
-            return
-        }
-
-        let channel = channels[focusedRow]
-        selectChannel(channel)
-    }
+    // MARK: - Selection
 
     private func selectChannel(_ channel: UnifiedChannel) {
-        if displayMode == .pip {
-            // Already playing - switch channel if different, then go fullscreen
-            if activeChannel?.id != channel.id {
-                playerSessionId = UUID()
-                activeChannel = channel
-            }
-            // Instant transition to fullscreen - no animation
-            var transaction = Transaction()
-            transaction.animation = nil
-            withTransaction(transaction) {
-                displayMode = .fullscreen
-            }
-        } else {
-            // Start fresh - no animation needed
-            playerSessionId = UUID()
-            activeChannel = channel
-            displayMode = .fullscreen
+        // Live TV plays through Aether (same OSD as Aether VOD): HLS goes
+        // straight to AVPlayer, everything else is remuxed by the engine.
+        // Presented as a full-screen modal so it escapes the guide's
+        // TabView / safe-area insets.
+        guard let scene = UIApplication.shared.connectedScenes
+                .compactMap({ $0 as? UIWindowScene }).first,
+              let root = (scene.windows.first(where: { $0.isKeyWindow }) ?? scene.windows.first)?.rootViewController
+        else { return }
+
+        var top = root
+        while let presented = top.presentedViewController { top = presented }
+
+        let vc = LiveTVAetherPlayerViewController(channel: channel)
+        vc.modalPresentationStyle = .fullScreen
+        top.present(vc, animated: true)
+    }
+
+    // MARK: - Helpers
+
+    private func setupStartTime() {
+        let cal = Calendar.current
+        let nowDate = Date()
+        let minute = cal.component(.minute, from: nowDate)
+        timelineStart = cal.date(bySettingHour: cal.component(.hour, from: nowDate),
+                                 minute: (minute / 30) * 30, second: 0, of: nowDate) ?? nowDate
+    }
+
+    private func seedFocus() {
+        guard let first = channels.first else {
+            focusedChannel = nil
+            focusedProgram = nil
+            return
         }
-    }
-
-    private func handleNav(_ dir: MoveCommandDirection) {
-        guard !channels.isEmpty else { return }
-
-        switch dir {
-        case .up:
-            if focusedRow > 0 {
-                focusedRow -= 1
-                clampCol()
-            } else if displayMode == .pip {
-                // At top of guide and PIP is showing - return to fullscreen (no animation)
-                var transaction = Transaction()
-                transaction.animation = nil
-                withTransaction(transaction) {
-                    displayMode = .fullscreen
-                }
-            }
-        case .down:
-            if focusedRow < channels.count - 1 {
-                focusedRow += 1
-                clampCol()
-            }
-        case .left:
-            if focusedColumn > 0 {
-                focusedColumn -= 1
-            } else if timeOffset > 0 {
-                // Scroll back in time
-                timeOffset -= 1
-                focusedColumn = 0  // Start at first program when scrolling back
-            }
-        case .right:
-            let visibleStart = guideStartTime.addingTimeInterval(Double(timeOffset * 30 * 60))
-            let visibleEnd = visibleStart.addingTimeInterval(180 * 60)
-            let count = progCountFor(start: visibleStart, end: visibleEnd)
-            if focusedColumn < count - 1 {
-                focusedColumn += 1
-            } else if timeOffset < 18 {  // Allow 9 hours ahead (18 x 30min)
-                // Scroll forward in time
-                timeOffset += 1
-                focusedColumn = 0
-            }
-        @unknown default: break
+        if focusedChannel == nil {
+            focusedChannel = first
+            focusedProgram = dataStore.getCurrentProgram(for: first)
+                ?? dataStore.epg[first.id]?.first
         }
-    }
-
-    private func clampCol() {
-        let visibleStart = guideStartTime.addingTimeInterval(Double(timeOffset * 30 * 60))
-        let visibleEnd = visibleStart.addingTimeInterval(180 * 60)
-        focusedColumn = min(focusedColumn, max(0, progCountFor(start: visibleStart, end: visibleEnd) - 1))
-    }
-
-    private func progCountFor(start: Date, end: Date) -> Int {
-        guard focusedRow >= 0 && focusedRow < channels.count else { return 1 }
-        return max(1, dataStore.getPrograms(for: channels[focusedRow],
-                                            startDate: start, endDate: end).count)
     }
 }
 
-// Custom button style with no focus chrome
-private struct GuideButtonStyle: ButtonStyle {
+// MARK: - Category tab button style
+
+/// Renders only the label — no default background, scale, or focus chrome — so
+/// the pill (driven by `@FocusState`) is the sole focus indicator.
+private struct CategoryTabButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
+            .opacity(configuration.isPressed ? 0.75 : 1.0)
     }
 }
 
-// MARK: - Subviews
+// MARK: - EPG failure banner
 
-private struct ChannelCell: View {
-    let channel: UnifiedChannel
-    let isSelected: Bool
-    let width: CGFloat
-    let height: CGFloat
-
-    var body: some View {
-        HStack(spacing: 10) {
-            // Channel logo - use CachedAsyncImage for better memory management
-            Group {
-                if let logoURL = channel.logoURL {
-                    CachedAsyncImage(url: logoURL) { phase in
-                        switch phase {
-                        case .success(let image):
-                            image
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                        default:
-                            Image(systemName: "tv")
-                                .font(.system(size: 36))
-                                .foregroundColor(.white.opacity(0.3))
-                        }
-                    }
-                } else {
-                    Image(systemName: "tv")
-                        .font(.system(size: 36))
-                        .foregroundColor(.white.opacity(0.3))
-                }
-            }
-            .frame(width: 100, height: 70)
-
-            // Channel info
-            VStack(alignment: .leading, spacing: 4) {
-                if let n = channel.channelNumber {
-                    Text("\(n)")
-                        .font(.system(size: 18, weight: .bold, design: .rounded))
-                        .foregroundColor(.white.opacity(0.5))
-                }
-                Text(channel.name)
-                    .font(.system(size: 20, weight: .semibold))
-                    .foregroundColor(.white)
-                    .lineLimit(2)
-                    .minimumScaleFactor(0.8)
-            }
-            Spacer(minLength: 0)
-        }
-        .padding(.leading, 12)
-        .frame(width: width, height: height)
-        .background(Color(white: isSelected ? 0.2 : 0.1))
-        .animation(.spring(response: 0.25, dampingFraction: 0.8), value: isSelected)
-    }
-}
-
-private struct TimeHeaderView: View {
-    let startTime: Date
-    let width: CGFloat
-    let height: CGFloat
-    let pxPerMin: CGFloat
-
-    private static let fmt: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "h:mm a"
-        return f
-    }()
-
-    var body: some View {
-        HStack(spacing: 0) {
-            ForEach(0..<6, id: \.self) { i in  // 6 x 30min = 3hrs
-                Text(Self.fmt.string(from: startTime.addingTimeInterval(Double(i * 30 * 60))))
-                    .font(.system(size: 22, weight: .semibold))
-                    .foregroundColor(.white.opacity(0.8))
-                    .frame(width: pxPerMin * 30, alignment: .leading)
-                    .padding(.leading, 14)
-            }
-        }
-        .frame(width: width, height: height, alignment: .leading)
-        .background(Color(white: 0.12))
-    }
-}
-
-private struct ProgramRowView: View {
-    let programs: [UnifiedProgram]
-    let startTime: Date
-    let width: CGFloat
-    let height: CGFloat
-    let pxPerMin: CGFloat
-    let isRowFocused: Bool
-    let focusedCol: Int?
-
-    private let endTime: Date
-
-    init(programs: [UnifiedProgram], startTime: Date, width: CGFloat, height: CGFloat,
-         pxPerMin: CGFloat, isRowFocused: Bool, focusedCol: Int?) {
-        self.programs = programs
-        self.startTime = startTime
-        self.width = width
-        self.height = height
-        self.pxPerMin = pxPerMin
-        self.isRowFocused = isRowFocused
-        self.focusedCol = focusedCol
-        self.endTime = startTime.addingTimeInterval(180 * 60)
-    }
-
-    var body: some View {
-        ZStack(alignment: .leading) {
-            Rectangle().fill(Color(white: isRowFocused ? 0.08 : 0.05))
-
-            if programs.isEmpty {
-                ProgramCell(title: "No Data", time: nil, x: 2, cellWidth: width - 4,
-                           height: height, isFocused: isRowFocused, isAiring: false)
-            } else {
-                ForEach(Array(programs.enumerated()), id: \.element.id) { idx, prog in
-                    let (x, w) = position(prog)
-                    let now = Date()
-                    ProgramCell(
-                        title: prog.title,
-                        time: Self.fmt.string(from: prog.startTime),
-                        x: x,
-                        cellWidth: w,
-                        height: height,
-                        isFocused: isRowFocused && focusedCol == idx,
-                        isAiring: prog.startTime <= now && prog.endTime > now
-                    )
-                }
-            }
-        }
-        .frame(width: width, height: height)
-        .clipped()
-    }
-
-    private func position(_ p: UnifiedProgram) -> (CGFloat, CGFloat) {
-        let visStart = max(p.startTime, startTime)
-        let visEnd = min(p.endTime, endTime)
-        let x = CGFloat(visStart.timeIntervalSince(startTime) / 60) * pxPerMin
-        let w = max(CGFloat(visEnd.timeIntervalSince(visStart) / 60) * pxPerMin, 60)
-        return (x, w)
-    }
-
-    private static let fmt: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "h:mm a"
-        return f
-    }()
-}
-
-private struct ProgramCell: View {
-    let title: String
-    let time: String?
-    let x: CGFloat
-    let cellWidth: CGFloat
-    let height: CGFloat
-    let isFocused: Bool
-    let isAiring: Bool
-
-    var body: some View {
-        // Match the native tvOS highlight effect styling
-        // Normal: 0.12, Airing: 0.18, Focused: 0.35 (distinct from airing)
-        let bg: Color = {
-            if isFocused {
-                return Color(white: 0.35)
-            } else if isAiring {
-                return Color(white: 0.18)
-            } else {
-                return Color(white: 0.12)
-            }
-        }()
-
-        VStack(alignment: .leading, spacing: 4) {
-            Text(title)
-                .font(.system(size: 22, weight: .semibold))
-                .foregroundColor(.white)
-                .lineLimit(2)
-            if let t = time {
-                Text(t)
-                    .font(.system(size: 16))
-                    .foregroundColor(.white.opacity(0.6))
-            }
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .frame(width: cellWidth - 6, height: height - 14, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(bg)
-        )
-        // Lift shadow when focused (mimics tvOS highlight)
-        .shadow(color: isFocused ? .black.opacity(0.6) : .clear, radius: 12, x: 0, y: 6)
-        .scaleEffect(isFocused ? 1.02 : 1.0, anchor: .leading)
-        .zIndex(isFocused ? 1 : 0)
-        .animation(.spring(response: 0.25, dampingFraction: 0.8), value: isFocused)
-        .offset(x: x + 3)
-    }
-}
-
-private struct TimeLineView: View {
-    let now: Date
-    let startTime: Date
-    let endTime: Date
-    let headerHeight: CGFloat
-    let pxPerMin: CGFloat
-    let totalHeight: CGFloat
-
-    var body: some View {
-        if now >= startTime && now <= endTime {
-            let x = CGFloat(now.timeIntervalSince(startTime) / 60) * pxPerMin
-            Rectangle()
-                .fill(Color.red)
-                .frame(width: 2, height: totalHeight)
-                .offset(x: x)
-        }
-    }
-}
-
-// MARK: - EPG Issue Banner
-
-/// Passive banner shown above the guide when one or more EPG fetches failed.
-/// Tells the user *which* source failed and *why* in a short phrase, so that
-/// an empty guide reads as "your EPG server is down" rather than "Rivulet is
-/// broken". Non-focusable by design — the fix belongs in Settings or on the
-/// upstream server, not behind a button here.
 private struct EPGIssueBanner: View {
     let issues: [LiveTVDataStore.EPGFetchIssue]
 
@@ -617,4 +456,3 @@ private struct EPGIssueBanner: View {
         )
     }
 }
-

--- a/Rivulet/Views/LiveTV/LiveGuideInfoCardView.swift
+++ b/Rivulet/Views/LiveTV/LiveGuideInfoCardView.swift
@@ -1,0 +1,117 @@
+//
+//  LiveGuideInfoCardView.swift
+//  Rivulet
+//
+//  Rail-panel info card for Live TV. The VOD player's CardInfoView is built
+//  around PlexMetadata; live channels have no Plex metadata, so this card is
+//  fed from the guide (UnifiedProgram) instead: channel line, the programme
+//  airing now (title, time range, summary), and what's on next.
+//
+//  Presented inside PlayerRailPanelView, which supplies the glass, the focus
+//  fence, and Menu handling. The card itself is one focusable block (same
+//  model as CardInfoView) so the panel ring carries the focus treatment.
+//
+
+import UIKit
+
+final class LiveGuideInfoCardView: UIView {
+
+    /// Mirrors CardInfoView's hook: the panel brightens its border while the
+    /// card holds focus.
+    var onFocusChange: ((Bool) -> Void)?
+
+    init(channel: UnifiedChannel, current: UnifiedProgram?, next: UnifiedProgram?) {
+        super.init(frame: .zero)
+
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 10
+        stack.alignment = .fill
+        addSubview(stack)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: topAnchor),
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+
+        // Channel line: "7 · Seven"
+        let channelLabel = UILabel()
+        channelLabel.font = .systemFont(ofSize: 22, weight: .semibold)
+        channelLabel.textColor = UIColor.white.withAlphaComponent(0.66)
+        channelLabel.text = [channel.channelNumber.map(String.init), channel.name]
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
+            .joined(separator: " · ")
+        stack.addArrangedSubview(channelLabel)
+
+        // Now playing
+        let titleLabel = UILabel()
+        titleLabel.font = .systemFont(ofSize: 30, weight: .bold)
+        titleLabel.textColor = .white
+        titleLabel.numberOfLines = 2
+        titleLabel.text = current?.title ?? "No guide data available."
+        stack.addArrangedSubview(titleLabel)
+
+        if let current {
+            let timeLabel = UILabel()
+            timeLabel.font = .systemFont(ofSize: 20, weight: .regular)
+            timeLabel.textColor = UIColor.white.withAlphaComponent(0.55)
+            timeLabel.text = Self.timeRange(current)
+            stack.addArrangedSubview(timeLabel)
+
+            if let summary = current.description, !summary.isEmpty {
+                let summaryLabel = UILabel()
+                summaryLabel.font = .systemFont(ofSize: 21, weight: .regular)
+                summaryLabel.textColor = UIColor.white.withAlphaComponent(0.8)
+                summaryLabel.numberOfLines = 7
+                summaryLabel.text = summary
+                stack.setCustomSpacing(14, after: timeLabel)
+                stack.addArrangedSubview(summaryLabel)
+            }
+        }
+
+        // Up next
+        if let next {
+            let nextHeader = UILabel()
+            nextHeader.font = .systemFont(ofSize: 20, weight: .semibold)
+            nextHeader.textColor = UIColor.white.withAlphaComponent(0.5)
+            nextHeader.text = "UP NEXT"
+            if let last = stack.arrangedSubviews.last {
+                stack.setCustomSpacing(22, after: last)
+            }
+            stack.addArrangedSubview(nextHeader)
+
+            let nextLabel = UILabel()
+            nextLabel.font = .systemFont(ofSize: 23, weight: .medium)
+            nextLabel.textColor = .white
+            nextLabel.numberOfLines = 2
+            nextLabel.text = "\(Self.timeRange(next))  \(next.title)"
+            stack.setCustomSpacing(6, after: nextHeader)
+            stack.addArrangedSubview(nextLabel)
+        }
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    private static func timeRange(_ program: UnifiedProgram) -> String {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        formatter.dateStyle = .none
+        return "\(formatter.string(from: program.startTime)) – \(formatter.string(from: program.endTime))"
+    }
+
+    // MARK: - Focus
+
+    override var canBecomeFocused: Bool { true }
+
+    override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+        super.didUpdateFocus(in: context, with: coordinator)
+        if context.nextFocusedView === self {
+            onFocusChange?(true)
+        } else if context.previouslyFocusedView === self {
+            onFocusChange?(false)
+        }
+    }
+}

--- a/Rivulet/Views/LiveTV/LiveTVAetherPlayerViewController.swift
+++ b/Rivulet/Views/LiveTV/LiveTVAetherPlayerViewController.swift
@@ -1,0 +1,631 @@
+//
+//  LiveTVAetherPlayerViewController.swift
+//  Rivulet
+//
+//  Live TV player on Rivulet's own chrome (no AVKit). Video renders through
+//  the engine surface (`AetherPlayerView` → `engine.bind(view:)`), which hosts
+//  whichever layer the active backend uses — AVPlayerLayer on the native /
+//  loopback-HLS paths, AVSampleBufferDisplayLayer on the software path
+//  (MPEG-2, interlaced H.264). Audio is engine-owned: with no AVKit in the
+//  picture the renderer activates the audio session itself, which is what the
+//  multi-stream grid already relies on.
+//
+//  Chrome: the same UIKit glass rail as Aether VOD (PlayerRailView +
+//  PlayerRailPanelView), driven by GUIDE data instead of Plex metadata —
+//  programme title/times from LiveTVDataStore's EPG, subtitle and audio
+//  pickers from the engine's track lists (CardTrackListView), and a
+//  guide-fed info card (LiveGuideInfoCardView). Select shows the rail,
+//  Menu hides it (or dismisses the player when it's already hidden).
+//
+//  Subtitles (including DVB/teletext decoded engine-side) render through
+//  AetherSubtitleOverlayView, the same overlay Aether VOD uses.
+//
+//  Playback routing (inside `AetherPlayer.loadLive`):
+//    - plain HLS (.m3u8 / format=hls) → nativeRemoteHLS: AVPlayer plays the
+//      remote playlist directly, engine re-attaches its layer to the surface.
+//    - raw MPEG-TS and Plex tuned sessions (progressive start.ts remux) →
+//      engine demux/decode.
+//
+//  Failure ladder (each stage re-resolves the URL — fresh Plex tune/session):
+//    0 primary → 1 engine demux → 2 bare AVPlayer on an AVPlayerLayer.
+//
+
+import AVKit
+import AetherEngine
+import Combine
+import SwiftUI
+import UIKit
+
+final class LiveTVAetherPlayerViewController: UIViewController {
+
+    private let channel: UnifiedChannel
+
+    private var aetherPlayer: AetherPlayer?
+
+    /// Engine render surface — the only correct way to display Aether video.
+    private let engineSurfaceView = AetherPlayerView()
+
+    /// Shown until the first frame plays; the engine spins up demux + decode
+    /// before any picture, so give the user something in the meantime.
+    private let loadingSpinner = UIActivityIndicatorView(style: .large)
+
+    private let subtitleModel = SubtitleModel()
+    private var subtitleHostingController: UIHostingController<AetherSubtitleOverlayView>?
+    private var captionStyle: CaptionStyle = CaptionAppearance.current()
+    private var cancellables = Set<AnyCancellable>()
+
+    /// Last-resort AVPlayer (fallback stage 2) rendered on its own layer.
+    private var lastResortPlayer: AVPlayer?
+    private var lastResortLayer: AVPlayerLayer?
+
+    /// Escalating recovery for playback failures (a Plex session can die
+    /// server-side after load): 0 = primary, 1 = fresh URL + engine demux,
+    /// 2 = fresh URL + bare AVPlayer.
+    private var fallbackStage = 0
+    private var isFallbackInFlight = false
+
+    /// Plex releases a tuned /livetv/sessions grab unless the client reports
+    /// a timeline periodically. Pings every 60s while playing; a final
+    /// "stopped" ping on teardown releases the tuner promptly.
+    private var keepAliveTask: Task<Void, Never>?
+    private var stopPingURL: URL?
+
+    // MARK: Chrome state
+
+    /// Same glass rail as Aether VOD; Up Next and Insights are hidden (they
+    /// have no meaning for a live broadcast).
+    private let railView = PlayerRailView()
+    private var railVisible = false
+    private var activePanel: PlayerRailPanelView?
+    private var autoHideTimer: Timer?
+    private var programInfoTimer: Timer?
+
+    /// Invisible focus target that holds focus while the chrome is hidden so
+    /// remote presses reach this VC through the responder chain (tvOS routes
+    /// presses via the focused view; a fullscreen video with no focusable
+    /// content would swallow them).
+    private final class FocusCatcherView: UIView {
+        override var canBecomeFocused: Bool { true }
+    }
+    private let focusCatcher = FocusCatcherView()
+
+    /// Called once when the player is dismissed, so the guide can restore state.
+    var onDismiss: (() -> Void)?
+
+    init(channel: UnifiedChannel) {
+        self.channel = channel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .black
+
+        engineSurfaceView.frame = view.bounds
+        engineSurfaceView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        view.addSubview(engineSurfaceView)
+
+        loadingSpinner.color = .white
+        loadingSpinner.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(loadingSpinner)
+        NSLayoutConstraint.activate([
+            loadingSpinner.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            loadingSpinner.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+        loadingSpinner.startAnimating()
+
+        mountSubtitleOverlay()
+        observeCaptionAppearance()
+        setupChrome()
+
+        let aether = AetherPlayer()
+        aetherPlayer = aether
+        aether.bind(view: engineSurfaceView)
+        bindAetherSubtitles(aether)
+
+        aether.playbackStatePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                guard let self else { return }
+                switch state {
+                case .playing:
+                    self.loadingSpinner.stopAnimating()
+                case .failed:
+                    guard !self.isFallbackInFlight else { return }
+                    self.advanceFallback()
+                default:
+                    break
+                }
+            }
+            .store(in: &cancellables)
+
+        // Keep the rail's audio meta line current as the engine reports tracks.
+        aether.$audioTracks
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.updateRailContent() }
+            .store(in: &cancellables)
+
+        Task { @MainActor in
+            // Resolve performs the Plex tune step for cloud-EPG/DVB channels;
+            // other sources pass straight through.
+            guard let url = await LiveTVDataStore.shared.resolveStreamURL(for: channel) else {
+                onDismiss?()
+                dismiss(animated: true)
+                return
+            }
+            startLiveSessionKeepAlive(for: url)
+            do {
+                try await aether.loadLive(url: url, headers: nil)
+                aether.play()
+            } catch {
+                self.advanceFallback()
+            }
+        }
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        guard isBeingDismissed || isMovingFromParent else { return }
+        stopLiveSessionKeepAlive()
+        autoHideTimer?.invalidate()
+        autoHideTimer = nil
+        programInfoTimer?.invalidate()
+        programInfoTimer = nil
+        activePanel?.dismissPanel()
+        activePanel = nil
+        if let hosting = subtitleHostingController {
+            hosting.willMove(toParent: nil)
+            hosting.view.removeFromSuperview()
+            hosting.removeFromParent()
+            subtitleHostingController = nil
+        }
+        NotificationCenter.default.removeObserver(
+            self,
+            name: CaptionAppearance.changedNotification,
+            object: nil
+        )
+        lastResortPlayer?.pause()
+        lastResortPlayer = nil
+        lastResortLayer?.removeFromSuperlayer()
+        lastResortLayer = nil
+        aetherPlayer?.stop()
+        aetherPlayer?.unbind(view: engineSurfaceView)
+        aetherPlayer = nil
+        cancellables.removeAll()
+        onDismiss?()
+    }
+
+    // MARK: - Chrome (glass rail + panels)
+
+    private func setupChrome() {
+        // Focus catcher: 1pt, transparent, always present.
+        focusCatcher.frame = CGRect(x: 0, y: 0, width: 1, height: 1)
+        focusCatcher.backgroundColor = .clear
+        view.addSubview(focusCatcher)
+
+        railView.setUpNextAvailable(false)
+        railView.setInsightsAvailable(false)
+        railView.setLoading(false)
+        railView.alpha = 0
+        railView.transform = CGAffineTransform(translationX: 0, y: 24)
+        view.addSubview(railView)
+        railView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            railView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 90),
+            railView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -90),
+            railView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -84),
+            railView.heightAnchor.constraint(equalToConstant: PlayerRailView.railHeight),
+        ])
+
+        railView.onSubtitles = { [weak self] in self?.presentSubtitlePanel() }
+        railView.onAudio = { [weak self] in self?.presentAudioPanel() }
+        railView.onInfo = { [weak self] in self?.presentInfoPanel() }
+
+        updateRailContent()
+
+        // The guide's "current programme" rolls over on its own clock.
+        programInfoTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.updateRailContent() }
+        }
+    }
+
+    /// Rail metadata from GUIDE data: programme title, channel line, air
+    /// window, and the engine's current audio track.
+    private func updateRailContent() {
+        let current = LiveTVDataStore.shared.getCurrentProgram(for: channel)
+
+        let eyebrow = [channel.channelNumber.map(String.init), channel.name]
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
+            .joined(separator: " · ")
+        railView.setTitle(current?.title ?? channel.name, eyebrow: eyebrow.isEmpty ? nil : eyebrow)
+
+        var runtime: String?
+        if let current {
+            let formatter = DateFormatter()
+            formatter.timeStyle = .short
+            formatter.dateStyle = .none
+            runtime = "\(formatter.string(from: current.startTime)) – \(formatter.string(from: current.endTime))"
+        }
+
+        var audioDescription: String?
+        if let aether = aetherPlayer,
+           let activeId = aether.currentAudioTrackId,
+           let track = aether.audioTracks.first(where: { $0.id == activeId }) {
+            audioDescription = [track.language, track.codec?.uppercased()]
+                .compactMap { $0 }
+                .joined(separator: " ")
+        }
+
+        railView.setMeta(rating: "LIVE", runtime: runtime, audio: audioDescription)
+    }
+
+    private func showRail() {
+        guard !railVisible else { return }
+        railVisible = true
+        updateRailContent()
+        UIView.animate(withDuration: 0.25) {
+            self.railView.alpha = 1
+            self.railView.transform = .identity
+        }
+        rebuildSubtitleOverlay()
+        setNeedsFocusUpdate()
+        updateFocusIfNeeded()
+        restartAutoHide()
+    }
+
+    private func hideRail() {
+        guard railVisible else { return }
+        railVisible = false
+        autoHideTimer?.invalidate()
+        autoHideTimer = nil
+        railView.resetFocusMemory()
+        UIView.animate(withDuration: 0.2) {
+            self.railView.alpha = 0
+            self.railView.transform = CGAffineTransform(translationX: 0, y: 24)
+        }
+        rebuildSubtitleOverlay()
+        setNeedsFocusUpdate()
+        updateFocusIfNeeded()
+    }
+
+    /// Chrome auto-hides after a few idle seconds, same spirit as the VOD
+    /// container. Any focus movement inside the rail restarts the clock; an
+    /// open panel suspends it.
+    private func restartAutoHide() {
+        autoHideTimer?.invalidate()
+        autoHideTimer = Timer.scheduledTimer(withTimeInterval: 6, repeats: false) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self, self.activePanel == nil else { return }
+                self.hideRail()
+            }
+        }
+    }
+
+    override var preferredFocusEnvironments: [UIFocusEnvironment] {
+        if let activePanel { return [activePanel] }
+        return railVisible ? [railView] : [focusCatcher]
+    }
+
+    override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+        super.didUpdateFocus(in: context, with: coordinator)
+        if railVisible, activePanel == nil,
+           let next = context.nextFocusedView, next.isDescendant(of: railView) {
+            restartAutoHide()
+        }
+    }
+
+    // MARK: - Panels
+
+    private func presentPanel(content: UIView, width: CGFloat) {
+        guard activePanel == nil else { return }
+        autoHideTimer?.invalidate()
+        autoHideTimer = nil
+        let panel = PlayerRailPanelView.present(
+            content: content,
+            width: width,
+            in: view,
+            aboveRail: railView,
+            towards: railView
+        )
+        panel.onDismiss = { [weak self] in
+            guard let self else { return }
+            self.activePanel = nil
+            self.setNeedsFocusUpdate()
+            self.updateFocusIfNeeded()
+            self.restartAutoHide()
+        }
+        activePanel = panel
+        setNeedsFocusUpdate()
+        updateFocusIfNeeded()
+    }
+
+    private func presentSubtitlePanel() {
+        guard let aether = aetherPlayer else { return }
+        let list = CardTrackListView(
+            header: "Subtitles",
+            tracks: aether.subtitleTracks,
+            selectedTrackId: aether.currentSubtitleTrackId,
+            showsOffRow: true
+        ) { [weak self] trackId in
+            self?.aetherPlayer?.selectSubtitleTrack(id: trackId)
+            self?.activePanel?.dismissPanel()
+        }
+        presentPanel(content: list, width: 520)
+    }
+
+    private func presentAudioPanel() {
+        guard let aether = aetherPlayer else { return }
+        let list = CardTrackListView(
+            header: "Audio",
+            tracks: aether.audioTracks,
+            selectedTrackId: aether.currentAudioTrackId,
+            showsOffRow: false
+        ) { [weak self] trackId in
+            if let trackId { self?.aetherPlayer?.selectAudioTrack(id: trackId) }
+            self?.activePanel?.dismissPanel()
+            self?.updateRailContent()
+        }
+        presentPanel(content: list, width: 520)
+    }
+
+    private func presentInfoPanel() {
+        let card = LiveGuideInfoCardView(
+            channel: channel,
+            current: LiveTVDataStore.shared.getCurrentProgram(for: channel),
+            next: LiveTVDataStore.shared.getNextProgram(for: channel)
+        )
+        presentPanel(content: card, width: 560)
+        card.onFocusChange = { [weak self] focused in
+            self?.activePanel?.setFocusHighlight(focused)
+        }
+    }
+
+    // MARK: - Remote handling
+
+    override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        for press in presses {
+            switch press.type {
+            case .menu:
+                // An open panel fences focus and consumes Menu itself; this
+                // branch is only the focus-outside-panel edge case.
+                if let activePanel {
+                    activePanel.dismissPanel()
+                    return
+                }
+                if railVisible {
+                    hideRail()
+                    return
+                }
+                dismiss(animated: true)
+                return
+            case .select:
+                if !railVisible {
+                    showRail()
+                    return
+                }
+            case .playPause:
+                togglePlayPause()
+                return
+            default:
+                break
+            }
+        }
+        super.pressesBegan(presses, with: event)
+    }
+
+    override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        // Menu is fully consumed at began; an unswallowed ended phase bubbles
+        // to the system and peels an extra layer.
+        for press in presses where press.type == .menu { return }
+        super.pressesEnded(presses, with: event)
+    }
+
+    private func togglePlayPause() {
+        if let lastResortPlayer {
+            lastResortPlayer.rate == 0 ? lastResortPlayer.play() : lastResortPlayer.pause()
+        } else if let aetherPlayer {
+            aetherPlayer.isPlaying ? aetherPlayer.pause() : aetherPlayer.play()
+        }
+    }
+
+    // MARK: - Failure ladder
+
+    /// Move to the next recovery stage. Each stage re-resolves the stream URL
+    /// so Plex channels get a FRESH tune/session (a dead session keeps
+    /// erroring). Non-Plex URLs re-resolve unchanged.
+    private func advanceFallback() {
+        fallbackStage += 1
+        guard fallbackStage <= 2 else {
+            loadingSpinner.stopAnimating()
+            return
+        }
+        let stage = fallbackStage
+
+        isFallbackInFlight = true
+        loadingSpinner.startAnimating()
+        Task { @MainActor in
+            defer { isFallbackInFlight = false }
+            guard let freshURL = await LiveTVDataStore.shared.resolveStreamURL(for: channel) else { return }
+            startLiveSessionKeepAlive(for: freshURL)
+
+            if stage == 1 {
+                // Retry through the engine's own demuxer (no native-HLS
+                // shortcut). Plex URLs also drop directPlay → 0 here: if the
+                // server refused raw passthrough on the first attempt, the
+                // fresh session retries as a pure direct-stream remux.
+                let retryURL = Self.forcingDirectStream(freshURL)
+                do {
+                    aetherPlayer?.stop()
+                    try await aetherPlayer?.loadLive(url: retryURL, headers: nil, forceEngineDemux: true)
+                    aetherPlayer?.play()
+                } catch {
+                    advanceFallback()
+                }
+            } else {
+                // Last resort: bare AVPlayer on its own layer (engine is done).
+                aetherPlayer?.stop()
+                aetherPlayer?.unbind(view: engineSurfaceView)
+                aetherPlayer = nil
+
+                let avPlayer = AVPlayer(url: freshURL)
+                let layer = AVPlayerLayer(player: avPlayer)
+                layer.frame = view.bounds
+                layer.videoGravity = .resizeAspect
+                view.layer.insertSublayer(layer, at: 0)
+                lastResortPlayer = avPlayer
+                lastResortLayer = layer
+                avPlayer.play()
+                loadingSpinner.stopAnimating()
+            }
+        }
+    }
+
+    /// Rewrite `directPlay=1` → `0` on Plex universal-transcode URLs so the
+    /// retry runs as a direct-stream remux. URLs without that query item
+    /// (IPTV, HDHomeRun raw TS) pass through untouched.
+    private static func forcingDirectStream(_ url: URL) -> URL {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              var items = components.queryItems,
+              let index = items.firstIndex(where: { $0.name == "directPlay" }) else {
+            return url
+        }
+        items[index] = URLQueryItem(name: "directPlay", value: "0")
+        components.queryItems = items
+        return components.url ?? url
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        lastResortLayer?.frame = view.bounds
+    }
+
+    // MARK: - Live session keepalive (Plex tuner grabs)
+
+    /// If the stream URL carries a tuned Plex live session, report a timeline
+    /// every 60s so the server keeps the tuner grab alive, and remember a
+    /// "stopped" ping to release it on dismiss. No-op for non-Plex streams.
+    private func startLiveSessionKeepAlive(for url: URL) {
+        keepAliveTask?.cancel()
+        keepAliveTask = nil
+        stopPingURL = nil
+
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let token = components.queryItems?.first(where: { $0.name == "X-Plex-Token" })?.value,
+              let scheme = components.scheme,
+              let host = components.host else { return }
+
+        // Session path comes from either form of tuned URL:
+        //  - direct part:          /livetv/sessions/<uuid>/<tuner>/index.m3u8
+        //  - universal transcode:  …start.ts?path=/livetv/sessions/<uuid>
+        let sessionPath: String
+        if url.path.hasPrefix("/livetv/sessions/") {
+            let parts = url.path.split(separator: "/")  // [livetv, sessions, uuid, …]
+            guard parts.count >= 3 else { return }
+            sessionPath = "/livetv/sessions/\(parts[2])"
+        } else if let queryPath = components.queryItems?.first(where: { $0.name == "path" })?.value,
+                  queryPath.hasPrefix("/livetv/sessions/") {
+            sessionPath = queryPath
+        } else {
+            return  // Not a tuned Plex session — no keepalive needed.
+        }
+
+        let port = components.port.map { ":\($0)" } ?? ""
+
+        func timelineURL(state: String) -> URL? {
+            var ping = URLComponents(string: "\(scheme)://\(host)\(port)/:/timeline")
+            ping?.queryItems = [
+                URLQueryItem(name: "key", value: sessionPath),
+                URLQueryItem(name: "state", value: state),
+                URLQueryItem(name: "time", value: "0"),
+                URLQueryItem(name: "X-Plex-Client-Identifier", value: PlexAPI.clientIdentifier),
+                URLQueryItem(name: "X-Plex-Token", value: token)
+            ]
+            return ping?.url
+        }
+
+        stopPingURL = timelineURL(state: "stopped")
+        guard let playingURL = timelineURL(state: "playing") else { return }
+
+        keepAliveTask = Task.detached(priority: .utility) {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(60))
+                guard !Task.isCancelled else { return }
+                _ = try? await URLSession.shared.data(from: playingURL)
+            }
+        }
+    }
+
+    private func stopLiveSessionKeepAlive() {
+        keepAliveTask?.cancel()
+        keepAliveTask = nil
+        if let stopURL = stopPingURL {
+            stopPingURL = nil
+            Task.detached(priority: .utility) {
+                _ = try? await URLSession.shared.data(from: stopURL)
+            }
+        }
+    }
+
+    // MARK: - Subtitle overlay (same overlay as Aether VOD)
+
+    private func mountSubtitleOverlay() {
+        let hosting = UIHostingController(rootView: makeOverlayRootView())
+        hosting.view.backgroundColor = .clear
+        hosting.view.isUserInteractionEnabled = false
+
+        addChild(hosting)
+        view.addSubview(hosting.view)
+        hosting.view.frame = view.bounds
+        hosting.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        hosting.didMove(toParent: self)
+
+        subtitleHostingController = hosting
+    }
+
+    private func makeOverlayRootView() -> AetherSubtitleOverlayView {
+        AetherSubtitleOverlayView(
+            model: subtitleModel,
+            style: captionStyle,
+            controlsVisible: railVisible  // lift captions above the glass rail
+        )
+    }
+
+    private func rebuildSubtitleOverlay() {
+        subtitleHostingController?.rootView = makeOverlayRootView()
+    }
+
+    private func bindAetherSubtitles(_ aether: AetherPlayer) {
+        aether.$subtitleCues
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] cues in self?.subtitleModel.update(cues: cues) }
+            .store(in: &cancellables)
+
+        aether.$sourceTime
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] time in self?.subtitleModel.sourceTime = time }
+            .store(in: &cancellables)
+    }
+
+    // MARK: - Caption appearance
+
+    private func observeCaptionAppearance() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(captionAppearanceDidChange),
+            name: CaptionAppearance.changedNotification,
+            object: nil
+        )
+    }
+
+    @objc private func captionAppearanceDidChange() {
+        captionStyle = CaptionAppearance.current()
+        rebuildSubtitleOverlay()
+    }
+}

--- a/Rivulet/Views/LiveTV/LiveTVAetherPlayerViewController.swift
+++ b/Rivulet/Views/LiveTV/LiveTVAetherPlayerViewController.swift
@@ -70,6 +70,11 @@ final class LiveTVAetherPlayerViewController: UIViewController {
     private var keepAliveTask: Task<Void, Never>?
     private var stopPingURL: URL?
 
+    /// The in-flight stream resolve/load (and its fallback retries). Held so it
+    /// can be cancelled on dismissal — otherwise a slow Plex tune could finish
+    /// after teardown and spin a new player/keep-alive on an off-screen VC.
+    private var streamLoadTask: Task<Void, Never>?
+
     // MARK: Chrome state
 
     /// Same glass rail as Aether VOD; Up Next and Insights are hidden (they
@@ -151,19 +156,23 @@ final class LiveTVAetherPlayerViewController: UIViewController {
             .sink { [weak self] _ in self?.updateRailContent() }
             .store(in: &cancellables)
 
-        Task { @MainActor in
+        streamLoadTask = Task { @MainActor in
             // Resolve performs the Plex tune step for cloud-EPG/DVB channels;
             // other sources pass straight through.
             guard let url = await LiveTVDataStore.shared.resolveStreamURL(for: channel) else {
+                if Task.isCancelled { return }
                 onDismiss?()
                 dismiss(animated: true)
                 return
             }
+            if Task.isCancelled { return }
             startLiveSessionKeepAlive(for: url)
             do {
                 try await aether.loadLive(url: url, headers: nil)
+                if Task.isCancelled { return }
                 aether.play()
             } catch {
+                if Task.isCancelled { return }
                 self.advanceFallback()
             }
         }
@@ -172,6 +181,8 @@ final class LiveTVAetherPlayerViewController: UIViewController {
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         guard isBeingDismissed || isMovingFromParent else { return }
+        streamLoadTask?.cancel()
+        streamLoadTask = nil
         stopLiveSessionKeepAlive()
         autoHideTimer?.invalidate()
         autoHideTimer = nil
@@ -450,9 +461,10 @@ final class LiveTVAetherPlayerViewController: UIViewController {
 
         isFallbackInFlight = true
         loadingSpinner.startAnimating()
-        Task { @MainActor in
+        streamLoadTask = Task { @MainActor in
             defer { isFallbackInFlight = false }
             guard let freshURL = await LiveTVDataStore.shared.resolveStreamURL(for: channel) else { return }
+            if Task.isCancelled { return }
             startLiveSessionKeepAlive(for: freshURL)
 
             if stage == 1 {
@@ -464,12 +476,15 @@ final class LiveTVAetherPlayerViewController: UIViewController {
                 do {
                     aetherPlayer?.stop()
                     try await aetherPlayer?.loadLive(url: retryURL, headers: nil, forceEngineDemux: true)
+                    if Task.isCancelled { return }
                     aetherPlayer?.play()
                 } catch {
+                    if Task.isCancelled { return }
                     advanceFallback()
                 }
             } else {
                 // Last resort: bare AVPlayer on its own layer (engine is done).
+                if Task.isCancelled { return }
                 aetherPlayer?.stop()
                 aetherPlayer?.unbind(view: engineSurfaceView)
                 aetherPlayer = nil

--- a/Rivulet/Views/LiveTV/MultiStreamViewModel.swift
+++ b/Rivulet/Views/LiveTV/MultiStreamViewModel.swift
@@ -218,9 +218,9 @@ final class MultiStreamViewModel: ObservableObject {
             layoutMode = .grid
         }
 
-        // Start playback
+        // Start playback (resolve = Plex tune step for cloud-EPG/DVB channels)
         let loadStartTime = Date()
-        if let url = LiveTVDataStore.shared.buildStreamURL(for: channel) {
+        if let url = await LiveTVDataStore.shared.resolveStreamURL(for: channel) {
 
             // Determine stream type for logging
             let streamType: String = {
@@ -509,8 +509,8 @@ final class MultiStreamViewModel: ObservableObject {
             layoutMode = .focus(mainId: newSlot.id)
         }
 
-        // Start playback
-        if let url = LiveTVDataStore.shared.buildStreamURL(for: channel) {
+        // Start playback (resolve = Plex tune step for cloud-EPG/DVB channels)
+        if let url = await LiveTVDataStore.shared.resolveStreamURL(for: channel) {
             // Log stream replacement attempt for debugging
             let breadcrumb = Breadcrumb(level: .info, category: "livetv_playback")
             breadcrumb.message = "Replacing Live TV stream"
@@ -912,7 +912,7 @@ final class MultiStreamViewModel: ObservableObject {
         recoveringSlots.insert(slotId)
         defer { recoveringSlots.remove(slotId) }
 
-        guard let url = LiveTVDataStore.shared.buildStreamURL(for: channel) else {
+        guard let url = await LiveTVDataStore.shared.resolveStreamURL(for: channel) else {
             scheduleAutoRecovery(for: slotId, channel: channel, reason: "no-url")
             return
         }

--- a/Rivulet/Views/Player/Aether/AetherSubtitleOverlayView.swift
+++ b/Rivulet/Views/Player/Aether/AetherSubtitleOverlayView.swift
@@ -10,7 +10,8 @@
 //  routes, so subtitles sit at the same height on every route):
 //    true  -> 368 pt bottom padding (rail bottom inset 84 + railHeight 260
 //             + 24 gap; clears the 3a glass rail)
-//    false -> 60 pt bottom padding (minimal clear of screen edge)
+//    false -> 100 pt bottom padding (same resting height as the AVPlayer
+//             route's SubtitleOverlayView, mirroring native caption placement)
 //
 
 import SwiftUI
@@ -29,8 +30,11 @@ struct AetherSubtitleOverlayView: View {
 
     // Bottom padding constants (pts). controlsVisiblePadding =
     // PlayerRailView.railHeight (260) + rail bottom inset (84) + 24 gap.
+    // defaultPadding matches SubtitleOverlayView's resting bottomOffset (100)
+    // on the AVPlayer route, which mirrors native AVPlayer caption placement —
+    // 60 sat visibly too close to the screen edge.
     private static let controlsVisiblePadding: CGFloat = 368
-    private static let defaultPadding: CGFloat = 60
+    private static let defaultPadding: CGFloat = 100
 
     var body: some View {
         GeometryReader { geo in
@@ -49,6 +53,14 @@ struct AetherSubtitleOverlayView: View {
 
                 // Text cues: stack vertically at bottom-centre. Also keyed by
                 // contentKey; see the note above.
+                //
+                // ORDER MATTERS: the bottom padding must be applied INSIDE the
+                // full-screen frame (padding first, then frame). Padding after
+                // the frame grows the composite beyond the screen — the frame
+                // stays screen-height, the ZStack top-anchors it, and the
+                // padding hangs invisibly off the bottom edge, so the inset
+                // never lifted the text at all (subs sat glued to the edge and
+                // the rail lift was a no-op).
                 VStack(spacing: 4) {
                     ForEach(model.activeCues.filter(\.isText), id: \.contentKey) { cue in
                         if case .text(let string) = cue.body {
@@ -56,10 +68,10 @@ struct AetherSubtitleOverlayView: View {
                         }
                     }
                 }
-                .frame(width: geo.size.width, height: geo.size.height, alignment: .bottom)
                 .padding(.bottom, controlsVisible
                     ? Self.controlsVisiblePadding
                     : Self.defaultPadding)
+                .frame(width: geo.size.width, height: geo.size.height, alignment: .bottom)
             }
         }
         .allowsHitTesting(false)

--- a/Rivulet/Views/Player/UniversalPlayerView.swift
+++ b/Rivulet/Views/Player/UniversalPlayerView.swift
@@ -944,9 +944,10 @@ struct UniversalPlayerView: View {
             } else if viewModel.player != nil {
                 SubtitleOverlayView(
                     subtitleManager: viewModel.subtitleManager,
-                    // 368 = rail bottom inset 84 + railHeight 260 + 24 gap
-                    // (matches AetherSubtitleOverlayView's controlsVisiblePadding).
-                    bottomOffset: (viewModel.showControls || viewModel.isScrubbing) ? 368 : 60
+                    // 368 = rail bottom inset 84 + railHeight 260 + 24 gap;
+                    // resting 100 — both match AetherSubtitleOverlayView so
+                    // captions sit at the same height on every route.
+                    bottomOffset: (viewModel.showControls || viewModel.isScrubbing) ? 368 : 100
                 )
                 .ignoresSafeArea()
             }

--- a/TopShelfExtension/Info.plist
+++ b/TopShelfExtension/Info.plist
@@ -2,10 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>arm64</string>
-	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
Complete visual overhaul of Live TV and change of playback engine.

EPG updated to look similar to the old Plex tvOS app.

HLS will funnel through Aether into Native AVPlayer playback

Other streams should remix through Aether - though largely untested and certainly not my expertise.

Visuals, navigate and OSD may have bugs and be rough around the edges but all in all I think this is un update on what was currently in place and a good starting point to build Live TV off.

BONUS: Also fixed VOD Aether subtitles positioning - now raised off the bottom of the screen and will shuffle up if the OSD is brought onto the screen)