### PR TITLE
Live TV/Guide updates + Aether/Ffmpeg bump

### DIFF
--- a/Rivulet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Rivulet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/superuser404notfound/AetherEngine",
       "state" : {
-        "revision" : "b05d384705792e949f22b0bd7c98ac8453cbd208",
-        "version" : "5.8.4"
+        "revision" : "54b0b864ca1669865596cd3b348be367a23f1ba9",
+        "version" : "5.17.3"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/superuser404notfound/FFmpegBuild",
       "state" : {
-        "revision" : "e8ae797a8ac9b715dfb6805b4929cc9f3e4173f2",
-        "version" : "2.1.0"
+        "revision" : "e832f22c89909297b7abe3a94c05b2816414b054",
+        "version" : "2.2.0"
       }
     },
     {

--- a/Rivulet/Services/Plex/Playback/AetherPlayer.swift
+++ b/Rivulet/Services/Plex/Playback/AetherPlayer.swift
@@ -482,19 +482,14 @@ final class AetherPlayer: PlayerProtocol {
         )
     }
 
-    /// Live TV load. Sets `isLive` so the engine treats the source as live
-    /// (seek becomes a no-op, live-edge/reconnect behavior). HLS sources use
-    /// `nativeRemoteHLS` so AVPlayer plays the remote playlist directly (no
-    /// demuxer probe / loopback — "HLS straight to AVPlayer"); everything else
-    /// (raw MPEG-TS, etc.) goes through the engine's demux/remux to a loopback
-    /// HLS stream. Either way the engine publishes `currentAVPlayer` for the
-    /// AVKit OSD. No start position (live).
-    /// `forceEngineDemux` disables the native-HLS shortcut so the engine's own
-    /// demuxer opens the playlist instead — used as a fallback when AVPlayer's
-    /// native path fails against a server (e.g. a Plex transcode session that
-    /// rejects AVPlayer's request pattern).
-    func loadLive(url: URL, headers: [String: String]?, forceEngineDemux: Bool = false) async throws {
-        let isHLS = Self.isHLSURL(url) && !forceEngineDemux
+    /// Live TV load. Plain HLS uses Aether's native remote-HLS route. Plex HLS
+    /// needs `hlsIngest`: its MPEG-TS segments carry broadcast audio and
+    /// DVB/teletext subtitle streams that AVPlayer's remote-HLS route would not
+    /// expose. Aether 5.17+ requires those playlists to enter through
+    /// `HLSLiveIngestReader`; handing a playlist to the raw URL reader now fails
+    /// closed instead of relying on FFmpeg network demuxing.
+    func loadLive(url: URL, headers: [String: String]?, hlsIngest: Bool = false) async throws {
+        let nativeRemoteHLS = Self.isHLSURL(url) && !hlsIngest
         let options = LoadOptions(
             suppressDisplayCriteria: false,
             httpHeaders: headers ?? [:],
@@ -505,7 +500,7 @@ final class AetherPlayer: PlayerProtocol {
             isLive: true,
             // ~30-minute DVR rewind window (engine retains it disk-backed).
             dvrWindowSeconds: 1800,
-            nativeRemoteHLS: isHLS,
+            nativeRemoteHLS: nativeRemoteHLS,
             preserveASSMarkup: true,
             probesize: 5 * 1024 * 1024,
             maxAnalyzeDuration: 5_000_000,
@@ -532,9 +527,21 @@ final class AetherPlayer: PlayerProtocol {
             // (Engine flag is labeled test-only but is the exact switch for
             // this; reset immediately after dispatch. Not applied to the
             // native-HLS shortcut, which never enters the demux dispatch.)
-            if !isHLS { AetherEngine.setForceSoftwarePathForTesting(true) }
-            defer { if !isHLS { AetherEngine.setForceSoftwarePathForTesting(false) } }
-            try await engine.load(url: url, startPosition: nil, options: options)
+            if !nativeRemoteHLS { AetherEngine.setForceSoftwarePathForTesting(true) }
+            defer { if !nativeRemoteHLS { AetherEngine.setForceSoftwarePathForTesting(false) } }
+            if hlsIngest {
+                let reader = HLSLiveIngestReader(
+                    playlistURL: url,
+                    httpHeaders: headers ?? [:]
+                )
+                try await engine.load(
+                    source: .custom(reader, formatHint: "mpegts"),
+                    startPosition: nil,
+                    options: options
+                )
+            } else {
+                try await engine.load(url: url, startPosition: nil, options: options)
+            }
         } catch {
             let pe = PlayerError.loadFailed(String(describing: error))
             errorSubject.send(pe)

--- a/Rivulet/Views/LiveTV/EPGGuideView.swift
+++ b/Rivulet/Views/LiveTV/EPGGuideView.swift
@@ -84,6 +84,12 @@ private extension UnifiedProgram {
 
 // MARK: - SwiftUI wrapper
 
+struct EPGFocusRequest: Equatable {
+    let id = UUID()
+    let channelID: String
+    let programID: String?
+}
+
 struct EPGGuide: UIViewRepresentable {
     let channels: [UnifiedChannel]
     let programsByChannel: [String: [UnifiedProgram]]
@@ -92,6 +98,10 @@ struct EPGGuide: UIViewRepresentable {
     let now: Date
     /// When true the grid releases focus (e.g. an overlay is presented).
     var menuActive: Bool = false
+    /// A one-shot request to scroll to and focus a specific programme.
+    var focusRequest: EPGFocusRequest? = nil
+    /// When present, consumes Menu and hands it to the guide host.
+    var onMenu: (() -> Void)? = nil
     var onFocus: (UnifiedChannel?, UnifiedProgram?) -> Void
     var onSelect: (UnifiedChannel, UnifiedProgram?) -> Void
     /// Fired when horizontal scroll (or focus) nears the loaded right edge, so
@@ -112,7 +122,7 @@ struct EPGGuide: UIViewRepresentable {
         // keeps cells within the CV's bounds).
         let infoBarInset = topInset ?? (transparent ? 0 : EPGTheme.infoBarHeight)
         layout.topOffset = 0
-        let cv = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        let cv = EPGCollectionView(frame: .zero, collectionViewLayout: layout)
         cv.backgroundColor = .clear
         cv.contentInsetAdjustmentBehavior = .never
         cv.contentInset = UIEdgeInsets(top: layout.gridTopInset,
@@ -137,7 +147,7 @@ struct EPGGuide: UIViewRepresentable {
 
         context.coordinator.collectionView = cv
         context.coordinator.apply(self, to: layout)
-
+        cv.onMenuPress = self.onMenu
         // Play/Pause jumps back to the now-airing programme.
         let jump = UITapGestureRecognizer(target: context.coordinator,
                                           action: #selector(Coordinator.jumpToNow))
@@ -155,6 +165,7 @@ struct EPGGuide: UIViewRepresentable {
         context.coordinator.parent = self
         guard let cv = context.coordinator.collectionView,
               let layout = cv.collectionViewLayout as? EPGLayout else { return }
+        cv.onMenuPress = self.onMenu
         cv.isUserInteractionEnabled = !menuActive
         let dataChanged = context.coordinator.apply(self, to: layout)
         if dataChanged {
@@ -167,18 +178,21 @@ struct EPGGuide: UIViewRepresentable {
             // Likely just `now` advanced — move the now-line without a reload.
             layout.invalidateLayout()
         }
+        context.coordinator.applyFocusRequest(self.focusRequest)
     }
 
     // MARK: Coordinator
 
     final class Coordinator: NSObject, UICollectionViewDataSource, UICollectionViewDelegate {
         var parent: EPGGuide
-        weak var collectionView: UICollectionView?
+        weak var collectionView: EPGCollectionView?
         private(set) var sections: [UnifiedChannel] = []
         private(set) var programs: [[UnifiedProgram]] = []
         private var lastSignature: Int = 0
         private var currentSection = 0
         private var pendingFocus: IndexPath?
+        private var pendingFocusWorkItem: DispatchWorkItem?
+        private var lastFocusRequestID: UUID?
         var didRestScroll = false
         /// The committed horizontal offset. The timeline only moves sideways on a
         /// deliberate left/right move (or drag); during channel changes and when
@@ -294,6 +308,12 @@ struct EPGGuide: UIViewRepresentable {
             guard let ip = context.nextFocusedIndexPath,
                   let channel = sections[safe: ip.section],
                   let program = programs[safe: ip.section]?[safe: ip.item] else { return }
+            if pendingFocus == ip {
+                pendingFocus = nil
+                pendingFocusWorkItem?.cancel()
+                pendingFocusWorkItem = nil
+                cv.remembersLastFocusedIndexPath = true
+            }
             let now = parent.now
             currentSection = ip.section
             currentFocusedIsLive = program.isLive(at: now)
@@ -382,11 +402,10 @@ struct EPGGuide: UIViewRepresentable {
 
         func collectionView(_ cv: UICollectionView, didSelectItemAt indexPath: IndexPath) {
             guard let channel = sections[safe: indexPath.section] else { return }
-            let now = parent.now
-            let row = programs[safe: indexPath.section] ?? []
-            let current = row.first { $0.isLive(at: now) } ?? row.last { $0.start <= now }
-            // Hand selection back to SwiftUI, which launches Rivulet's player.
-            parent.onSelect(channel, current)
+            let selected = programs[safe: indexPath.section]?[safe: indexPath.item]
+            // Hand the actual selected cell back to SwiftUI. The host decides
+            // whether it represents a playable current programme.
+            parent.onSelect(channel, selected)
         }
 
         // Play/Pause → move focus to the now-playing programme in the current row.
@@ -404,10 +423,102 @@ struct EPGGuide: UIViewRepresentable {
             cv.updateFocusIfNeeded()
         }
 
+        func applyFocusRequest(_ request: EPGFocusRequest?) {
+            guard let request, request.id != lastFocusRequestID,
+                  let cv = collectionView,
+                  let section = sections.firstIndex(where: { $0.id == request.channelID }),
+                  let row = programs[safe: section], !row.isEmpty
+            else { return }
+
+            lastFocusRequestID = request.id
+            let now = parent.now
+            let item = request.programID.flatMap { id in row.firstIndex(where: { $0.id == id }) }
+                ?? row.firstIndex { $0.isLive(at: now) }
+                ?? row.lastIndex { $0.start <= now }
+                ?? 0
+            let target = IndexPath(item: item, section: section)
+
+            pendingFocusWorkItem?.cancel()
+            pendingFocus = target
+            // Otherwise UICollectionView's remembered old cell can win the
+            // focus decision and pull the guide straight back on the next move.
+            cv.remembersLastFocusedIndexPath = false
+            currentSection = section
+            freeScrollUntil = Date().addingTimeInterval(0.8)
+            cv.layoutIfNeeded()
+            cv.scrollToItem(
+                at: target,
+                at: [.centeredHorizontally, .centeredVertically],
+                animated: true
+            )
+
+            // Keep the target pending until didUpdateFocus confirms that the
+            // highlight actually moved. Clearing it merely because UIKit asked
+            // for a preferred path loses the request if the scroll is still
+            // settling, leaving the old highlighted cell in control.
+            let work = DispatchWorkItem { [weak self, weak cv] in
+                self?.focusPendingTarget(in: cv, expected: target)
+            }
+            pendingFocusWorkItem = work
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.45, execute: work)
+        }
+
         func indexPathForPreferredFocusedView(in collectionView: UICollectionView) -> IndexPath? {
-            defer { pendingFocus = nil }
+            guard let pendingFocus,
+                  collectionView.cellForItem(at: pendingFocus) != nil else { return nil }
             return pendingFocus
         }
+
+        func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+            guard let cv = collectionView, let pendingFocus else { return }
+            focusPendingTarget(in: cv, expected: pendingFocus)
+        }
+
+        private func focusPendingTarget(
+            in collectionView: UICollectionView?,
+            expected target: IndexPath
+        ) {
+            guard let collectionView,
+                  pendingFocus == target,
+                  let cell = collectionView.cellForItem(at: target),
+                  cell.window != nil else { return }
+            collectionView.layoutIfNeeded()
+            collectionView.setNeedsFocusUpdate()
+            collectionView.updateFocusIfNeeded()
+        }
+    }
+}
+
+/// While a minimised player is active, Menu belongs to the guide's
+/// return-to-playing-programme action. With no handler it follows the normal
+/// responder chain unchanged.
+final class EPGCollectionView: UICollectionView {
+    var onMenuPress: (() -> Void)?
+    private var consumedMenu = false
+
+    override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        if presses.contains(where: { $0.type == .menu }), let onMenuPress {
+            consumedMenu = true
+            onMenuPress()
+            return
+        }
+        super.pressesBegan(presses, with: event)
+    }
+
+    override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        if consumedMenu, presses.contains(where: { $0.type == .menu }) {
+            consumedMenu = false
+            return
+        }
+        super.pressesEnded(presses, with: event)
+    }
+
+    override func pressesCancelled(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        if consumedMenu, presses.contains(where: { $0.type == .menu }) {
+            consumedMenu = false
+            return
+        }
+        super.pressesCancelled(presses, with: event)
     }
 }
 

--- a/Rivulet/Views/LiveTV/GuideLayoutView.swift
+++ b/Rivulet/Views/LiveTV/GuideLayoutView.swift
@@ -118,6 +118,18 @@ struct GuideLayoutView: View {
     @State private var focusedChannel: UnifiedChannel?
     @State private var focusedProgram: UnifiedProgram?
 
+    // Backdrop transition state. Keep the existing artwork treatment, but let
+    // the wash settle before revealing the crisp image for the new programme.
+    @State private var outgoingBackdropImage: UIImage?
+    @State private var incomingBackdropImage: UIImage?
+    @State private var backdropProgress: Double = 1
+    @State private var displayedArtworkImage: UIImage?
+    @State private var artworkOpacity: Double = 0
+
+    private let artworkFadeOutDuration = 0.18
+    private let backdropFadeDuration = 0.55
+    private let artworkFadeInDuration = 0.42
+
     private let tick = Timer.publish(every: 30, on: .main, in: .common).autoconnect()
 
     var body: some View {
@@ -270,57 +282,132 @@ struct GuideLayoutView: View {
     /// is used; otherwise the stock settings background shows through the clear.
     private var ambiance: some View {
         GeometryReader { geo in
-            if let url = guideBackdropURL {
-                ZStack(alignment: .topTrailing) {
-                    // Vibrant wash: the SOURCE image itself, blurred + stretched
-                    // to fill the whole guide, so its real colours bleed across
-                    // and down the screen. A left + bottom scrim keeps the
-                    // metadata column and grid readable.
-                    backdropImage(url)
-                        .frame(width: geo.size.width, height: geo.size.height)
-                        .clipped()
-                        .blur(radius: 70, opaque: true)
-                        .overlay(
-                            LinearGradient(
-                                colors: [Color.black.opacity(0.72), Color.black.opacity(0.05)],
-                                startPoint: .leading, endPoint: .trailing)
-                        )
-                        .overlay(
-                            LinearGradient(
-                                colors: [Color.clear, Color.black.opacity(0.65)],
-                                startPoint: .top, endPoint: .bottom)
-                        )
-
-                    // Crisp image in the top-right quarter; its left + bottom
-                    // edges fade into the blurred wash.
-                    backdropImage(url)
-                        .frame(width: geo.size.width * 0.5, height: geo.size.height * 0.55)
-                        .clipped()
-                        .mask(
-                            LinearGradient(colors: [.clear, .white],
-                                           startPoint: .leading, endPoint: .trailing)
-                        )
-                        .mask(
-                            LinearGradient(stops: [
-                                .init(color: .white, location: 0.0),
-                                .init(color: .white, location: 0.45),
-                                .init(color: .clear, location: 1.0)
-                            ], startPoint: .top, endPoint: .bottom)
-                        )
+            ZStack(alignment: .topTrailing) {
+                if let outgoingBackdropImage {
+                    blurredBackdrop(outgoingBackdropImage, size: geo.size)
+                        .opacity(1 - backdropProgress)
                 }
-                .frame(width: geo.size.width, height: geo.size.height, alignment: .topTrailing)
+
+                if let incomingBackdropImage {
+                    blurredBackdrop(incomingBackdropImage, size: geo.size)
+                        .opacity(backdropProgress)
+                }
+
+                if let displayedArtworkImage {
+                    crispArtwork(displayedArtworkImage, size: geo.size)
+                        .opacity(artworkOpacity)
+                }
             }
+            .frame(width: geo.size.width, height: geo.size.height, alignment: .topTrailing)
         }
         .ignoresSafeArea()
+        .task(id: guideBackdropURL) {
+            await transitionBackdrop(to: guideBackdropURL)
+        }
     }
 
-    @ViewBuilder private func backdropImage(_ url: URL) -> some View {
-        CachedAsyncImage(url: url) { phase in
-            switch phase {
-            case .success(let img): img.resizable().scaledToFill()
-            default: Color.clear
-            }
+    private func blurredBackdrop(_ image: UIImage, size: CGSize) -> some View {
+        // Existing main-branch treatment: the source image is blurred and
+        // stretched across the guide, with the same readability scrims.
+        backdropImage(image)
+            .frame(width: size.width, height: size.height)
+            .clipped()
+            .blur(radius: 70, opaque: true)
+            .overlay(
+                LinearGradient(
+                    colors: [Color.black.opacity(0.72), Color.black.opacity(0.05)],
+                    startPoint: .leading, endPoint: .trailing)
+            )
+            .overlay(
+                LinearGradient(
+                    colors: [Color.clear, Color.black.opacity(0.65)],
+                    startPoint: .top, endPoint: .bottom)
+            )
+    }
+
+    private func crispArtwork(_ image: UIImage, size: CGSize) -> some View {
+        // Existing main-branch image size and masks are intentionally unchanged.
+        backdropImage(image)
+            .frame(width: size.width * 0.5, height: size.height * 0.55)
+            .clipped()
+            .mask(
+                LinearGradient(colors: [.clear, .white],
+                               startPoint: .leading, endPoint: .trailing)
+            )
+            .mask(
+                LinearGradient(stops: [
+                    .init(color: .white, location: 0.0),
+                    .init(color: .white, location: 0.45),
+                    .init(color: .clear, location: 1.0)
+                ], startPoint: .top, endPoint: .bottom)
+            )
+    }
+
+    @MainActor
+    private func transitionBackdrop(to newURL: URL?) async {
+        withAnimation(.easeOut(duration: artworkFadeOutDuration)) {
+            artworkOpacity = 0
         }
+
+        do {
+            try await Task.sleep(for: .seconds(artworkFadeOutDuration))
+        } catch {
+            return
+        }
+        guard !Task.isCancelled else { return }
+
+        // Remove the old artwork once its fade has completed. Keep the old blur
+        // visible while the replacement image loads, so no stale artwork can
+        // leak into the background crossfade.
+        displayedArtworkImage = nil
+        let newImage = await loadBackdrop(newURL)
+        guard !Task.isCancelled else { return }
+
+        // Continue from the most recently selected wash when focus changes
+        // quickly, rather than briefly restoring an older programme image.
+        outgoingBackdropImage = incomingBackdropImage ?? outgoingBackdropImage
+        incomingBackdropImage = newImage
+        backdropProgress = 0
+        displayedArtworkImage = newImage
+
+        // Commit the old-at-100% / new-at-0% state before starting the
+        // animation. Without this frame SwiftUI can coalesce both mutations and
+        // jump directly to the replacement blur.
+        do {
+            try await Task.sleep(for: .milliseconds(16))
+        } catch {
+            return
+        }
+        guard !Task.isCancelled else { return }
+
+        withAnimation(.easeInOut(duration: backdropFadeDuration)) {
+            backdropProgress = 1
+        }
+
+        do {
+            try await Task.sleep(for: .seconds(backdropFadeDuration))
+        } catch {
+            return
+        }
+        guard !Task.isCancelled else { return }
+
+        outgoingBackdropImage = nil
+        guard newImage != nil else { return }
+
+        withAnimation(.easeInOut(duration: artworkFadeInDuration)) {
+            artworkOpacity = 1
+        }
+    }
+
+    private func loadBackdrop(_ url: URL?) async -> UIImage? {
+        guard let url else { return nil }
+        return await ImageCacheManager.shared.image(for: url)
+    }
+
+    private func backdropImage(_ image: UIImage) -> some View {
+        Image(uiImage: image)
+            .resizable()
+            .scaledToFill()
     }
 
     // MARK: - Player layer (fullscreen + PiP)

--- a/Rivulet/Views/LiveTV/GuideLayoutView.swift
+++ b/Rivulet/Views/LiveTV/GuideLayoutView.swift
@@ -20,7 +20,7 @@ import UIKit
 enum LiveTVDisplayMode: Equatable {
     case hidden      // No player visible
     case fullscreen  // Player is fullscreen overlay
-    case pip         // Player is in PiP (small, top-right)
+    case minimised   // Player continues beneath the guide artwork treatment
 }
 
 struct GuideLayoutView: View {
@@ -28,6 +28,7 @@ struct GuideLayoutView: View {
     var sourceIdFilter: String?
 
     @StateObject private var dataStore = LiveTVDataStore.shared
+    @AppStorage("liveTVPlayerMinimise") private var playerMinimiseEnabled = false
 
     /// Selected category tab. nil = "All Channels"; otherwise an M3U group title.
     @State private var selectedGroup: String?
@@ -109,6 +110,7 @@ struct GuideLayoutView: View {
 
     // Player state
     @State private var activeChannel: UnifiedChannel?
+    @State private var activePlayerController: LiveTVAetherPlayerViewController?
     @State private var playerSessionId = UUID()
     @State private var displayMode: LiveTVDisplayMode = .hidden
 
@@ -117,6 +119,7 @@ struct GuideLayoutView: View {
     @State private var now = Date()
     @State private var focusedChannel: UnifiedChannel?
     @State private var focusedProgram: UnifiedProgram?
+    @State private var guideFocusRequest: EPGFocusRequest?
 
     // Backdrop transition state. Keep the existing artwork treatment, but let
     // the wash settle before revealing the crisp image for the new programme.
@@ -140,13 +143,28 @@ struct GuideLayoutView: View {
                 // through. When artwork exists, `ambiance` paints it on top.
                 ambiance
 
+                // The live surface replaces the crisp top-right artwork while
+                // minimised. It stays above the blur but below the guide, so
+                // the same edge masks and guide cells naturally obscure it.
+                if displayMode == .minimised,
+                   let controller = activePlayerController {
+                    liveTVPlayerLayer(
+                        controller: controller,
+                        screenSize: geo.size,
+                        topSafeAreaInset: geo.safeAreaInsets.top
+                    )
+                        .zIndex(1)
+                }
+
                 if channels.isEmpty {
                     ProgressView()
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .zIndex(2)
                 } else {
                     guideContent
                         .opacity(displayMode == .fullscreen ? 0 : 1)
                         .disabled(displayMode == .fullscreen)
+                        .zIndex(2)
                 }
 
                 // EPG failure banner — surfaced so an empty guide doesn't look
@@ -157,13 +175,9 @@ struct GuideLayoutView: View {
                         .padding(.top, 16)
                         .frame(maxWidth: .infinity, alignment: .top)
                         .allowsHitTesting(false)
+                        .zIndex(3)
                 }
 
-                // Player layer — present when a channel is active.
-                if let channel = activeChannel {
-                    liveTVPlayerLayer(channel: channel, screenSize: geo.size)
-                        .zIndex(displayMode == .fullscreen ? 100 : 10)
-                }
             }
         }
         .ignoresSafeArea(edges: [.bottom, .trailing])
@@ -177,9 +191,15 @@ struct GuideLayoutView: View {
         }
         .onChange(of: channels.count) { _, _ in seedFocus() }
         .onReceive(tick) { t in now = t }
+        .onExitCommand(perform: guideMenuHandler)
     }
 
     // MARK: - Guide (grid + info bar)
+
+    private var guideMenuHandler: (() -> Void)? {
+        guard displayMode == .minimised else { return nil }
+        return { requestPlayingProgramFocus() }
+    }
 
     private var guideContent: some View {
         ZStack(alignment: .topLeading) {
@@ -190,11 +210,15 @@ struct GuideLayoutView: View {
                 totalMinutes: totalMinutes,
                 now: now,
                 menuActive: displayMode == .fullscreen,
+                focusRequest: guideFocusRequest,
+                onMenu: guideMenuHandler,
                 onFocus: { channel, program in
                     focusedChannel = channel
                     focusedProgram = program
                 },
-                onSelect: { channel, _ in selectChannel(channel) },
+                onSelect: { channel, program in
+                    selectChannel(channel, selectedProgram: program)
+                },
                 onNeedMore: {
                     Task { await dataStore.extendEPG(byHours: EPGTheme.lazyLoadChunkHours) }
                 },
@@ -293,7 +317,7 @@ struct GuideLayoutView: View {
                         .opacity(backdropProgress)
                 }
 
-                if let displayedArtworkImage {
+                if displayMode != .minimised, let displayedArtworkImage {
                     crispArtwork(displayedArtworkImage, size: geo.size)
                         .opacity(artworkOpacity)
                 }
@@ -410,62 +434,67 @@ struct GuideLayoutView: View {
             .scaledToFill()
     }
 
-    // MARK: - Player layer (fullscreen + PiP)
-
-    private var pipScale: CGFloat { 0.28 }
-    private var pipMargin: CGFloat { 60 }
+    // MARK: - Player layer (minimised guide artwork)
 
     @ViewBuilder
-    private func liveTVPlayerLayer(channel: UnifiedChannel, screenSize: CGSize) -> some View {
-        let player = LiveTVPlayerView(
-            channel: channel,
-            onDismiss: {
-                displayMode = .hidden
-                activeChannel = nil
-                playerSessionId = UUID()
-            },
-            onEnterPIP: {
-                var transaction = Transaction()
-                transaction.animation = nil
-                withTransaction(transaction) {
-                    displayMode = .pip
-                }
-            },
-            isInteractive: displayMode == .fullscreen  // Disable focus capture in PiP mode
-        )
-        // Force a fresh player session when changing channels or after exit/reopen.
-        .id("\(playerSessionId.uuidString)-\(channel.id)")
-        .transaction { transaction in
-            transaction.animation = nil
-        }
-        .animation(nil, value: displayMode)
-
-        if displayMode == .pip {
-            // PiP: a small 16:9 box pinned top-right. Integral 16px width steps
-            // avoid fractional scaling artifacts (a thin bottom strip).
-            let pipWidth = max(16, floor((screenSize.width * pipScale) / 16.0) * 16.0)
-            let pipHeight = pipWidth * 9.0 / 16.0
-            player
-                .frame(width: pipWidth, height: pipHeight)
-                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-                .shadow(color: .black.opacity(0.5), radius: 20, x: 0, y: 10)
-                .position(x: screenSize.width - pipMargin - pipWidth / 2,
-                          y: pipMargin + pipHeight / 2)
-                .allowsHitTesting(false)
-        } else {
-            // Fullscreen: fill the true screen and ignore the guide's safe-area
-            // inset. Sizing to the GeometryReader's (inset) size is what made the
-            // player render as a centered box instead of edge-to-edge.
-            player
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .ignoresSafeArea()
-                .allowsHitTesting(true)
-        }
+    private func liveTVPlayerLayer(
+        controller: LiveTVAetherPlayerViewController,
+        screenSize: CGSize,
+        topSafeAreaInset: CGFloat
+    ) -> some View {
+        // Fullscreen playback is a real UIKit modal so it covers the app
+        // sidebar and owns Menu. Only the minimised state is embedded here.
+        LiveTVEmbeddedAetherPlayer(controller: controller)
+            .id(playerSessionId)
+            .frame(width: screenSize.width * 0.5, height: screenSize.height * 0.55)
+            .clipped()
+            .mask(
+                LinearGradient(stops: [
+                    .init(color: .clear, location: 0.0),
+                    .init(color: .white.opacity(0.22), location: 0.05),
+                    .init(color: .white.opacity(0.62), location: 0.16),
+                    .init(color: .white, location: 0.34),
+                    .init(color: .white, location: 1.0)
+                ],
+                startPoint: .leading,
+                endPoint: .trailing
+                )
+            )
+            .mask(
+                LinearGradient(stops: [
+                    .init(color: .white, location: 0.0),
+                    .init(color: .white, location: 0.70),
+                    .init(color: .white.opacity(0.65), location: 0.84),
+                    .init(color: .clear, location: 1.0)
+                ], startPoint: .top, endPoint: .bottom)
+            )
+            .position(
+                x: screenSize.width * 0.75,
+                // The guide itself begins below tvOS's top safe area. Move the
+                // video back into that area so its top edge matches the
+                // full-screen artwork rather than the info-card content.
+                y: screenSize.height * 0.275 - topSafeAreaInset
+            )
+            .allowsHitTesting(false)
     }
 
     // MARK: - Selection
 
-    private func selectChannel(_ channel: UnifiedChannel) {
+    private func selectChannel(_ channel: UnifiedChannel, selectedProgram: UnifiedProgram?) {
+        // Selecting the currently airing cell for the still-playing channel
+        // returns the existing controller to fullscreen and restores its OSD.
+        if displayMode == .minimised,
+           activeChannel?.id == channel.id {
+            guard selectedProgram?.isCurrentlyAiring == true else { return }
+            restorePlayerFullscreen()
+            return
+        }
+
+        if playerMinimiseEnabled {
+            startMinimisablePlayer(channel)
+            return
+        }
+
         // Live TV plays through Aether (same OSD as Aether VOD): HLS goes
         // straight to AVPlayer, everything else is remuxed by the engine.
         // Presented as a full-screen modal so it escapes the guide's
@@ -481,6 +510,124 @@ struct GuideLayoutView: View {
         let vc = LiveTVAetherPlayerViewController(channel: channel)
         vc.modalPresentationStyle = .fullScreen
         top.present(vc, animated: true)
+    }
+
+    private func startMinimisablePlayer(_ channel: UnifiedChannel) {
+        // Replacing a channel while the old player is embedded should tear the
+        // old session down normally. Start the new modal after SwiftUI has
+        // removed that child controller from the guide hierarchy.
+        if activePlayerController != nil {
+            activePlayerController?.onMinimize = nil
+            activePlayerController?.onDismiss = nil
+            activePlayerController = nil
+            activeChannel = nil
+            displayMode = .hidden
+            DispatchQueue.main.async {
+                startMinimisablePlayer(channel)
+            }
+            return
+        }
+
+        let sessionID = UUID()
+        let controller = LiveTVAetherPlayerViewController(channel: channel)
+        controller.modalPresentationStyle = .fullScreen
+        controller.onMinimize = { [weak controller] in
+            guard let controller,
+                  activePlayerController === controller,
+                  playerSessionId == sessionID else { return }
+            controller.setMinimizedPresentation(true)
+            withAnimation(.easeInOut(duration: 0.3)) {
+                displayMode = .minimised
+            }
+            // Returning from fullscreen should land on the programme that is
+            // still playing, not whichever guide cell launched the session.
+            DispatchQueue.main.async {
+                requestPlayingProgramFocus()
+            }
+        }
+        controller.onDismiss = { [weak controller] in
+            guard let controller,
+                  activePlayerController === controller,
+                  playerSessionId == sessionID else { return }
+            displayMode = .hidden
+            activeChannel = nil
+            activePlayerController = nil
+            playerSessionId = UUID()
+        }
+
+        activeChannel = channel
+        activePlayerController = controller
+        playerSessionId = sessionID
+        displayMode = .fullscreen
+        presentPlayerController(controller, sessionID: sessionID)
+    }
+
+    private func restorePlayerFullscreen() {
+        guard displayMode == .minimised,
+              let controller = activePlayerController else { return }
+        let sessionID = playerSessionId
+
+        // Removing a child controller normally tears Aether down. Arm this
+        // single reparent first, then let SwiftUI detach it before presenting.
+        controller.prepareForReparenting()
+        displayMode = .fullscreen
+        DispatchQueue.main.async {
+            presentPlayerController(controller, sessionID: sessionID)
+        }
+    }
+
+    private func presentPlayerController(
+        _ controller: LiveTVAetherPlayerViewController,
+        sessionID: UUID,
+        attempt: Int = 0
+    ) {
+        guard activePlayerController === controller,
+              playerSessionId == sessionID else { return }
+
+        // A UIViewController cannot be presented while SwiftUI still owns it
+        // as a child. Usually one run-loop turn is enough; retry briefly if the
+        // representable is still being dismantled.
+        guard controller.parent == nil,
+              controller.presentingViewController == nil else {
+            guard attempt < 12 else { return }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) {
+                presentPlayerController(
+                    controller,
+                    sessionID: sessionID,
+                    attempt: attempt + 1
+                )
+            }
+            return
+        }
+
+        guard let top = topViewController() else { return }
+        controller.setMinimizedPresentation(false)
+        controller.modalPresentationStyle = .fullScreen
+        top.present(controller, animated: true)
+    }
+
+    private func topViewController() -> UIViewController? {
+        guard let scene = UIApplication.shared.connectedScenes
+                .compactMap({ $0 as? UIWindowScene }).first,
+              let root = (scene.windows.first(where: { $0.isKeyWindow })
+                ?? scene.windows.first)?.rootViewController
+        else { return nil }
+
+        var top = root
+        while let presented = top.presentedViewController { top = presented }
+        return top
+    }
+
+    private func requestPlayingProgramFocus() {
+        guard displayMode == .minimised, let channel = activeChannel else { return }
+        let program = dataStore.getCurrentProgram(for: channel)
+        selectedGroup = nil
+        focusedChannel = channel
+        focusedProgram = program
+        guideFocusRequest = EPGFocusRequest(
+            channelID: channel.id,
+            programID: program?.id
+        )
     }
 
     // MARK: - Helpers
@@ -504,6 +651,24 @@ struct GuideLayoutView: View {
             focusedProgram = dataStore.getCurrentProgram(for: first)
                 ?? dataStore.epg[first.id]?.first
         }
+    }
+}
+
+/// Hosts an existing UIKit Live TV controller in the passive top-right guide
+/// treatment. Fullscreen uses UIKit presentation instead of this representable.
+private struct LiveTVEmbeddedAetherPlayer: UIViewControllerRepresentable {
+    let controller: LiveTVAetherPlayerViewController
+
+    func makeUIViewController(context: Context) -> LiveTVAetherPlayerViewController {
+        controller.setMinimizedPresentation(true)
+        return controller
+    }
+
+    func updateUIViewController(
+        _ controller: LiveTVAetherPlayerViewController,
+        context: Context
+    ) {
+        controller.setMinimizedPresentation(true)
     }
 }
 

--- a/Rivulet/Views/LiveTV/LiveTVAetherPlayerViewController.swift
+++ b/Rivulet/Views/LiveTV/LiveTVAetherPlayerViewController.swift
@@ -26,8 +26,9 @@
 //  Playback routing (inside `AetherPlayer.loadLive`):
 //    - plain HLS (.m3u8 / format=hls) → nativeRemoteHLS: AVPlayer plays the
 //      remote playlist directly, engine re-attaches its layer to the surface.
-//    - raw MPEG-TS and Plex tuned sessions (progressive start.ts remux) →
-//      engine demux/decode.
+//    - Plex HLS → HLSLiveIngestReader → engine demux/remux, retaining the
+//      broadcast audio and DVB/teletext subtitle streams in its TS segments.
+//    - raw MPEG-TS → engine demux/decode.
 //
 //  Failure ladder (each stage re-resolves the URL — fresh Plex tune/session):
 //    0 primary → 1 engine demux → 2 bare AVPlayer on an AVPlayerLayer.
@@ -53,7 +54,8 @@ final class LiveTVAetherPlayerViewController: UIViewController {
     private let loadingSpinner = UIActivityIndicatorView(style: .large)
 
     private let subtitleModel = SubtitleModel()
-    private var subtitleHostingController: UIHostingController<AetherSubtitleOverlayView>?
+    private let subtitleChromeState = LiveTVSubtitleChromeState()
+    private var subtitleHostingController: UIHostingController<LiveTVSubtitleOverlayRoot>?
     private var captionStyle: CaptionStyle = CaptionAppearance.current()
     private var cancellables = Set<AnyCancellable>()
 
@@ -141,6 +143,10 @@ final class LiveTVAetherPlayerViewController: UIViewController {
     /// Same glass rail as Aether VOD; Up Next and Insights are hidden (they
     /// have no meaning for a live broadcast).
     private let railView = PlayerRailView()
+    /// Same foreground scrim as VOD. It sits above subtitles and below the
+    /// glass rail so captions slide underneath the OSD instead of reading over
+    /// its translucent material.
+    private let chromeScrim = ChromeScrimView()
     /// The SAME scrubber component VOD uses (same assets + spot in the rail),
     /// but driven non-seekably: it shows the current programme's air window
     /// (start/end wall-clock at the edges, current time on the playhead) with
@@ -162,6 +168,13 @@ final class LiveTVAetherPlayerViewController: UIViewController {
 
     /// Called once when the player is dismissed, so the guide can restore state.
     var onDismiss: (() -> Void)?
+    /// Set for a minimisable guide session. Menu with all chrome closed keeps
+    /// playback alive and returns the same controller to the guide.
+    var onMinimize: (() -> Void)?
+    private var isMinimizedPresentation = false
+    /// A modal↔guide reparent keeps the same controller and playback session.
+    /// The next disappearance must therefore skip normal teardown.
+    private var preservePlaybackForReparenting = false
 
     init(channel: UnifiedChannel) {
         self.channel = channel
@@ -232,7 +245,10 @@ final class LiveTVAetherPlayerViewController: UIViewController {
             guard let url = await LiveTVDataStore.shared.resolveStreamURL(for: channel) else {
                 if Task.isCancelled { return }
                 onDismiss?()
-                dismiss(animated: true)
+                if presentingViewController != nil {
+                    onMinimize = nil
+                    dismiss(animated: true)
+                }
                 return
             }
             if Task.isCancelled { return }
@@ -244,7 +260,7 @@ final class LiveTVAetherPlayerViewController: UIViewController {
                 try await aether.loadLive(
                     url: url,
                     headers: nil,
-                    forceEngineDemux: url.path.hasPrefix("/livetv/sessions/")
+                    hlsIngest: Self.shouldUsePlexHLSIngest(url, channel: channel)
                 )
                 if Task.isCancelled { return }
                 aether.play()
@@ -258,6 +274,10 @@ final class LiveTVAetherPlayerViewController: UIViewController {
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         guard isBeingDismissed || isMovingFromParent else { return }
+        if preservePlaybackForReparenting {
+            preservePlaybackForReparenting = false
+            return
+        }
         streamLoadTask?.cancel()
         streamLoadTask = nil
         stopLiveSessionKeepAlive()
@@ -300,9 +320,61 @@ final class LiveTVAetherPlayerViewController: UIViewController {
         onDismiss?()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        preservePlaybackForReparenting = false
+    }
+
+    /// Called before SwiftUI removes this controller from the guide so it can
+    /// be presented modally again without stopping Aether during the handoff.
+    func prepareForReparenting() {
+        preservePlaybackForReparenting = true
+    }
+
+    /// Switches the embedded controller between fullscreen interaction and a
+    /// passive guide preview without rebuilding the Aether playback session.
+    func setMinimizedPresentation(_ minimized: Bool) {
+        guard isMinimizedPresentation != minimized else { return }
+        isMinimizedPresentation = minimized
+        guard isViewLoaded else { return }
+
+        if minimized {
+            activePanel?.dismissPanel()
+            if railVisible { hideRail() }
+            focusCatcher.isHidden = true
+            view.isUserInteractionEnabled = false
+        } else {
+            view.isUserInteractionEnabled = true
+            focusCatcher.isHidden = false
+            showRail()
+        }
+
+        // The focused environment changes from this controller to the EPG (or
+        // back again). Ask their shared root after SwiftUI commits the new
+        // disabled/z-order state, otherwise a local focus request can be
+        // ignored because this controller no longer contains focus.
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            let root = self.view.window?.rootViewController ?? self
+            root.setNeedsFocusUpdate()
+            root.updateFocusIfNeeded()
+        }
+    }
+
     // MARK: - Chrome (glass rail + panels)
 
     private func setupChrome() {
+        chromeScrim.alpha = 0
+        chromeScrim.isUserInteractionEnabled = false
+        view.addSubview(chromeScrim)
+        chromeScrim.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            chromeScrim.topAnchor.constraint(equalTo: view.topAnchor),
+            chromeScrim.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            chromeScrim.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            chromeScrim.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+
         // Focus catcher: 1pt, transparent, always present.
         focusCatcher.frame = CGRect(x: 0, y: 0, width: 1, height: 1)
         focusCatcher.backgroundColor = .clear
@@ -334,6 +406,14 @@ final class LiveTVAetherPlayerViewController: UIViewController {
             progressBar.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -132),
             progressBar.bottomAnchor.constraint(equalTo: railView.bottomAnchor, constant: -34),
         ])
+
+        // State the intended VOD-matching order explicitly. The subtitle host
+        // was mounted before setupChrome; the scrim occludes it, while the rail
+        // and progress bar remain crisp above both.
+        view.bringSubviewToFront(chromeScrim)
+        view.bringSubviewToFront(railView)
+        view.bringSubviewToFront(progressBar)
+        view.bringSubviewToFront(focusCatcher)
 
         railView.onSubtitles = { [weak self] in self?.presentSubtitlePanel() }
         railView.onAudio = { [weak self] in self?.presentAudioPanel() }
@@ -396,12 +476,13 @@ final class LiveTVAetherPlayerViewController: UIViewController {
         railVisible = true
         updateRailContent()
         UIView.animate(withDuration: 0.25) {
+            self.chromeScrim.alpha = 1
             self.railView.alpha = 1
             self.railView.transform = .identity
             self.progressBar.alpha = 1
             self.progressBar.transform = .identity
         }
-        rebuildSubtitleOverlay()
+        subtitleChromeState.controlsVisible = true
         setNeedsFocusUpdate()
         updateFocusIfNeeded()
         restartAutoHide()
@@ -414,12 +495,13 @@ final class LiveTVAetherPlayerViewController: UIViewController {
         autoHideTimer = nil
         railView.resetFocusMemory()
         UIView.animate(withDuration: 0.2) {
+            self.chromeScrim.alpha = 0
             self.railView.alpha = 0
             self.railView.transform = CGAffineTransform(translationX: 0, y: 24)
             self.progressBar.alpha = 0
             self.progressBar.transform = CGAffineTransform(translationX: 0, y: 24)
         }
-        rebuildSubtitleOverlay()
+        subtitleChromeState.controlsVisible = false
         setNeedsFocusUpdate()
         updateFocusIfNeeded()
     }
@@ -847,6 +929,15 @@ final class LiveTVAetherPlayerViewController: UIViewController {
             completion?()
             return
         }
+        if let onMinimize {
+            armDismissEchoBlock()
+            preservePlaybackForReparenting = true
+            super.dismiss(animated: flag) {
+                onMinimize()
+                completion?()
+            }
+            return
+        }
         super.dismiss(animated: flag, completion: completion)
     }
 
@@ -898,7 +989,11 @@ final class LiveTVAetherPlayerViewController: UIViewController {
                 let retryURL = Self.forcingDirectStream(freshURL)
                 do {
                     aetherPlayer?.stop()
-                    try await aetherPlayer?.loadLive(url: retryURL, headers: nil, forceEngineDemux: true)
+                    try await aetherPlayer?.loadLive(
+                        url: retryURL,
+                        headers: nil,
+                        hlsIngest: Self.isHLSDelivery(retryURL)
+                    )
                     if Task.isCancelled { return }
                     aetherPlayer?.play()
                 } catch {
@@ -939,6 +1034,30 @@ final class LiveTVAetherPlayerViewController: UIViewController {
         return components.url ?? url
     }
 
+    /// Plex returns HLS from several URLs that do not advertise it in their
+    /// extension, notably `/livetv/.../tune` and `/livetv/sessions/...`.
+    /// Route those through Aether's explicit live-HLS ingest reader. Raw tuner
+    /// URLs (HDHomeRun `/auto/...`, UDP, etc.) remain on the raw demux path.
+    private static func shouldUsePlexHLSIngest(
+        _ url: URL,
+        channel: UnifiedChannel
+    ) -> Bool {
+        guard channel.sourceType == .plex else { return false }
+        return isHLSDelivery(url)
+    }
+
+    private static func isHLSDelivery(_ url: URL) -> Bool {
+        let path = url.path.lowercased()
+        let text = url.absoluteString.lowercased()
+        if url.pathExtension.lowercased() == "m3u8"
+            || text.contains(".m3u8")
+            || text.contains("format=hls") {
+            return true
+        }
+        return path.hasPrefix("/livetv/")
+            && (path.hasSuffix("/tune") || path.contains("/sessions/"))
+    }
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         lastResortLayer?.frame = view.bounds
@@ -970,11 +1089,11 @@ final class LiveTVAetherPlayerViewController: UIViewController {
         subtitleHostingController = hosting
     }
 
-    private func makeOverlayRootView() -> AetherSubtitleOverlayView {
-        AetherSubtitleOverlayView(
+    private func makeOverlayRootView() -> LiveTVSubtitleOverlayRoot {
+        LiveTVSubtitleOverlayRoot(
             model: subtitleModel,
             style: captionStyle,
-            controlsVisible: railVisible  // lift captions above the glass rail
+            chromeState: subtitleChromeState
         )
     }
 
@@ -1015,5 +1134,31 @@ final class LiveTVAetherPlayerViewController: UIViewController {
     @objc private func captionAppearanceDidChange() {
         captionStyle = CaptionAppearance.current()
         rebuildSubtitleOverlay()
+    }
+}
+
+/// Keeps the Live TV subtitle overlay mounted while the OSD changes. Replacing
+/// a UIHostingController root view makes the bottom inset jump immediately;
+/// publishing this value lets SwiftUI interpolate it exactly like VOD.
+@MainActor
+private final class LiveTVSubtitleChromeState: ObservableObject {
+    @Published var controlsVisible = false
+}
+
+private struct LiveTVSubtitleOverlayRoot: View {
+    let model: SubtitleModel
+    let style: CaptionStyle
+    @ObservedObject var chromeState: LiveTVSubtitleChromeState
+
+    var body: some View {
+        AetherSubtitleOverlayView(
+            model: model,
+            style: style,
+            controlsVisible: chromeState.controlsVisible
+        )
+        .animation(
+            .easeInOut(duration: 0.25),
+            value: chromeState.controlsVisible
+        )
     }
 }

--- a/Rivulet/Views/Settings/SettingsDescriptors.swift
+++ b/Rivulet/Views/Settings/SettingsDescriptors.swift
@@ -174,6 +174,11 @@ enum SettingsDescriptorStore {
             iconColor: .indigo,
             description: "Hides player controls during live TV for a traditional television experience. Swipe up to show controls."
         ),
+        "liveTVPlayerMinimise": SettingDescriptor(
+            icon: "pip.fill",
+            iconColor: .cyan,
+            description: "Keeps a channel playing in the top-right of the Guide when you leave fullscreen. Press Menu to return to its current programme, then select it to go fullscreen again."
+        ),
         "combineSources": SettingDescriptor(
             icon: "square.stack.3d.down.right",
             iconColor: .purple,

--- a/Rivulet/Views/Settings/UIKit/SettingsPageModels.swift
+++ b/Rivulet/Views/Settings/UIKit/SettingsPageModels.swift
@@ -310,6 +310,7 @@ enum SettingsContent {
             SettingsRowItem(id: "liveTVSources", title: "Live TV Sources", kind: .navigation(.iptv)),
             toggle("liveTVAboveLibraries", "Live TV Above Libraries", key: "liveTVAboveLibraries", default: false),
             toggle("classicTVMode", "Classic TV Mode", key: "classicTVMode", default: false),
+            toggle("liveTVPlayerMinimise", "Guide Mini-Player", key: "liveTVPlayerMinimise", default: false),
             toggle("combineSources", "Combine Sources", key: "combineLiveTVSources", default: true),
             SettingsRowItem(id: "defaultLayout", title: "Default Layout",
                             kind: .cycle(value: { LiveTVLayout(rawValue: SettingsStore.string("liveTVLayout", default: LiveTVLayout.guide.rawValue))?.description ?? "" },


### PR DESCRIPTION
- Added a fade effect to the background/art for the Live TV guide so make navigation appear smoother.

- Added 'Guide Mini-Player' option in 'Live TV' settings (opt in). Replaces the top right artwork with a minimised player to let the user navigate the guide while still enjoying playback.

- Changed EPG navigation to prevent 'Back/Menu' from exiting guide - now will always focus back on the currently playing program (if mini-player active).

- Updated Aether code to let Plex Live TV continue to function correctly.

- Bump AetherEngine version to 5.17.3

- Bump FfmpegBuild version to 2.2.0

- Adjusted Live TV subtitle settings (custom renderer) to mimic 'slide' effect behind the OSD when the OSD is bought up.