### PR TITLE
CW removal: animate a batch delete so focus stays coherent

### DIFF
--- a/Rivulet/Views/Media/PlexHome/UIKit/PlexHomeViewController.swift
+++ b/Rivulet/Views/Media/PlexHome/UIKit/PlexHomeViewController.swift
@@ -501,6 +501,19 @@ final class PlexHomeViewController: UIViewController {
         var hasReachedEnd: Bool
     }
     private var paginationStates: [HomeSectionID: PaginationState] = [:]
+
+    /// Continue Watching removals applied optimistically: these itemIDs are
+    /// hidden from CW rows the moment the user picks Remove, while the
+    /// server PUT + CW refetch run behind. Each ID is cleared on reconcile —
+    /// after a confirmed refetch (data no longer contains it) or on failure
+    /// (tile reappears; server truth wins) — so a later rewatch can re-enter
+    /// the row. Render-only: never persisted, never fed back into the store.
+    private var pendingCWRemovals: Set<String> = []
+    /// One-shot view-side companion to `pendingCWRemovals`: the shelf slot
+    /// (section, tile index) of the removal that triggered the next snapshot
+    /// apply, so the visible row can animate a batch DELETE at that index
+    /// instead of crossfade-reloading. Consumed by `updateVisibleShelfRows`.
+    private var pendingShelfRemoval: (sectionID: HomeSectionID, index: Int)?
     private let paginationPageSize = 24
 
     // MARK: Library-mode grid state
@@ -2596,8 +2609,23 @@ final class PlexHomeViewController: UIViewController {
             else { continue }
             let section = sectionsSnapshot[indexPath.section]
             guard isShelfKind(section.kind) else { continue }
-            configureShelfRow(cell, sectionID: section.id)
+            if let pending = pendingShelfRemoval, pending.sectionID == section.id {
+                // Animate the captured single-tile removal: delete that index
+                // so the survivors slide left to fill. The cellProvider
+                // closures from the prior configure stay valid (they capture
+                // the stable sectionID), so no reconfigure is needed.
+                cell.animateRemoval(at: pending.index,
+                                    newRealCount: shelfRealCount(section),
+                                    newSkeleton: paginationStates[section.id]?.isLoadingMore == true,
+                                    contentToken: shelfContentToken(section))
+            } else {
+                configureShelfRow(cell, sectionID: section.id)
+            }
         }
+        // A captured removal is valid only for the apply it triggered; clear
+        // it so a later apply can't replay a stale delete (and an off-screen
+        // CW row just reloads fresh when scrolled back into view).
+        pendingShelfRemoval = nil
     }
 
     /// Tile cell inside a shelf row. Mirrors the per-item cases the outer
@@ -2705,7 +2733,8 @@ final class PlexHomeViewController: UIViewController {
             guard itemIndex < section.items.count else { return }
             let item = section.items[itemIndex]
             presentTileMenu(sections: tileMenuSections(for: item,
-                                                       isContinueWatching: section.kind == .continueWatching))
+                                                       isContinueWatching: section.kind == .continueWatching,
+                                                       shelfLocation: (sectionID: sectionID, itemIndex: itemIndex)))
         case .discoverList:
             presentDiscoverTileMenu(sectionID: sectionID, itemIndex: itemIndex)
         case .searchGrid:
