### PR TITLE
fix: scale poster proportionally when opening a title

### DIFF
--- a/Rivulet/Views/Components/WhatsNewView.swift
+++ b/Rivulet/Views/Components/WhatsNewView.swift
@@ -143,6 +143,7 @@ struct WhatsNewView: View {
         ("1.0.4 (69)", [
             "New Content Filtering in Playback settings can mute strong language and skip scenes during playback, with per category controls and a quick toggle in the player",
             "Language muting works on any title with subtitles, and scene skipping uses filter lists in the MCF or EDL format from a URL you provide, without ever changing your files",
+            "Opening a movie or show now grows its poster proportionally instead of stretching it out of shape",
             "The backdrop that appears while paused now waits ten seconds instead of five, so you have more time to look at the paused frame",
             "Pressing Back while the paused backdrop is showing now brings back the paused frame instead of closing the player",
             "Fixed playback getting stuck after leaving the app and coming back, the video now picks up right where you left off",

--- a/Rivulet/Views/Media/PreviewCarousel/UIKit/PreviewCarouselViewController.swift
+++ b/Rivulet/Views/Media/PreviewCarousel/UIKit/PreviewCarouselViewController.swift
@@ -56,6 +56,12 @@ final class PreviewCarouselViewController: UIViewController {
     private var hasPreparedEntrySnapshots = false
     private var didStandaloneExpand = false
 
+    /// Clipping windows wrapping each entry snapshot. The morph animates
+    /// these, not the snapshots (see EntryMorphWindowView). Parallel to
+    /// `entrySnapshots` rather than keyed by item index, so repeated indices
+    /// each keep their own window instead of one silently replacing another.
+    private var entryMorphWindows: [(window: EntryMorphWindowView, itemIndex: Int, sourceFrame: CGRect)] = []
+
     /// CADisplayLink-driven paging state. Replaces UIViewPropertyAnimator
     /// because UIVPA's contentOffset interpolation doesn't trigger
     /// per-frame layout invalidation, which breaks parallax and
@@ -650,19 +656,20 @@ final class PreviewCarouselViewController: UIViewController {
         if !hasPreparedEntrySnapshots {
             hasPreparedEntrySnapshots = true
             for entry in entrySnapshots.sorted(by: { $0.itemIndex < $1.itemIndex }) {
-                let snapshot = entry.snapshotView
-                snapshot.removeFromSuperview()
-                snapshot.layer.cornerCurve = .continuous
-                snapshot.layer.cornerRadius = 16
-                snapshot.layer.masksToBounds = true
-                snapshot.layer.zPosition = entry.itemIndex == selectedIndex
+                let window = EntryMorphWindowView(
+                    content: entry.snapshotView,
+                    sourceSize: entry.sourceFrame.size
+                )
+                window.layer.cornerRadius = 16
+                window.layer.zPosition = entry.itemIndex == selectedIndex
                     ? 100
                     : CGFloat(50 - abs(entry.itemIndex - selectedIndex))
-                entrySnapshotContainer.addSubview(snapshot)
+                entryMorphWindows.append((window, entry.itemIndex, entry.sourceFrame))
+                entrySnapshotContainer.addSubview(window)
             }
         }
-        for entry in entrySnapshots {
-            entry.snapshotView.frame = view.convert(entry.sourceFrame, from: nil)
+        for entry in entryMorphWindows {
+            entry.window.setWindow(view.convert(entry.sourceFrame, from: nil))
         }
     }
 
@@ -688,20 +695,21 @@ final class PreviewCarouselViewController: UIViewController {
         let morpher = UIViewPropertyAnimator(duration: 0.45, timingParameters: timing)
         morpher.addAnimations { [weak self] in
             guard let self else { return }
-            for entry in self.entrySnapshots {
+            for entry in self.entryMorphWindows {
                 guard self.items.indices.contains(entry.itemIndex) else {
-                    entry.snapshotView.alpha = 0
+                    entry.window.alpha = 0
                     continue
                 }
-                entry.snapshotView.frame = self.carouselFrameInView(for: entry.itemIndex)
-                entry.snapshotView.layer.cornerRadius = PreviewCarouselGeometry.cornerRadius
+                entry.window.setWindow(self.carouselFrameInView(for: entry.itemIndex))
+                entry.window.layer.cornerRadius = PreviewCarouselGeometry.cornerRadius
             }
         }
         morpher.addCompletion { [weak self] _ in
             guard let self else { return }
-            for entry in self.entrySnapshots {
-                entry.snapshotView.removeFromSuperview()
+            for entry in self.entryMorphWindows {
+                entry.window.removeFromSuperview()
             }
+            self.entryMorphWindows.removeAll()
             self.entrySnapshotContainer.isHidden = true
             self.state.completeEntryMorph()
             self.updateCurrentCellChrome(animated: true)
@@ -1457,7 +1465,9 @@ final class PreviewCarouselViewController: UIViewController {
             view.drawHierarchy(in: view.bounds, afterScreenUpdates: false)
         }
 
-        var liveSnapshots: [PreviewEntrySnapshot] = []
+        // Same clipping window as the entry morph, so shrinking back into a
+        // portrait tile crops the composite instead of squashing it.
+        var liveWindows: [(window: EntryMorphWindowView, sourceFrame: CGRect)] = []
         for entry in entrySnapshots {
             guard items.indices.contains(entry.itemIndex) else { continue }
             let cardFrame = carouselFrameInView(for: entry.itemIndex)
@@ -1469,20 +1479,16 @@ final class PreviewCarouselViewController: UIViewController {
                 height: cardFrame.height * composite.scale
             )) else { continue }
             let snapshot = UIImageView(image: UIImage(cgImage: cropped, scale: composite.scale, orientation: composite.imageOrientation))
-            snapshot.frame = cardFrame
+            // Safe: the window keeps this box at the composite's aspect ratio.
             snapshot.contentMode = .scaleToFill
-            snapshot.layer.cornerCurve = .continuous
-            snapshot.layer.cornerRadius = PreviewCarouselGeometry.cornerRadius
-            snapshot.layer.masksToBounds = true
-            snapshot.layer.zPosition = entry.itemIndex == selectedIndex
+            let window = EntryMorphWindowView(content: snapshot, sourceSize: cardFrame.size)
+            window.layer.cornerRadius = PreviewCarouselGeometry.cornerRadius
+            window.layer.zPosition = entry.itemIndex == selectedIndex
                 ? 100
                 : CGFloat(50 - abs(entry.itemIndex - selectedIndex))
-            entrySnapshotContainer.addSubview(snapshot)
-            liveSnapshots.append(PreviewEntrySnapshot(
-                itemIndex: entry.itemIndex,
-                sourceFrame: entry.sourceFrame,
-                snapshotView: snapshot
-            ))
+            window.setWindow(cardFrame)
+            entrySnapshotContainer.addSubview(window)
+            liveWindows.append((window, entry.sourceFrame))
         }
 
         backdropPlane.alpha = 0
@@ -1498,10 +1504,10 @@ final class PreviewCarouselViewController: UIViewController {
         let morpher = UIViewPropertyAnimator(duration: 0.45, timingParameters: timing)
         morpher.addAnimations { [weak self] in
             guard let self else { return }
-            for entry in liveSnapshots {
-                entry.snapshotView.frame = self.view.convert(entry.sourceFrame, from: nil)
-                entry.snapshotView.layer.cornerRadius = 16
-                entry.snapshotView.alpha = 0
+            for live in liveWindows {
+                live.window.setWindow(self.view.convert(live.sourceFrame, from: nil))
+                live.window.layer.cornerRadius = 16
+                live.window.alpha = 0
             }
             self.backdrop.alpha = 0
         }

--- a/Rivulet/Views/Media/PreviewCarousel/UIKit/PreviewEntrySnapshot.swift
+++ b/Rivulet/Views/Media/PreviewCarousel/UIKit/PreviewEntrySnapshot.swift
@@ -18,3 +18,63 @@ struct PreviewEntrySnapshot {
     let sourceFrame: CGRect
     let snapshotView: UIView
 }
+
+/// Clipping window for a captured tile snapshot during the row -> carousel
+/// morph.
+///
+/// A `snapshotView(afterScreenUpdates:)` stretches its contents to whatever
+/// bounds you assign, so animating one straight to the card frame squashes it
+/// (a 2:3 poster tile into a ~1.70:1 card is x5.89 across but x2.32 down).
+/// The window takes that frame instead; the snapshot inside is aspect-filled
+/// and top-anchored, so it scales uniformly and overflows the bottom edge.
+///
+/// No display link needed: both endpoint content frames satisfy
+/// `h = w / aspect`, and linear interpolation preserves that, so the ratio
+/// holds at every intermediate frame.
+@MainActor
+final class EntryMorphWindowView: UIView {
+
+    private let contentAspect: CGFloat
+    private let content: UIView
+
+    /// `sourceSize` is the size the snapshot was captured at — its true aspect.
+    init(content: UIView, sourceSize: CGSize) {
+        self.content = content
+        self.contentAspect = sourceSize.height > 0
+            ? sourceSize.width / sourceSize.height
+            : 1
+        super.init(frame: CGRect(origin: .zero, size: sourceSize))
+        clipsToBounds = true
+        layer.cornerCurve = .continuous
+        content.removeFromSuperview()
+        addSubview(content)
+        setWindow(CGRect(origin: .zero, size: sourceSize))
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("not Storyboard-backed") }
+
+    /// Call inside an animation block — both frames tween on that curve.
+    func setWindow(_ rect: CGRect) {
+        frame = rect
+        content.frame = Self.contentFrame(inWindowOfSize: rect.size, aspect: contentAspect)
+    }
+
+    /// Aspect-fill, anchored to the window's top edge so growth spills off the
+    /// bottom.
+    static func contentFrame(inWindowOfSize size: CGSize, aspect: CGFloat) -> CGRect {
+        guard size.width > 0, size.height > 0, aspect > 0 else {
+            return CGRect(origin: .zero, size: size)
+        }
+        let width = size.width >= size.height * aspect
+            ? size.width
+            : size.height * aspect
+        let height = width / aspect
+        return CGRect(
+            x: (size.width - width) / 2,
+            y: 0,
+            width: width,
+            height: height
+        )
+    }
+}

--- a/RivuletTests/Unit/EntryMorphWindowViewTests.swift
+++ b/RivuletTests/Unit/EntryMorphWindowViewTests.swift
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+// Copyright (C) 2025-2026 Bain Gurley
+
+//
+//  EntryMorphWindowViewTests.swift
+//  RivuletTests
+//
+//  Regression cover for the row -> carousel entry morph squashing the poster.
+//  Pins the aspect-fill geometry and the interpolation invariant the fix
+//  leans on (see EntryMorphWindowView).
+//
+
+import XCTest
+@testable import Rivulet
+
+@MainActor
+final class EntryMorphWindowViewTests: XCTestCase {
+
+    /// MediaRowMetrics poster tile.
+    private let tile = CGSize(width: 296, height: 444)
+    /// PreviewCarouselGeometry.centeredCardFrame at 1920x1080.
+    private let card = CGSize(width: 1744, height: 1028)
+
+    private var posterAspect: CGFloat { tile.width / tile.height }
+
+    private func fit(_ size: CGSize, _ aspect: CGFloat) -> CGRect {
+        EntryMorphWindowView.contentFrame(inWindowOfSize: size, aspect: aspect)
+    }
+
+    private func lerp(_ a: CGFloat, _ b: CGFloat, _ t: CGFloat) -> CGFloat {
+        a + (b - a) * t
+    }
+
+    // MARK: - Endpoints
+
+    func test_atSourceTile_contentFillsWindowExactly() {
+        let r = fit(tile, posterAspect)
+        XCTAssertEqual(r.width, 296, accuracy: 0.5)
+        XCTAssertEqual(r.height, 444, accuracy: 0.5)
+        XCTAssertEqual(r.minX, 0, accuracy: 0.5)
+        XCTAssertEqual(r.minY, 0)
+    }
+
+    func test_atCard_contentOverflowsBottomInsteadOfSquashing() {
+        let r = fit(card, posterAspect)
+        XCTAssertEqual(r.width, 1744, accuracy: 0.5)
+        // NOT the card's 1028, which is what squashed it.
+        XCTAssertEqual(r.height, 2616, accuracy: 0.5)
+        XCTAssertEqual(r.height - card.height, 1588, accuracy: 0.5,
+                       "the cropped remainder should run off the bottom edge")
+    }
+
+    func test_scaleIsUniformOnBothAxes() {
+        let r = fit(card, posterAspect)
+        XCTAssertEqual(r.width / tile.width, r.height / tile.height, accuracy: 0.001)
+        XCTAssertEqual(r.width / tile.width, 5.89, accuracy: 0.01)
+    }
+
+    func test_contentIsTopAnchoredAtBothEnds() {
+        XCTAssertEqual(fit(tile, posterAspect).minY, 0)
+        XCTAssertEqual(fit(card, posterAspect).minY, 0)
+    }
+
+    // MARK: - The invariant the fix depends on
+
+    /// UIKit lerps width and height independently. Safe only because both
+    /// endpoints satisfy h = w / aspect. If this fails, the morph needs a
+    /// CADisplayLink like the corner-radius lerp has.
+    func test_aspectHoldsAtEveryInterpolatedFrame() {
+        let start = fit(tile, posterAspect)
+        let end = fit(card, posterAspect)
+
+        for step in 0...100 {
+            let t = CGFloat(step) / 100
+            let w = lerp(start.width, end.width, t)
+            let h = lerp(start.height, end.height, t)
+            XCTAssertEqual(w / h, posterAspect, accuracy: 0.0001,
+                           "aspect drifted at t=\(t)")
+        }
+    }
+
+    /// The original bug: animating the snapshot's own frame (content ==
+    /// window) skews it badly.
+    func test_oldBehaviour_didDistort() {
+        let mid = CGSize(width: lerp(tile.width, card.width, 0.5),
+                         height: lerp(tile.height, card.height, 0.5))
+        XCTAssertEqual(mid.width, 1020, accuracy: 0.5)
+        XCTAssertEqual(mid.height, 736, accuracy: 0.5)
+        XCTAssertEqual(mid.width / mid.height / posterAspect, 2.08, accuracy: 0.01)
+
+        let peak = (card.width / card.height) / posterAspect
+        XCTAssertEqual(peak, 2.54, accuracy: 0.01, "end-of-morph distortion")
+    }
+
+    func test_fixedMidpointStaysProportional() {
+        let start = fit(tile, posterAspect)
+        let end = fit(card, posterAspect)
+        XCTAssertEqual(lerp(start.width, end.width, 0.5), 1020, accuracy: 0.5)
+        XCTAssertEqual(lerp(start.height, end.height, 0.5), 1530, accuracy: 0.5)
+    }
+
+    // MARK: - Other tile shapes
+
+    /// Aspect comes from the source frame, so landscape Continue Watching
+    /// tiles need no special case.
+    func test_landscapeSourceTile_coversAndStaysUniform() {
+        let cw = CGSize(width: 357, height: 277)
+        let r = fit(card, cw.width / cw.height)
+
+        XCTAssertGreaterThanOrEqual(r.width, card.width - 0.5)
+        XCTAssertGreaterThanOrEqual(r.height, card.height - 0.5)
+        XCTAssertEqual(r.width / cw.width, r.height / cw.height, accuracy: 0.001)
+        XCTAssertEqual(r.minY, 0)
+    }
+
+    /// Exit runs the other way, so height drives the fill and the overflow is
+    /// horizontal.
+    func test_exitDirection_cardCompositeIntoPosterTile() {
+        let r = fit(tile, card.width / card.height)
+
+        XCTAssertGreaterThanOrEqual(r.width, tile.width - 0.5)
+        XCTAssertGreaterThanOrEqual(r.height, tile.height - 0.5)
+        XCTAssertEqual(r.width / card.width, r.height / card.height, accuracy: 0.001)
+        XCTAssertLessThan(r.minX, 0, "horizontal overflow should be centred")
+        XCTAssertEqual(r.minY, 0, "top-anchored in both directions")
+    }
+
+    // MARK: - Degenerate input
+
+    func test_degenerateInputsStayFinite() {
+        let cases: [(CGSize, CGFloat)] = [
+            (.zero, 0.667),
+            (CGSize(width: 100, height: 0), 0.667),
+            (CGSize(width: 296, height: 444), 0),
+            (CGSize(width: 296, height: 444), -2)
+        ]
+        for (size, aspect) in cases {
+            let r = fit(size, aspect)
+            XCTAssertTrue(r.width.isFinite && r.height.isFinite,
+                          "size \(size) aspect \(aspect) produced \(r)")
+        }
+    }
+
+    // MARK: - The view
+
+    func test_setWindow_movesWindowAndRefitsContent() {
+        let content = UIView()
+        let window = EntryMorphWindowView(content: content, sourceSize: tile)
+
+        XCTAssertTrue(window.clipsToBounds, "the window must crop the overflow")
+        XCTAssertEqual(content.frame.size, tile, "starts filling its source frame")
+
+        let target = CGRect(x: 88, y: 52, width: card.width, height: card.height)
+        window.setWindow(target)
+
+        XCTAssertEqual(window.frame, target)
+        XCTAssertEqual(content.frame.width, 1744, accuracy: 0.5)
+        XCTAssertEqual(content.frame.height, 2616, accuracy: 0.5)
+        XCTAssertEqual(content.frame.minY, 0, "content stays pinned to the top")
+    }
+
+    func test_windowReparentsContent() {
+        let content = UIView()
+        let holder = UIView()
+        holder.addSubview(content)
+
+        let window = EntryMorphWindowView(content: content, sourceSize: tile)
+
+        XCTAssertEqual(content.superview, window)
+        XCTAssertTrue(holder.subviews.isEmpty)
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/l984-451/Rivulet/issues/221

Opening a movie or show stretched its poster instead of scaling it. This makes the growth proportional and anchors it to the top, the way the Apple TV+ app does it.

## The bug

Tapping a tile captures `cell.snapshotView(afterScreenUpdates:)` for each visible tile and flies it into the carousel card in `runRowEntryMorph()`. A snapshot view is bitmap-backed — its contents stretch to whatever bounds you assign — and the two frames are far apart in shape:

- poster tile **296 × 444** (2:3) — `MediaRowMetrics`
- centered card **1744 × 1028** (~1.70:1) at 1920 × 1080 — `PreviewCarouselGeometry.centeredCardFrame`

That's **×5.89 across against ×2.32 down**, applied to a bitmap. The dismiss direction had the same problem, stated outright as `contentMode = .scaleToFill`.

The `standaloneDetail` paths (hero Info, tile-menu "More Info") don't show it — they open already-expanded with no card-grow morph.

## Before (Zendaya's head is squished, change playback speed if the effect is too fast) 

https://github.com/user-attachments/assets/335c0eab-c4de-49cf-b69c-019586ebb2e3 

## After (scale like Apple TV+ ) 
https://github.com/user-attachments/assets/f31ce61d-3593-4211-82c9-b98fb5ecd5bd

## The fix

`EntryMorphWindowView` is a clipping window that takes the frame the snapshot used to take. The snapshot lives inside it, aspect-filled and top-anchored, so it only ever scales uniformly and overflows the bottom edge — which is then cropped. Same construction as `BackdropPlaneView.Panel` (clipping container over an oversized image).

Three call sites move from `snapshotView.frame = …` to `window.setWindow(…)`: snapshot setup, the entry morph, and the exit morph.

No `CADisplayLink` is needed, unlike the corner-radius lerp. Both endpoint content frames satisfy `h = w / aspect`, and linear interpolation preserves that:

```
h(t) = h₀ + t(h₁ − h₀) = (w₀ + t(w₁ − w₀)) / aspect = w(t) / aspect
```

Top-anchoring is free for the same reason — content `y` is 0 at both endpoints, so it's 0 throughout.

Aspect is read from `sourceFrame` rather than hardcoded, so Continue Watching's landscape tiles (357 × 277) need no special case.

## Testing

**Unit** — `EntryMorphWindowViewTests.swift`, **12 tests, all pass** in the tvOS Simulator: both endpoints, uniform scale on both axes, top-anchoring, bottom overflow, landscape tiles, the exit direction, degenerate input, a swept-t proportionality check, and a reproduction of the old distorting path.

```bash
xcodebuild test -scheme Rivulet -destination 'platform=tvOS Simulator,name=Apple TV' \
  -only-testing:RivuletTests/EntryMorphWindowViewTests
```

**Visual** — built and run in the tvOS Simulator; the morph was watched on screen and recorded. Before/after clips above.

## Notes from self-review

Worth a look before this merges:

1. **Scale discontinuity at the hand-off (most likely to need a design call).** The morph now ends with the poster at ×5.89 while `backdropPlane` cross-fades in at roughly ×1. For items *with* backdrop art the fade covers it, since they're different images. For items *without* it, `BackdropPlaneView.loadArtwork` falls back to `item.artwork.poster` (`BackdropPlaneView.swift:164`) and renders it `.scaleAspectFill` over the full stage — so the fade blends the same poster against itself at a ~6× scale difference. The old code didn't have this, because its end state was squashed but still roughly ×1. **Worth testing a title with no backdrop specifically.**
2. **Dismiss during the entry morph.** Pressing Menu inside the 0.45s window is reachable (`.entryMorph` returns `.dismissOverlay`), and the entry animator's completion sets `entrySnapshotContainer.isHidden = true`, blanking the exit morph mid-flight. Pre-existing, not introduced here, but it lives in a function this PR rewrites.
3. `contentFrame` is pure `CGGeometry` but inherits `@MainActor` from the class, which forces the test class to be `@MainActor` too. Could be `nonisolated`, or lifted next to `PreviewCarouselGeometry`.
4. `EntryMorphWindowView.init` sets its frame twice — `super.init(frame:)` then `setWindow` with the same size. Taking the full source `CGRect` (both callers have it) would set it once.
5. `test_setWindow_movesWindowAndRefitsContent` uses exact `CGSize` equality; it passes only because 296/444 round-trips exactly in double precision. Every other numeric assertion in the file uses `accuracy: 0.5` and this one should too.

Changelog line added under `1.0.3 (68)`.

Happy to fold any of the above in, or drop the exit-morph half if you'd rather keep dismiss exactly as it behaves today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


