### PR TITLE
Hero timer skip markers

### DIFF
--- a/Rivulet.xcodeproj/project.pbxproj
+++ b/Rivulet.xcodeproj/project.pbxproj
@@ -361,7 +361,7 @@
 				CODE_SIGN_ENTITLEMENTS = TopShelfExtension/TopShelfExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 66;
-				DEVELOPMENT_TEAM = ZHB786H6YN;
+				DEVELOPMENT_TEAM = UXB66N824W;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TopShelfExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = TopShelfExtension;
@@ -372,7 +372,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0.3;
-				PRODUCT_BUNDLE_IDENTIFIER = com.gstudios.rivulet.TopShelfExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jbstudios.rivulet.TopShelfExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
@@ -392,7 +392,7 @@
 				CODE_SIGN_ENTITLEMENTS = TopShelfExtension/TopShelfExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 66;
-				DEVELOPMENT_TEAM = ZHB786H6YN;
+				DEVELOPMENT_TEAM = UXB66N824W;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TopShelfExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = TopShelfExtension;
@@ -403,7 +403,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0.3;
-				PRODUCT_BUNDLE_IDENTIFIER = com.gstudios.rivulet.TopShelfExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jbstudios.rivulet.TopShelfExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
@@ -427,7 +427,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 66;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = ZHB786H6YN;
+				DEVELOPMENT_TEAM = UXB66N824W;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -456,7 +456,7 @@
 					"-liconv",
 					"-lz",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.gstudios.rivulet;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jbstudios.rivulet;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
@@ -485,7 +485,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 66;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = ZHB786H6YN;
+				DEVELOPMENT_TEAM = UXB66N824W;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -514,7 +514,7 @@
 					"-liconv",
 					"-lz",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.gstudios.rivulet;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jbstudios.rivulet;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
@@ -660,10 +660,10 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 53;
-				DEVELOPMENT_TEAM = ZHB786H6YN;
+				DEVELOPMENT_TEAM = UXB66N824W;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.gstudios.RivuletTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jbstudios.RivuletTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -683,10 +683,10 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 53;
-				DEVELOPMENT_TEAM = ZHB786H6YN;
+				DEVELOPMENT_TEAM = UXB66N824W;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.gstudios.RivuletTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jbstudios.RivuletTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;

--- a/Rivulet/Info.plist
+++ b/Rivulet/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>AVInitialRouteSharingPolicy</key>
+	<string>LongFormAudio</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -13,31 +15,20 @@
 			</array>
 		</dict>
 	</array>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
-	<!-- Users connect to their own media servers (a Plex server, or an IPTV/M3U
-	     provider they subscribe to). These are commonly reached over HTTP on a local
-	     network or a self-hosted box without a TLS certificate, so arbitrary loads are
-	     required to support user-supplied endpoints. -->
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
-		<key>NSAllowsLocalNetworking</key>
-		<true/>
 	</dict>
-	<key>NSLocalNetworkUsageDescription</key>
-	<string>Rivulet connects to media servers on your local network, such as your Plex server, to stream your library.</string>
-	<key>AVInitialRouteSharingPolicy</key>
-	<string>LongFormAudio</string>
-	<key>UIBackgroundModes</key>
-	<array>
-		<string>audio</string>
-	</array>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>com.rivulet.viewMedia</string>
 		<string>com.rivulet.playMedia</string>
+	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+		<string>picture-in-picture</string>
 	</array>
 </dict>
 </plist>

--- a/Rivulet/Models/Plex/PlexMetadata.swift
+++ b/Rivulet/Models/Plex/PlexMetadata.swift
@@ -259,6 +259,17 @@ nonisolated struct PlexMarker: Codable, Identifiable, Sendable {
     var isCommercial: Bool {
         type == "commercial"
     }
+
+    /// Whether this is a recap ("previously on…") marker. Plex never emits
+    /// these; they come from the IntroDB backup (introdb.app/theintrodb.org).
+    var isRecap: Bool {
+        type == "recap"
+    }
+
+    /// Whether this is a next-episode preview marker.
+    var isPreview: Bool {
+        type == "preview"
+    }
 }
 
 // MARK: - Main Metadata Model
