### PR TITLE
fix: leaked player end-time observer + cache guide formatter

### DIFF
--- a/Rivulet/Views/LiveTV/LiveGuideInfoCardView.swift
+++ b/Rivulet/Views/LiveTV/LiveGuideInfoCardView.swift
@@ -98,11 +98,15 @@ final class LiveGuideInfoCardView: UIView {
 
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
-    private static func timeRange(_ program: UnifiedProgram) -> String {
+    private static let timeFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.timeStyle = .short
         formatter.dateStyle = .none
-        return "\(formatter.string(from: program.startTime)) – \(formatter.string(from: program.endTime))"
+        return formatter
+    }()
+
+    private static func timeRange(_ program: UnifiedProgram) -> String {
+        "\(timeFormatter.string(from: program.startTime)) – \(timeFormatter.string(from: program.endTime))"
     }
 
     // MARK: - Focus


### PR DESCRIPTION
## What

Two small, verified fixes from a bug/perf pass:

### Leaked `AVPlayerItemDidPlayToEndTime` observer.
It was registered with the block-based `addObserver(forName:…)` API (which returns an opaque token) but torn down with `removeObserver(self,)` — a call that does not match a token-based registration. One `[weak self]` block leaked per HLS-route item (each next-episode / route change added another). Now the token is stored and removed in `teardownAVPlayerObservers()` and `deinit`.
### Per-call `DateFormatter` in `LiveGuideInfoCardView`.
`timeRange(_:)` allocated a formatter on every call — it runs on guide focus changes during channel scrolling. Hoisted to a cached `static let`, matching the pattern already used by `PlayerProgressBarView.endsAtFormatter` / `EpisodeCell`.

No behavior change: the deleted `removeObserver(self,)` was a confirmed no-op (only one such observer exists in the file), and the newest observer — the one for the current item — still drives `.ended` exactly as before.

## Test

`xcodebuild -scheme Rivulet -destination 'platform=tvOS Simulator,name=Apple TV' build` → **BUILD SUCCEEDED**

Verified the `deinit` access compiles the same way as the existing `appBackgroundObserver` teardown (identical isolated-`Any?` pattern under Swift 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)