### PR TITLE
Settings: one title size for every row kind

### DIFF
--- a/Rivulet/Views/Settings/UIKit/SettingsCell.swift
+++ b/Rivulet/Views/Settings/UIKit/SettingsCell.swift
@@ -58,7 +58,7 @@ final class SettingsCell: UICollectionViewCell {
         selectedBackgroundView = nil
         contentView.backgroundColor = .clear
 
-        titleLabel.font = .systemFont(ofSize: 32, weight: .regular)
+        titleLabel.font = .systemFont(ofSize: 36, weight: .regular)
         titleLabel.textColor = .white
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         bg.addSubview(titleLabel)
@@ -107,11 +107,8 @@ final class SettingsCell: UICollectionViewCell {
         ])
     }
 
-    /// `titleSize` matches the SwiftUI rows: 36 for navigation rows, 32 for
-    /// toggles / cycles / actions / info.
     func configure(title: String, value: String?, showsChevron: Bool, destructive: Bool,
-                   titleSize: CGFloat, showsCheckmark: Bool = false) {
-        titleLabel.font = .systemFont(ofSize: titleSize, weight: .regular)
+                   showsCheckmark: Bool = false) {
         titleLabel.text = title
         checkmark.isHidden = !showsCheckmark
         valueLabel.text = value

--- a/Rivulet/Views/Settings/UIKit/SettingsCell.swift
+++ b/Rivulet/Views/Settings/UIKit/SettingsCell.swift
@@ -58,12 +58,12 @@ final class SettingsCell: UICollectionViewCell {
         selectedBackgroundView = nil
         contentView.backgroundColor = .clear
 
-        titleLabel.font = .systemFont(ofSize: 36, weight: .regular)
+        titleLabel.font = .systemFont(ofSize: 36, weight: .medium)
         titleLabel.textColor = .white
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         bg.addSubview(titleLabel)
 
-        valueLabel.font = .systemFont(ofSize: 32, weight: .regular)
+        valueLabel.font = .systemFont(ofSize: 32, weight: .medium)
         valueLabel.textColor = UIColor.white.withAlphaComponent(0.55)
         valueLabel.textAlignment = .right
         valueLabel.setContentHuggingPriority(.required, for: .horizontal)

--- a/Rivulet/Views/Settings/UIKit/SettingsPageViewController.swift
+++ b/Rivulet/Views/Settings/UIKit/SettingsPageViewController.swift
@@ -197,13 +197,8 @@ extension SettingsPageViewController: UICollectionViewDataSource, UICollectionVi
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Self.cellID, for: indexPath) as! SettingsCell
         let item = rows[indexPath.item]
-        let titleSize: CGFloat
-        switch item.kind {
-        case .navigation, .navigationValue, .info: titleSize = 36
-        default: titleSize = 32
-        }
         cell.configure(title: item.title, value: item.valueText, showsChevron: item.showsChevron,
-                       destructive: item.isDestructive, titleSize: titleSize, showsCheckmark: item.showsCheckmark)
+                       destructive: item.isDestructive, showsCheckmark: item.showsCheckmark)
         cell.onFocusGained = { [weak self] in self?.onFocusRow?(item.id) }
         return cell
     }


### PR DESCRIPTION
Settings rows use two different title sizes depending on what kind of row they are. This makes them all one size.

## The problem

| Row kind | Title size |
|---|---|
| Navigation, info (drill-in rows) | 36pt |
| Toggle, cycle, action (in-place controls) | 32pt |

A settings page mixes both kinds freely, so the title size steps by 4pt every few rows with no rule the eye can pick up. On an Apple TV it reads as rows being misaligned, not as a hierarchy.

## Screenshots
Before: "Display size" setting font is larger than the other Toggle settings.
After: All settings are the same size
| Before | After |
|:--:|:--:|
| <img width="420" alt="before" src="https://github.com/user-attachments/assets/52742c87-dd5b-4abe-be45-51d299c313a6" /> | <img width="420" alt="after" src="https://github.com/user-attachments/assets/d91f9b9e-2b0f-4fb4-9c35-5d85d769b232" /> |



## The change

**Commit 1** — one title size for every row kind, and the per-kind `titleSize` parameter is removed so there's no longer a knob that can reintroduce the split.

36pt is the one kept, because navigation rows are the majority on most pages, and the 36pt title / 32pt value pairing that results is what `navigationValue` rows already shipped.

**Commit 2** — title and value labels move from regular to medium weight. The tvOS scale is medium at nearly every level, and light strokes lose definition over TV compression at distance.

The two are split so either can be dropped on its own.

Nothing else changes: no row heights, colors, focus behavior, or layout.

## References

- [tvOS typography](https://developer.apple.com/design/human-interface-guidelines/tvos/visual-design/typography) — the type scale and weights
- [Lists and tables](https://developer.apple.com/design/human-interface-guidelines/lists-and-tables) — disclosure indicators as the navigation affordance