@@ -947,6 +958,16 @@ extension PlexMetadata {
     /// Commercial markers if available
     var commercialMarkers: [PlexMarker] {
         Marker?.filter { $0.isCommercial } ?? []
+    }
+
+    /// Recap markers if available (IntroDB backup — Plex never emits these)
+    var recapMarkers: [PlexMarker] {
+        Marker?.filter { $0.isRecap } ?? []
+    }
+
+    /// Next-episode preview markers if available
+    var previewMarkers: [PlexMarker] {
+        Marker?.filter { $0.isPreview } ?? []
     }
 
     /// All markers

--- a/Rivulet/Services/Plex/Playback/IntroDBClient.swift
+++ b/Rivulet/Services/Plex/Playback/IntroDBClient.swift
@@ -52,8 +52,12 @@ nonisolated struct IntroDBClient {
             URLQueryItem(name: "season", value: String(season)),
             URLQueryItem(name: "episode", value: String(episode)),
         ]
-        guard let url = comps.url,
-              let (data, _) = try? await URLSession.shared.data(from: url) else { return [] }
+        guard let url = comps.url else { return [] }
+        // Short timeout: these are community DBs; a dead endpoint must not
+        // hold the (already off-critical-path) backfill task for a minute.
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 8
+        guard let (data, _) = try? await URLSession.shared.data(for: request) else { return [] }
         return Self.decode(data)
     }
 

--- a/Rivulet/Services/Plex/Playback/IntroDBClient.swift
+++ b/Rivulet/Services/Plex/Playback/IntroDBClient.swift
@@ -1,0 +1,80 @@
+//
+//  IntroDBClient.swift
+//  Rivulet
+//
+//  Fallback marker source backed by the community intro databases
+//  (introdb.app + theintrodb.org), ported from PlexGuide/Flume. When Plex has
+//  no intro/credit markers for an episode we query by the show's IMDB id +
+//  season/episode. Reads are anonymous (no key). These DBs also provide RECAP
+//  segments, which Plex never emits.
+//
+//  Markers come back as `PlexMarker` values (type "intro" / "recap" /
+//  "credits") with NEGATIVE synthetic ids, so they flow through the existing
+//  marker check/skip machinery untouched and can never collide with Plex's
+//  own (positive) marker ids.
+//
+
+import Foundation
+
+nonisolated struct IntroDBClient {
+
+    /// Tried in order; the first DB with data for a given segment kind wins.
+    private static let bases = [
+        "https://api.introdb.app/segments",
+        "https://api.theintrodb.org/segments",
+    ]
+
+    /// Synthetic ids for backup markers — negative so the per-id skipped sets
+    /// work and Plex ids (positive) can never collide.
+    private static let syntheticIds: [String: Int] = [
+        "intro": -9001,
+        "recap": -9002,
+        "credits": -9003,
+    ]
+
+    func markers(imdbID: String, season: Int, episode: Int) async -> [PlexMarker] {
+        var byType: [String: PlexMarker] = [:]
+        for base in Self.bases {
+            let found = await fetch(base: base, imdbID: imdbID, season: season, episode: episode)
+            for marker in found {
+                if let type = marker.type, byType[type] == nil {
+                    byType[type] = marker
+                }
+            }
+        }
+        return Array(byType.values)
+    }
+
+    private func fetch(base: String, imdbID: String, season: Int, episode: Int) async -> [PlexMarker] {
+        guard var comps = URLComponents(string: base) else { return [] }
+        comps.queryItems = [
+            URLQueryItem(name: "imdb_id", value: imdbID),
+            URLQueryItem(name: "season", value: String(season)),
+            URLQueryItem(name: "episode", value: String(episode)),
+        ]
+        guard let url = comps.url,
+              let (data, _) = try? await URLSession.shared.data(from: url) else { return [] }
+        return Self.decode(data)
+    }
+
+    static func decode(_ data: Data) -> [PlexMarker] {
+        struct Segment: Decodable { let start_sec: Double?; let end_sec: Double? }
+        struct Wire: Decodable { let intro: Segment?; let recap: Segment?; let outro: Segment? }
+        guard let wire = try? JSONDecoder().decode(Wire.self, from: data) else { return [] }
+
+        func marker(_ seg: Segment?, _ type: String) -> PlexMarker? {
+            guard let s = seg?.start_sec, let e = seg?.end_sec, e > s else { return nil }
+            return PlexMarker(
+                id: syntheticIds[type],
+                type: type,
+                startTimeOffset: Int(s * 1000),
+                endTimeOffset: Int(e * 1000)
+            )
+        }
+        return [
+            marker(wire.intro, "intro"),
+            marker(wire.recap, "recap"),
+            marker(wire.outro, "credits"),   // outro == end credits
+        ].compactMap { $0 }
+    }
+}