@@ -2878,10 +2907,14 @@ final class PlexHomeViewController: UIViewController {
         for hub in dataStore.homeItems {
             let id = HomeSectionID(raw: hub.id)
             let merged = mergedItems(forSection: id, initial: hub.items)
+            var items = merged.items
+            if hub.isContinueWatching, !pendingCWRemovals.isEmpty {
+                items.removeAll { pendingCWRemovals.contains($0.ref.itemID) }
+            }
             sections.append(.hub(
                 id: id,
                 title: hub.title,
-                items: merged.items,
+                items: items,
                 isContinueWatching: hub.isContinueWatching,
                 hubKey: hub.hubKey,
                 hubIdentifier: hub.hubIdentifier,
@@ -2938,10 +2971,14 @@ final class PlexHomeViewController: UIViewController {
         for hub in dataStore.libraryItemsByKey[key] ?? [] {
             let id = HomeSectionID(raw: hub.id)
             let merged = mergedItems(forSection: id, initial: hub.items)
+            var items = merged.items
+            if hub.isContinueWatching, !pendingCWRemovals.isEmpty {
+                items.removeAll { pendingCWRemovals.contains($0.ref.itemID) }
+            }
             sections.append(.hub(
                 id: id,
                 title: hub.title,
-                items: merged.items,
+                items: items,
                 isContinueWatching: hub.isContinueWatching,
                 hubKey: hub.hubKey,
                 hubIdentifier: hub.hubIdentifier,
@@ -4326,7 +4363,9 @@ extension PlexHomeViewController: UICollectionViewDelegate {
     /// home rows + library grid — the only long-press menu in the app now
     /// that the SwiftUI detail is gone. CW rows swap the watched
     /// group for Remove-from-CW + Go-to-Show.
-    private func tileMenuSections(for item: MediaItem, isContinueWatching: Bool) -> [[TileMenuAction]] {
+    private func tileMenuSections(for item: MediaItem,
+                                  isContinueWatching: Bool,
+                                  shelfLocation: (sectionID: HomeSectionID, itemIndex: Int)? = nil) -> [[TileMenuAction]] {
         guard let serverURL = authManager.selectedServerURL,
               let token = authManager.selectedServerToken,
               !item.ref.itemID.isEmpty
@@ -4371,9 +4410,7 @@ extension PlexHomeViewController: UICollectionViewDelegate {
                 TileMenuAction(title: "Remove from Continue Watching",
                                systemImage: "trash",
                                destructive: true) { [weak self] in
-                    self?.performMenuAction {
-                        try await network.removeFromContinueWatching(serverURL: serverURL, authToken: token, ratingKey: ratingKey)
-                    }
+                    self?.removeFromContinueWatchingOptimistically(item, shelfLocation: shelfLocation)
                 },
             ]
 
@@ -4461,6 +4498,43 @@ extension PlexHomeViewController: UICollectionViewDelegate {
             } catch {}
             await dataStore.refreshHubs()
             await dataStore.refreshLibraryHubs()
+        }
+    }
+
+    /// Optimistic Continue Watching removal: the tile disappears the moment
+    /// the menu closes; the server PUT + refetch run behind it. Suppression
+    /// (`pendingCWRemovals`) holds until the refreshed data itself no longer
+    /// contains the item, so racing hub refreshes can't flash it back. On
+    /// failure the suppression lifts and the tile returns — server truth wins.
+    private func removeFromContinueWatchingOptimistically(
+        _ item: MediaItem,
+        shelfLocation: (sectionID: HomeSectionID, itemIndex: Int)? = nil
+    ) {
+        let ratingKey = item.ref.itemID
+        guard !ratingKey.isEmpty,
+              let serverURL = authManager.selectedServerURL,
+              let token = authManager.selectedServerToken else { return }
+
+        pendingCWRemovals.insert(ratingKey)
+        // Capture the tile's on-screen slot BEFORE the data mutates: the
+        // visible row then deletes exactly that index in a batch update
+        // (survivors slide over, focus stays coherent through the delete)
+        // instead of crossfade-reloading and re-arming focus afterwards.
+        pendingShelfRemoval = shelfLocation.map { ($0.sectionID, $0.itemIndex) }
+        applySnapshot(animated: true)
+
+        Task { @MainActor in
+            do {
+                try await PlexNetworkManager.shared.removeFromContinueWatching(
+                    serverURL: serverURL, authToken: token, ratingKey: ratingKey)
+                // Refetch CW (and library hubs, which carry their own CW rows)
+                // BEFORE lifting the suppression, so the data is already clean
+                // and the reconcile snapshot is a visual no-op.
+                await dataStore.refreshContinueWatchingIfStale(olderThan: 0)
+                await dataStore.refreshLibraryHubs()
+            } catch {}
+            pendingCWRemovals.remove(ratingKey)
+            applySnapshot(animated: true)
         }
     }
 

--- a/Rivulet/Views/Media/UIKit/Cells/ShelfRowCell.swift
+++ b/Rivulet/Views/Media/UIKit/Cells/ShelfRowCell.swift
@@ -288,6 +288,43 @@ final class ShelfRowCell: UICollectionViewCell {
         }
     }
 
+    /// Single-tile removal without nuking focus: delete the tile at the
+    /// captured index inside a batch update so the survivors slide over to
+    /// fill the gap. UIKit keeps focus coherent through a batch delete (it
+    /// tracks the focused cell across the update, landing on the slot's new
+    /// occupant when the focused tile itself was deleted) — which a
+    /// crossfade reload does not: the reload re-binds cell instances and
+    /// strands focus on whatever cell object the engine was holding. Falls
+    /// back to a plain reload when the caller's expectation doesn't match
+    /// the collection's actual shape (racing refresh).
+    func animateRemoval(at index: Int, newRealCount: Int, newSkeleton: Bool, contentToken: Int) {
+        let oldReal = realCount
+        let oldSkeleton = hasSkeleton
+        self.contentToken = contentToken
+        realCount = newRealCount
+        hasSkeleton = newSkeleton
+        guard index >= 0, index < oldReal, newRealCount == oldReal - 1,
+              rowCollectionView.numberOfItems(inSection: 0) == oldReal + (oldSkeleton ? 1 : 0)
+        else {
+            rowCollectionView.reloadData()
+            rowCollectionView.layoutIfNeeded()
+            return
+        }
+        let keepOffset = rowCollectionView.contentOffset.x
+        rowCollectionView.performBatchUpdates {
+            rowCollectionView.deleteItems(at: [IndexPath(item: index, section: 0)])
+            // Reconcile the skeleton placeholder (just past the real items) in
+            // the same batch, expressed in old-index space like the delete.
+            if oldSkeleton, !newSkeleton {
+                rowCollectionView.deleteItems(at: [IndexPath(item: oldReal, section: 0)])
+            } else if !oldSkeleton, newSkeleton {
+                rowCollectionView.insertItems(at: [IndexPath(item: newRealCount, section: 0)])
+            }
+        } completion: { [weak self] _ in
+            self?.setOffset(clampedTo: keepOffset)
+        }
+    }
+
     /// Append-only growth (pagination) without nuking focus: inserts the new
     /// trailing items; the skeleton placeholder (an unchanged trailing item)
     /// shifts to the new end automatically.


### PR DESCRIPTION
This picks up where fe734d39 and bb087605 left off. The root problem with the crossfade approach was that the reload re-binds cell instances, so by the time any restore logic runs, the focus engine is holding a cell object that no longer corresponds to the tile the user was on. Restoring focus after breaking it is a race that is hard to win, which is what 90bfd2b3 ran into before going back to the plain server call.

This change brings the optimistic removal back and stops breaking focus instead of trying to restore it. The removal handler captures the tile's on-screen slot before the data mutates, and the visible shelf row then performs `deleteItems` at that index inside `performBatchUpdates` rather than reloading. UIKit tracks focus through a batch delete natively: the survivors slide over to fill the gap, and when the focused tile itself was deleted, focus lands on the slot's new occupant, clamped to the new end when the last tile was removed. If a racing hub refresh changed the row's shape so the captured index no longer matches, the row falls back to a plain reload.

The data side is the same shape 90bfd2b3 reverted: `pendingCWRemovals` suppression from the snapshot, the server PUT behind it, and the refetch-before-reconcile flow so the suppression lifts only once the refreshed data is already clean. With the focus problem gone there is no remaining reason to wait on the server, and the tile disappears the moment the menu closes.

We have been running this approach in our fork for several weeks of daily use across four Apple TVs (4K 1st, 2nd, and two 3rd gen) with no stranded-focus recurrences.