--- a/Rivulet/Views/Media/PlexHome/UIKit/HeroButtonRowView.swift
+++ b/Rivulet/Views/Media/PlexHome/UIKit/HeroButtonRowView.swift
@@ -472,7 +472,7 @@ final class HeroCircleButton: UIControl {
 @MainActor
 final class HeroPagingDotsView: UIView {
     private let stack = UIStackView()
-    private var dots: [UIView] = []
+    private var dots: [HeroDotView] = []
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -492,34 +492,68 @@ final class HeroPagingDotsView: UIView {
 
     required init?(coder: NSCoder) { fatalError() }
 
-    func update(count: Int, activeIndex: Int) {
+    /// Updates the dots. When `progressDuration` is non-nil, the active dot
+    /// fills white over that many seconds — the auto-advance cycle countdown
+    /// (ported from PlexGuide). nil leaves the active dot solid.
+    func update(count: Int, activeIndex: Int, progressDuration: TimeInterval? = nil) {
         if dots.count != count {
             dots.forEach { $0.removeFromSuperview() }
             dots.removeAll()
             for _ in 0..<count {
-                let dot = UIView()
-                dot.translatesAutoresizingMaskIntoConstraints = false
-                dot.layer.cornerRadius = 4
-                dot.layer.cornerCurve = .continuous
+                let dot = HeroDotView()
                 stack.addArrangedSubview(dot)
-                NSLayoutConstraint.activate([
-                    dot.heightAnchor.constraint(equalToConstant: 8)
-                ])
                 dots.append(dot)
             }
         }
+        for (i, dot) in dots.enumerated() {
+            let active = i == activeIndex
+            dot.setActive(active, progress: active ? progressDuration : nil)
+        }
         UIView.animate(withDuration: 0.25, delay: 0, options: [.curveEaseInOut]) {
-            for (i, dot) in self.dots.enumerated() {
-                let active = i == activeIndex
-                let width: CGFloat = active ? 22 : 8
-                // Update width constraint
-                for c in dot.constraints where c.firstAttribute == .width {
-                    dot.removeConstraint(c)
-                }
-                dot.widthAnchor.constraint(equalToConstant: width).isActive = true
-                dot.backgroundColor = UIColor.white.withAlphaComponent(active ? 1.0 : 0.35)
-            }
             self.layoutIfNeeded()
+        }
+    }
+}
+
+/// A single hero paging dot: a translucent track that widens when active and
+/// fills white. With a `progress` duration the fill animates linearly across
+/// the active width as an auto-advance countdown (ported from PlexGuide's
+/// DotView); without it the active dot is solid.
+final class HeroDotView: UIView {
+    private let fill = UIView()
+    private let dotHeight: CGFloat = 8
+    private let inactiveWidth: CGFloat = 8
+    private let activeWidth: CGFloat = 22
+    private var widthC: NSLayoutConstraint!
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        translatesAutoresizingMaskIntoConstraints = false
+        backgroundColor = UIColor.white.withAlphaComponent(0.35)
+        layer.cornerRadius = dotHeight / 2
+        layer.cornerCurve = .continuous
+        clipsToBounds = true
+        fill.backgroundColor = .white
+        addSubview(fill)
+        heightAnchor.constraint(equalToConstant: dotHeight).isActive = true
+        widthC = widthAnchor.constraint(equalToConstant: inactiveWidth)
+        widthC.isActive = true
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    func setActive(_ active: Bool, progress duration: TimeInterval?) {
+        fill.layer.removeAllAnimations()
+        widthC.constant = active ? activeWidth : inactiveWidth
+        if active, let duration {
+            // Reset to empty, then fill linearly over the cycle duration.
+            fill.frame = CGRect(x: 0, y: 0, width: 0, height: dotHeight)
+            UIView.animate(withDuration: duration, delay: 0,
+                           options: [.curveLinear, .beginFromCurrentState]) {
+                self.fill.frame = CGRect(x: 0, y: 0, width: self.activeWidth, height: self.dotHeight)
+            }
+        } else {
+            fill.frame = CGRect(x: 0, y: 0, width: active ? activeWidth : 0, height: dotHeight)
         }
     }
 }

--- a/Rivulet/Views/Media/PlexHome/UIKit/HeroOverlayView.swift
+++ b/Rivulet/Views/Media/PlexHome/UIKit/HeroOverlayView.swift
@@ -512,6 +512,14 @@ final class MediaItemHeroOverlayView: UIView {
     private var displayedIndex: Int = 0
     private var displayedSwapWorkItem: DispatchWorkItem?
 
+    // MARK: - Auto-advance (same cycle as the PlexMetadata hero)
+
+    /// Seconds each hero slide is shown before auto-advancing. The active
+    /// paging dot fills over this duration as a countdown.
+    private let heroCycleSeconds: TimeInterval = 9
+    private var autoAdvanceTimer: Timer?
+    private var isHeroFocused = false
+
     // MARK: - Callbacks
 
     var onIndexChanged: ((Int, MediaItem) -> Void)?
@@ -615,7 +623,15 @@ final class MediaItemHeroOverlayView: UIView {
         // while focus lives inside the hero (see
         // HeroButtonRowView.setSecondaryButtonsFocusable).
         let nextInside = context.nextFocusedView?.isDescendant(of: self) == true
+        let prevInside = context.previouslyFocusedView?.isDescendant(of: self) == true
         buttonRow.setSecondaryButtonsFocusable(nextInside)
+        if nextInside, !prevInside {
+            isHeroFocused = true
+            startAutoAdvanceCycle()   // begin auto-cycling while the hero is focused
+        } else if prevInside, !nextInside {
+            isHeroFocused = false
+            stopAutoAdvance()         // pause when focus leaves the hero
+        }
     }
 
     // MARK: - Scroll parallax
@@ -660,14 +676,55 @@ final class MediaItemHeroOverlayView: UIView {
         slideView.configure(item: item, onReady: onReady)
     }
 
-    private func renderPagingDots() {
+    private func renderPagingDots(progressDuration: TimeInterval? = nil) {
         pagingDotsBackground.isHidden = items.count <= 1
         // Track the PRESS index (currentIndex), not the lagged metadata
         // (displayedIndex) — dots advance with the backdrop image on the click.
-        pagingDots.update(count: items.count, activeIndex: currentIndex)
+        pagingDots.update(count: items.count, activeIndex: currentIndex,
+                          progressDuration: progressDuration)
+    }
+
+    // MARK: - Auto-advance cycle
+
+    /// Starts (or restarts) the auto-advance cycle: the active dot fills over
+    /// `heroCycleSeconds`, then the hero advances to the next slide. Only runs
+    /// while the hero is focused and there's more than one slide.
+    private func startAutoAdvanceCycle() {
+        autoAdvanceTimer?.invalidate()
+        autoAdvanceTimer = nil
+        guard isHeroFocused, items.count > 1 else {
+            renderPagingDots()
+            return
+        }
+        renderPagingDots(progressDuration: heroCycleSeconds)
+        autoAdvanceTimer = Timer.scheduledTimer(withTimeInterval: heroCycleSeconds,
+                                                repeats: false) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.advance()
+            }
+        }
+    }
+
+    private func stopAutoAdvance() {
+        autoAdvanceTimer?.invalidate()
+        autoAdvanceTimer = nil
+        renderPagingDots()
+    }
+
+    override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
+        if newWindow == nil { stopAutoAdvance() }
     }
 
     // MARK: - Paging
+
+    private func advance() {
+        guard items.count > 1 else { return }
+        setCurrentIndex((currentIndex + 1) % items.count)
+        // Reset the cycle so the dot countdown restarts from this slide, whether
+        // the advance came from the timer or the Next button.
+        if isHeroFocused { startAutoAdvanceCycle() }
+    }
 
     private func setCurrentIndex(_ newIndex: Int) {
         guard newIndex != currentIndex else { return }
@@ -712,8 +769,8 @@ final class MediaItemHeroOverlayView: UIView {
             self.onInfo?(item)
         }
         buttonRow.onNext = { [weak self] in
-            guard let self, self.items.count > 1 else { return }
-            self.setCurrentIndex((self.currentIndex + 1) % self.items.count)
+            // advance() (not setCurrentIndex) so the dot countdown restarts.
+            self?.advance()
         }
         buttonRow.onWatchlist = { [weak self] in
             guard let self, let item = self.currentItem else { return }

--- a/Rivulet/Views/Media/PlexHome/UIKit/HeroOverlayView.swift
+++ b/Rivulet/Views/Media/PlexHome/UIKit/HeroOverlayView.swift
@@ -64,6 +64,14 @@ final class HeroOverlayView: UIView {
 
     private var watchlistObserver: AnyCancellable?
 
+    // MARK: - Auto-advance
+
+    /// Seconds each hero slide is shown before auto-advancing. The active
+    /// paging dot fills over this duration as a countdown.
+    private let heroCycleSeconds: TimeInterval = 9
+    private var autoAdvanceTimer: Timer?
+    private var isHeroFocused = false
+
     // MARK: - Init
 
     override init(frame: CGRect) {
@@ -171,7 +179,12 @@ final class HeroOverlayView: UIView {
         let nextInside = context.nextFocusedView?.isDescendant(of: self) == true
         let prevInside = context.previouslyFocusedView?.isDescendant(of: self) == true
         if nextInside, !prevInside {
+            isHeroFocused = true
             onFocusEntered?()
+            startAutoAdvanceCycle()   // begin auto-cycling while the hero is focused
+        } else if prevInside, !nextInside {
+            isHeroFocused = false
+            stopAutoAdvance()         // pause when focus leaves the hero
         }
         // Land-on-Play gate: secondary buttons are focus candidates only
         // while focus lives inside the hero (see
@@ -203,12 +216,45 @@ final class HeroOverlayView: UIView {
                             animated: animated, manageAlpha: manageAlpha, onReady: onReady)
     }
 
-    private func renderPagingDots() {
+    private func renderPagingDots(progressDuration: TimeInterval? = nil) {
         pagingDotsBackground.isHidden = items.count <= 1
         // Dots track the PRESS index (currentIndex), not the lagged metadata
         // (displayedIndex), so they advance with the backdrop image on the
         // click rather than 600ms later when the metadata swaps in.
-        pagingDots.update(count: items.count, activeIndex: currentIndex)
+        pagingDots.update(count: items.count, activeIndex: currentIndex,
+                          progressDuration: progressDuration)
+    }
+
+    // MARK: - Auto-advance cycle
+
+    /// Starts (or restarts) the auto-advance cycle: the active dot fills over
+    /// `heroCycleSeconds`, then the hero advances to the next slide. Only runs
+    /// while the hero is focused and there's more than one slide.
+    private func startAutoAdvanceCycle() {
+        autoAdvanceTimer?.invalidate()
+        autoAdvanceTimer = nil
+        guard isHeroFocused, items.count > 1 else {
+            renderPagingDots()
+            return
+        }
+        renderPagingDots(progressDuration: heroCycleSeconds)
+        autoAdvanceTimer = Timer.scheduledTimer(withTimeInterval: heroCycleSeconds,
+                                                repeats: false) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.advance()
+            }
+        }
+    }
+
+    private func stopAutoAdvance() {
+        autoAdvanceTimer?.invalidate()
+        autoAdvanceTimer = nil
+        renderPagingDots()
+    }
+
+    override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
+        if newWindow == nil { stopAutoAdvance() }
     }
 
     // MARK: - Paging (button -> currentIndex -> backdrop -> delayed slide swap)
@@ -217,6 +263,9 @@ final class HeroOverlayView: UIView {
         guard items.count > 1 else { return }
         let next = (currentIndex + 1) % items.count
         setCurrentIndex(next)
+        // Reset the cycle so the dot countdown restarts from this slide, whether
+        // the advance came from the timer or the Next button.
+        if isHeroFocused { startAutoAdvanceCycle() }
     }
 
     private func setCurrentIndex(_ newIndex: Int) {

--- a/Rivulet/Views/Player/UniversalPlayerViewModel.swift
+++ b/Rivulet/Views/Player/UniversalPlayerViewModel.swift
@@ -156,6 +156,8 @@ final class UniversalPlayerViewModel: ObservableObject {
     private var hasSkippedIntro = false
     private var skippedCreditsIds: Set<Int> = []  // Track skipped credits by ID (can have multiple)
     private var skippedCommercialIds: Set<Int> = []  // Track skipped commercials by ID
+    private var skippedRecapIds: Set<Int> = []  // Track skipped recaps by ID (IntroDB backup)
+    private var skippedPreviewIds: Set<Int> = []  // Track skipped previews by ID
     private var hasTriggeredPostVideo = false
 
     // MARK: - Auto-Skip Countdown State
@@ -3002,6 +3004,30 @@ final class UniversalPlayerViewModel: ObservableObject {
         // Don't check while scrubbing or if post-video already showing
         guard !isScrubbing, postVideoState == .hidden else { return }
 
+        // Check recap markers first — recaps precede the intro in an episode.
+        // These only exist via the IntroDB backup (Plex never emits recap).
+        for recap in metadata.recapMarkers {
+            guard let recapId = recap.id else { continue }
+            guard recap.endTimeSeconds > recap.startTimeSeconds else { continue }
+
+            let previewStart = max(0, recap.startTimeSeconds - markerPreviewTime)
+
+            // Reset skip flag if user rewound before the marker (same
+            // starts-at-0 special case as intro markers)
+            if skippedRecapIds.contains(recapId) {
+                if time < previewStart {
+                    skippedRecapIds.remove(recapId)
+                } else if previewStart == 0 && time < recap.startTimeSeconds + 1.0 && activeMarker == nil {
+                    skippedRecapIds.remove(recapId)
+                }
+            }
+
+            if time >= previewStart && time < recap.endTimeSeconds {
+                handleRecapMarkerActive(recap, currentTime: time)
+                return
+            }
+        }
+
         // Check intro marker (show 5 seconds early)
         if let intro = metadata.introMarker {
             // Skip malformed markers where end time is not after start time
@@ -3107,6 +3133,28 @@ final class UniversalPlayerViewModel: ObservableObject {
 
             if time >= previewStart && time < commercial.endTimeSeconds {
                 handleCommercialMarkerActive(commercial, currentTime: time)
+                return
+            }
+        }
+
+        // Check next-episode preview markers
+        for preview in metadata.previewMarkers {
+            guard let previewId = preview.id else { continue }
+            guard preview.endTimeSeconds > preview.startTimeSeconds else { continue }
+
+            let previewStart = max(0, preview.startTimeSeconds - markerPreviewTime)
+
+            // Reset skip flag if user rewound before the marker
+            if skippedPreviewIds.contains(previewId) {
+                if time < previewStart {
+                    skippedPreviewIds.remove(previewId)
+                } else if previewStart == 0 && time < preview.startTimeSeconds + 1.0 && activeMarker == nil {
+                    skippedPreviewIds.remove(previewId)
+                }
+            }
+
+            if time >= previewStart && time < preview.endTimeSeconds {
+                handlePreviewMarkerActive(preview, currentTime: time)
                 return
             }
         }
@@ -3271,6 +3319,64 @@ final class UniversalPlayerViewModel: ObservableObject {
         }
     }
 
+    /// Handle when playback enters a recap marker range (or preview window).
+    /// Recap markers come from the IntroDB backup; same behaviour as the
+    /// other marker kinds.
+    private func handleRecapMarkerActive(_ marker: PlexMarker, currentTime: TimeInterval) {
+        guard let recapId = marker.id else { return }
+
+        let autoSkipRecap = UserDefaults.standard.bool(forKey: "autoSkipRecap")
+
+        // Only auto-skip when actually inside the marker (not during preview window)
+        let insideMarker = currentTime >= marker.startTimeSeconds
+
+        // Auto-skip with a visible countdown when the setting is on.
+        if autoSkipRecap && !skippedRecapIds.contains(recapId) && insideMarker && !userDeclinedAutoSkip {
+            if activeMarker == nil {
+                activeMarker = marker
+                showSkipButton = true
+            }
+            if skipCountdownTimer == nil && skipCountdownSeconds == 0 {
+                startSkipCountdown(for: marker)
+            }
+            return
+        }
+
+        // Show skip button if not already skipped
+        if !skippedRecapIds.contains(recapId) && activeMarker == nil {
+            activeMarker = marker
+            showSkipButton = true
+        }
+    }
+
+    /// Handle when playback enters a next-episode preview marker range.
+    private func handlePreviewMarkerActive(_ marker: PlexMarker, currentTime: TimeInterval) {
+        guard let previewId = marker.id else { return }
+
+        let autoSkipPreview = UserDefaults.standard.bool(forKey: "autoSkipPreview")
+
+        // Only auto-skip when actually inside the marker (not during preview window)
+        let insideMarker = currentTime >= marker.startTimeSeconds
+
+        // Auto-skip with a visible countdown when the setting is on.
+        if autoSkipPreview && !skippedPreviewIds.contains(previewId) && insideMarker && !userDeclinedAutoSkip {
+            if activeMarker == nil {
+                activeMarker = marker
+                showSkipButton = true
+            }
+            if skipCountdownTimer == nil && skipCountdownSeconds == 0 {
+                startSkipCountdown(for: marker)
+            }
+            return
+        }
+
+        // Show skip button if not already skipped
+        if !skippedPreviewIds.contains(previewId) && activeMarker == nil {
+            activeMarker = marker
+            showSkipButton = true
+        }
+    }
+
     /// Skip to end of current marker (called from UI skip button)
     func skipActiveMarker() async {
         guard let marker = activeMarker else { return }
@@ -3289,6 +3395,10 @@ final class UniversalPlayerViewModel: ObservableObject {
             skippedCreditsIds.insert(creditsId)
         } else if marker.isCommercial, let commercialId = marker.id {
             skippedCommercialIds.insert(commercialId)
+        } else if marker.isRecap, let recapId = marker.id {
+            skippedRecapIds.insert(recapId)
+        } else if marker.isPreview, let previewId = marker.id {
+            skippedPreviewIds.insert(previewId)
         }
 
         // Seek to end of marker, clamped so we never land at/after duration.
@@ -3328,6 +3438,10 @@ final class UniversalPlayerViewModel: ObservableObject {
             return "Skip Credits"
         } else if marker.isCommercial {
             return "Skip Ad"
+        } else if marker.isRecap {
+            return "Skip Recap"
+        } else if marker.isPreview {
+            return "Skip Preview"
         }
         return "Skip"
     }
@@ -3545,9 +3659,62 @@ final class UniversalPlayerViewModel: ObservableObject {
                 metadata.Guid = fullMetadata.Guid
             }
 
+            // Markers may be absent on the lightweight metadata the player
+            // started with (hub items) — carry them over from the full fetch.
+            if metadata.Marker == nil || metadata.Marker?.isEmpty == true {
+                metadata.Marker = fullMetadata.Marker
+            }
+
         } catch {
             print("🎬 [Metadata] Failed to fetch full metadata: \(error)")
         }
+
+        // IntroDB backup (introdb.app / theintrodb.org): fill in marker kinds
+        // Plex didn't provide — notably RECAP, which Plex never emits.
+        await backfillMarkersFromIntroDB()
+    }
+
+    /// Adds IntroDB backup markers for kinds Plex didn't provide. Episodes
+    /// only (the lookup keys on the show's IMDB id + season/episode). Plex is
+    /// authoritative: a kind Plex already emitted is never replaced.
+    private func backfillMarkersFromIntroDB() async {
+        guard metadata.type == "episode",
+              let season = metadata.parentIndex,
+              let episode = metadata.index else { return }
+
+        let presentKinds = Set((metadata.Marker ?? []).compactMap(\.type))
+        let missingKinds = ["intro", "recap", "credits"].filter { !presentKinds.contains($0) }
+        guard !missingKinds.isEmpty else { return }
+
+        guard let imdbID = await showIMDBID() else { return }
+
+        let generation = itemGeneration
+        let backup = await IntroDBClient().markers(imdbID: imdbID, season: season, episode: episode)
+        guard generation == itemGeneration else { return }  // item changed mid-fetch
+
+        let extras = backup.filter { marker in
+            guard let type = marker.type else { return false }
+            return missingKinds.contains(type)
+        }
+        guard !extras.isEmpty else { return }
+        metadata.Marker = (metadata.Marker ?? []) + extras
+        print("🎬 IntroDB: added backup markers \(extras.compactMap(\.type).sorted()) for S\(season)E\(episode)")
+    }
+
+    /// The show's IMDB id (e.g. "tt0903747"), resolved from the show-level
+    /// metadata's external guids.
+    private func showIMDBID() async -> String? {
+        guard let showKey = metadata.grandparentRatingKey else { return nil }
+        guard let show = try? await PlexNetworkManager.shared.getMetadata(
+            serverURL: serverURL,
+            authToken: authToken,
+            ratingKey: showKey,
+            includeGuids: true
+        ) else { return nil }
+        return show.Guid?
+            .compactMap(\.id)
+            .first { $0.hasPrefix("imdb://") }?
+            .replacingOccurrences(of: "imdb://", with: "")
     }
 
     /// Load the current season's episode list for the Up Next panel, sorted
@@ -4085,6 +4252,8 @@ final class UniversalPlayerViewModel: ObservableObject {
         hasSkippedIntro = false
         skippedCreditsIds.removeAll()
         skippedCommercialIds.removeAll()
+        skippedRecapIds.removeAll()
+        skippedPreviewIds.removeAll()
 
         // Clear any replay window left open from the previous episode — its
         // invokedAt is a timestamp on episode N's timeline, meaningless (and

--- a/Rivulet/Views/Player/UniversalPlayerViewModel.swift
+++ b/Rivulet/Views/Player/UniversalPlayerViewModel.swift
@@ -506,6 +506,16 @@ final class UniversalPlayerViewModel: ObservableObject {
             await fetchFullMetadataIfNeeded()
         }
 
+        // IntroDB backup markers: ALWAYS check, even when Plex metadata (and
+        // its markers) arrived complete — Plex never emits recap, so there is
+        // almost always a kind worth backfilling. Off the critical path so a
+        // slow/dead community DB can't delay playback start; the recap window
+        // sits at the top of the episode, and the merge lands within the
+        // first marker-check ticks.
+        Task { [weak self] in
+            await self?.backfillMarkersFromIntroDB()
+        }
+
         let routingContext = ContentRoutingContext(
             metadata: metadata,
             serverURL: URL(string: serverURL)!,
@@ -3668,10 +3678,6 @@ final class UniversalPlayerViewModel: ObservableObject {
         } catch {
             print("🎬 [Metadata] Failed to fetch full metadata: \(error)")
         }
-
-        // IntroDB backup (introdb.app / theintrodb.org): fill in marker kinds
-        // Plex didn't provide — notably RECAP, which Plex never emits.
-        await backfillMarkersFromIntroDB()
     }
 
     /// Adds IntroDB backup markers for kinds Plex didn't provide. Episodes
@@ -3686,8 +3692,12 @@ final class UniversalPlayerViewModel: ObservableObject {
         let missingKinds = ["intro", "recap", "credits"].filter { !presentKinds.contains($0) }
         guard !missingKinds.isEmpty else { return }
 
-        guard let imdbID = await showIMDBID() else { return }
+        guard let imdbID = await showIMDBID() else {
+            print("🎬 IntroDB: no IMDB id resolvable for show — skipping backup lookup")
+            return
+        }
 
+        print("🎬 IntroDB: checking \(imdbID) S\(season)E\(episode) for missing \(missingKinds)")
         let generation = itemGeneration
         let backup = await IntroDBClient().markers(imdbID: imdbID, season: season, episode: episode)
         guard generation == itemGeneration else { return }  // item changed mid-fetch
@@ -3696,7 +3706,10 @@ final class UniversalPlayerViewModel: ObservableObject {
             guard let type = marker.type else { return false }
             return missingKinds.contains(type)
         }
-        guard !extras.isEmpty else { return }
+        guard !extras.isEmpty else {
+            print("🎬 IntroDB: no backup markers found (DBs returned \(backup.compactMap(\.type).sorted()))")
+            return
+        }
         metadata.Marker = (metadata.Marker ?? []) + extras
         print("🎬 IntroDB: added backup markers \(extras.compactMap(\.type).sorted()) for S\(season)E\(episode)")
     }

--- a/Rivulet/Views/Settings/SettingsDescriptors.swift
+++ b/Rivulet/Views/Settings/SettingsDescriptors.swift
@@ -134,6 +134,16 @@ enum SettingsDescriptorStore {
             iconColor: .red,
             description: "Automatically skips advertisement segments when markers are available."
         ),
+        "autoSkipRecap": SettingDescriptor(
+            icon: "backward.end.circle",
+            iconColor: .teal,
+            description: "Automatically skips 'previously on' recaps. Recap markers come from the community intro database (introdb.app) when Plex has none."
+        ),
+        "autoSkipPreview": SettingDescriptor(
+            icon: "forward.end.circle",
+            iconColor: .purple,
+            description: "Automatically skips next-episode previews when markers are available."
+        ),
         "promptResumeOrRestart": SettingDescriptor(
             icon: "questionmark.circle",
             iconColor: .blue,

--- a/Rivulet/Views/Settings/UIKit/SettingsPageModels.swift
+++ b/Rivulet/Views/Settings/UIKit/SettingsPageModels.swift
@@ -200,6 +200,8 @@ enum SettingsContent {
             toggle("autoSkipIntro", "Auto-Skip Intro", key: "autoSkipIntro", default: false),
             toggle("autoSkipCredits", "Auto-Skip Credits", key: "autoSkipCredits", default: false),
             toggle("autoSkipAds", "Auto-Skip Ads", key: "autoSkipAds", default: false),
+            toggle("autoSkipRecap", "Auto-Skip Recap", key: "autoSkipRecap", default: false),
+            toggle("autoSkipPreview", "Auto-Skip Preview", key: "autoSkipPreview", default: false),
             toggle("promptResumeOrRestart", "Resume or Restart Prompt", key: "promptResumeOrRestart", default: false),
             SettingsRowItem(id: "autoplayCountdown", title: "Autoplay Countdown",
                             kind: .navigationValue(.autoplayCountdownPicker, value: {

--- a/TopShelfExtension/Info.plist
+++ b/TopShelfExtension/Info.plist
@@ -2,10 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>arm64</string>
-	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
Added timer on the 'dot' indicator below the hero. (feel free to change the timing as you see fit - possibly could link to autoplay timer?)

Added db backup to plex markers which also includes skip recap and skip preview.

Will possibly look to add a 'loading' left to right 'fill' animation instead of the current countdown.