### PR TITLE
feat: configurable skip length in Playback settings

### DIFF
--- a/Rivulet/Config/InputConfig.swift
+++ b/Rivulet/Config/InputConfig.swift
@@ -30,8 +30,10 @@ enum InputConfig {
 
     /// Single-press Left/Right skip. Applied uniformly across every remote and
     /// focus state (content-focused, IR d-pad, keyboard, and the focused
-    /// scrubber). May become a user-facing Playback setting later.
-    static let tapSeekSeconds: TimeInterval = 30
+    /// scrubber). User-configurable via Settings → Playback → Skip Length.
+    static var tapSeekSeconds: TimeInterval {
+        TimeInterval(SettingsStore.int(SkipInterval.storageKey, default: SkipInterval.defaultValue.rawValue))
+    }
     static let jumpSeekSeconds: TimeInterval = 30
 
     static let dpadThreshold: Float = 0.3

--- a/Rivulet/Services/Plex/Playback/NowPlayingService.swift
+++ b/Rivulet/Services/Plex/Playback/NowPlayingService.swift
@@ -32,6 +32,7 @@ final class NowPlayingService: ObservableObject {
     private var cachedArtwork: MPMediaItemArtwork?
     private var cachedArtworkURL: String?
     private var interruptionObserver: NSObjectProtocol?
+    private var skipIntervalObserver: NSObjectProtocol?
     private var inputCoordinator: PlaybackInputCoordinator?
     private var lastHandledPlaybackState: UniversalPlaybackState?
     /// Track if we've set Now Playing info with valid duration (> 0)
@@ -45,6 +46,15 @@ final class NowPlayingService: ObservableObject {
         // Configuring at app launch causes OSStatus error -50
         setupInterruptionHandling()
         setupRemoteCommandCenter()
+
+        // Keep the Control Center skip glyphs current when Skip Length changes.
+        skipIntervalObserver = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.refreshSkipIntervals()
+        }
     }
 
     // MARK: - Audio Session Configuration
@@ -274,27 +284,23 @@ final class NowPlayingService: ObservableObject {
             return .success
         }
 
-        // Skip forward (10 seconds)
+        // Skip forward. Seek by the live setting, not the event's interval:
+        // the event echoes preferredIntervals, which is only refreshed when the
+        // Skip Length setting changes (see refreshSkipIntervals).
         commandCenter.skipForwardCommand.isEnabled = true
-        commandCenter.skipForwardCommand.preferredIntervals = [NSNumber(value: InputConfig.tapSeekSeconds)]
-        commandCenter.skipForwardCommand.addTarget { [weak self] event in
-            guard let skipEvent = event as? MPSkipIntervalCommandEvent else {
-                return .commandFailed
-            }
-            self?.dispatchInputAction(.seekRelative(seconds: skipEvent.interval))
+        commandCenter.skipForwardCommand.addTarget { [weak self] _ in
+            self?.dispatchInputAction(.seekRelative(seconds: InputConfig.tapSeekSeconds))
             return .success
         }
 
-        // Skip backward (10 seconds)
+        // Skip backward (see note above).
         commandCenter.skipBackwardCommand.isEnabled = true
-        commandCenter.skipBackwardCommand.preferredIntervals = [NSNumber(value: InputConfig.tapSeekSeconds)]
-        commandCenter.skipBackwardCommand.addTarget { [weak self] event in
-            guard let skipEvent = event as? MPSkipIntervalCommandEvent else {
-                return .commandFailed
-            }
-            self?.dispatchInputAction(.seekRelative(seconds: -skipEvent.interval))
+        commandCenter.skipBackwardCommand.addTarget { [weak self] _ in
+            self?.dispatchInputAction(.seekRelative(seconds: -InputConfig.tapSeekSeconds))
             return .success
         }
+
+        refreshSkipIntervals()
 
         // Change playback position (scrubbing/seeking)
         commandCenter.changePlaybackPositionCommand.isEnabled = true
@@ -349,6 +355,16 @@ final class NowPlayingService: ObservableObject {
 
     private func setupRemoteCommandCenter() {
         configureRemoteCommands(on: MPRemoteCommandCenter.shared())
+    }
+
+    /// Sync the number shown inside the Control Center skip glyphs with the
+    /// user's Skip Length setting. The handlers already seek by the live
+    /// `InputConfig.tapSeekSeconds`; this only drives the displayed interval.
+    private func refreshSkipIntervals() {
+        let intervals = [NSNumber(value: InputConfig.tapSeekSeconds)]
+        let commandCenter = MPRemoteCommandCenter.shared()
+        commandCenter.skipForwardCommand.preferredIntervals = intervals
+        commandCenter.skipBackwardCommand.preferredIntervals = intervals
     }
 
     private func dispatchInputAction(_ action: PlaybackInputAction) {

--- a/Rivulet/Services/Plex/Playback/NowPlayingService.swift
+++ b/Rivulet/Services/Plex/Playback/NowPlayingService.swift
@@ -32,7 +32,6 @@ final class NowPlayingService: ObservableObject {
     private var cachedArtwork: MPMediaItemArtwork?
     private var cachedArtworkURL: String?
     private var interruptionObserver: NSObjectProtocol?
-    private var skipIntervalObserver: NSObjectProtocol?
     private var inputCoordinator: PlaybackInputCoordinator?
     private var lastHandledPlaybackState: UniversalPlaybackState?
     /// Track if we've set Now Playing info with valid duration (> 0)
@@ -46,15 +45,6 @@ final class NowPlayingService: ObservableObject {
         // Configuring at app launch causes OSStatus error -50
         setupInterruptionHandling()
         setupRemoteCommandCenter()
-
-        // Keep the Control Center skip glyphs current when Skip Length changes.
-        skipIntervalObserver = NotificationCenter.default.addObserver(
-            forName: UserDefaults.didChangeNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            self?.refreshSkipIntervals()
-        }
     }
 
     // MARK: - Audio Session Configuration
@@ -145,6 +135,10 @@ final class NowPlayingService: ObservableObject {
 
         self.viewModel = viewModel
         self.inputCoordinator = inputCoordinator
+
+        // Pick up any Skip Length change for this session's Control Center glyphs.
+        // Settings can't change mid-playback, so refreshing per attach suffices.
+        refreshSkipIntervals()
 
         // CRITICAL: Ensure audio session is active BEFORE setting Now Playing info
         // This is required for tvOS to register us as the Now Playing app
@@ -285,8 +279,8 @@ final class NowPlayingService: ObservableObject {
         }
 
         // Skip forward. Seek by the live setting, not the event's interval:
-        // the event echoes preferredIntervals, which is only refreshed when the
-        // Skip Length setting changes (see refreshSkipIntervals).
+        // the event echoes preferredIntervals, which only tracks the displayed
+        // glyph and is refreshed per playback session (see refreshSkipIntervals).
         commandCenter.skipForwardCommand.isEnabled = true
         commandCenter.skipForwardCommand.addTarget { [weak self] _ in
             self?.dispatchInputAction(.seekRelative(seconds: InputConfig.tapSeekSeconds))

--- a/Rivulet/Views/Components/WhatsNewView.swift
+++ b/Rivulet/Views/Components/WhatsNewView.swift
@@ -149,6 +149,7 @@ struct WhatsNewView: View {
             "Seeking is more dependable, a seek made while a title is still opening is no longer ignored, jumping far ahead no longer stalls playback until it gives up, and scrubbing to the very end no longer leaves Play unresponsive",
             "Subtitles now reappear when you seek onto a line that is already on screen, picture based subtitles with more than one element render in full, and external .sup subtitle files load",
             "Dolby Vision Profile 5 titles no longer play with a green or purple tint, and widescreen content encoded with non square pixels no longer appears squashed",
+            "You can now set how far a single Left or Right press skips during playback, from 5 to 30 seconds, in Playback settings",
         ]),
         ("1.0.4 (69)", [
             "New Content Filtering in Playback settings can mute strong language and skip scenes during playback, with per category controls and a quick toggle in the player",

--- a/Rivulet/Views/Settings/SettingsDescriptors.swift
+++ b/Rivulet/Views/Settings/SettingsDescriptors.swift
@@ -127,6 +127,10 @@ enum SettingsDescriptorStore {
             icon: "forward.end.alt",
             description: "How long to wait before automatically playing the next episode. Set to Off to disable autoplay."
         ),
+        "skipLength": SettingDescriptor(
+            icon: "forward.fill",
+            description: "How far a single Left or Right press skips during playback."
+        ),
         "showPostVideoUpNext": SettingDescriptor(
             icon: "rectangle.stack",
             description: "When off, closing credits play uninterrupted and the player returns to Home at the end of the episode."
@@ -353,6 +357,7 @@ enum SettingsDescriptorStore {
         case .userProfiles: return ("person.crop.circle", .systemCyan)
         case .displaySizePicker: return ("textformat.size", .systemOrange)
         case .autoplayCountdownPicker: return ("forward.end.alt", .systemPurple)
+        case .skipIntervalPicker: return ("forward.fill", .systemBlue)
         case .contentFilter: return ("hand.raised.fill", .systemOrange)
         case .contentFilterStrength: return ("dial.medium.fill", .systemOrange)
         case .liveTVSourceDetail: return ("tv.and.mediabox", .systemBlue)

--- a/Rivulet/Views/Settings/SettingsModels.swift
+++ b/Rivulet/Views/Settings/SettingsModels.swift
@@ -50,7 +50,7 @@ enum SettingsPage: Hashable, CaseIterable {
     case plex, iptv, libraries, cache, userProfiles
     case liveTVSourceDetail
     case addLiveTVSource, addOwnServer, addPlaylistURL
-    case displaySizePicker, autoplayCountdownPicker
+    case displaySizePicker, autoplayCountdownPicker, skipIntervalPicker
     case contentFilter, contentFilterStrength
 
     var title: String {
@@ -73,6 +73,7 @@ enum SettingsPage: Hashable, CaseIterable {
         case .userProfiles: return "User Profiles"
         case .displaySizePicker: return "Display Size"
         case .autoplayCountdownPicker: return "Autoplay Countdown"
+        case .skipIntervalPicker: return "Skip Length"
         case .contentFilter: return "Content Filtering"
         case .contentFilterStrength: return "Profanity Strength"
         }
@@ -95,6 +96,24 @@ enum AutoplayCountdown: Int, CaseIterable, CustomStringConvertible {
         case .twentySeconds: return "20 seconds"
         }
     }
+}
+
+// MARK: - Skip Length
+
+/// Single Left/Right tap-skip length (seconds). Drives `InputConfig.tapSeekSeconds`.
+/// Values are limited to magnitudes SF Symbols ships numbered goforward/gobackward
+/// glyphs for, so the on-screen seek indicator always shows the number.
+enum SkipInterval: Int, CaseIterable, CustomStringConvertible {
+    case fiveSeconds = 5
+    case tenSeconds = 10
+    case fifteenSeconds = 15
+    case thirtySeconds = 30
+
+    /// UserDefaults key backing the Skip Length setting.
+    static let storageKey = "skipSeconds"
+    static let defaultValue: SkipInterval = .thirtySeconds
+
+    var description: String { "\(rawValue) seconds" }
 }
 
 // Note: DisplaySize enum is in Services/UIScale.swift for global access.

--- a/Rivulet/Views/Settings/UIKit/SettingsPageModels.swift
+++ b/Rivulet/Views/Settings/UIKit/SettingsPageModels.swift
@@ -151,6 +151,7 @@ enum SettingsContent {
         case .about:       return about
         case .displaySizePicker:      return displaySizePicker
         case .autoplayCountdownPicker: return autoplayCountdownPicker
+        case .skipIntervalPicker:     return skipIntervalPicker
         case .contentFilter:          return contentFilter
         case .contentFilterStrength:  return contentFilterStrength
         }
@@ -171,6 +172,14 @@ enum SettingsContent {
             SettingsRowItem(id: "ac_\(opt.rawValue)", title: opt.description, kind: .option(
                 isSelected: { SettingsStore.int("autoplayCountdown", default: AutoplayCountdown.fiveSeconds.rawValue) == opt.rawValue },
                 select: { SettingsStore.setInt("autoplayCountdown", opt.rawValue) }))
+        }
+    }
+
+    private static var skipIntervalPicker: [SettingsRowItem] {
+        SkipInterval.allCases.map { opt in
+            SettingsRowItem(id: "si_\(opt.rawValue)", title: opt.description, kind: .option(
+                isSelected: { SettingsStore.int(SkipInterval.storageKey, default: SkipInterval.defaultValue.rawValue) == opt.rawValue },
+                select: { SettingsStore.setInt(SkipInterval.storageKey, opt.rawValue) }))
         }
     }
 
@@ -225,6 +234,10 @@ enum SettingsContent {
             SettingsRowItem(id: "autoplayCountdown", title: "Autoplay Countdown",
                             kind: .navigationValue(.autoplayCountdownPicker, value: {
                                 AutoplayCountdown(rawValue: SettingsStore.int("autoplayCountdown", default: AutoplayCountdown.fiveSeconds.rawValue))?.description ?? ""
+                            })),
+            SettingsRowItem(id: "skipLength", title: "Skip Length",
+                            kind: .navigationValue(.skipIntervalPicker, value: {
+                                SkipInterval(rawValue: SettingsStore.int(SkipInterval.storageKey, default: SkipInterval.defaultValue.rawValue))?.description ?? ""
                             })),
             toggle("showPostVideoUpNext", "Show Up Next Panel", key: "showPostVideoUpNext", default: true),
             SettingsRowItem(id: "cat_contentFilter", title: "Content Filtering",

--- a/RivuletTests/Unit/Input/SkipIntervalSettingTests.swift
+++ b/RivuletTests/Unit/Input/SkipIntervalSettingTests.swift
@@ -68,8 +68,12 @@ final class SkipIntervalSettingTests: XCTestCase {
 
         coordinator.handle(action: .stepSeek(forward: true), source: .siriMicroGamepad)
 
-        let until = Date().addingTimeInterval(InputConfig.seekCoalesceInterval + 0.08)
-        RunLoop.main.run(until: until)
+        // The coalesce timer fires on the main run loop; spin it until the
+        // seek is dispatched rather than betting on a fixed deadline.
+        let deadline = Date().addingTimeInterval(InputConfig.seekCoalesceInterval + 2.0)
+        while target.received.isEmpty && Date() < deadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+        }
 
         XCTAssertEqual(target.received.count, 1)
         guard case .seekRelative(let seconds) = target.received.first?.0 else {

--- a/RivuletTests/Unit/Input/SkipIntervalSettingTests.swift
+++ b/RivuletTests/Unit/Input/SkipIntervalSettingTests.swift
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+// Copyright (C) 2025-2026 Bain Gurley
+
+//
+//  SkipIntervalSettingTests.swift
+//  RivuletTests
+//
+//  The Skip Length setting (#233): the SkipInterval enum, and the wiring from
+//  the `skipSeconds` default through InputConfig.tapSeekSeconds into an actual
+//  coalesced seek.
+//
+
+import XCTest
+@testable import Rivulet
+
+@MainActor
+final class SkipIntervalSettingTests: XCTestCase {
+
+    private let key = SkipInterval.storageKey
+    private var savedValue: Any?
+
+    override func setUp() {
+        super.setUp()
+        savedValue = UserDefaults.standard.object(forKey: key)
+        UserDefaults.standard.removeObject(forKey: key)
+    }
+
+    override func tearDown() {
+        if let savedValue {
+            UserDefaults.standard.set(savedValue, forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        super.tearDown()
+    }
+
+    // MARK: Enum integrity
+
+    func testSkipIntervalOptionsAreNumberedGlyphMagnitudes() {
+        XCTAssertEqual(SkipInterval.allCases.map(\.rawValue), [5, 10, 15, 30])
+    }
+
+    func testSkipIntervalDescriptionRendersSeconds() {
+        XCTAssertEqual(SkipInterval.tenSeconds.description, "10 seconds")
+        XCTAssertEqual(SkipInterval.thirtySeconds.description, "30 seconds")
+    }
+
+    // MARK: InputConfig wiring
+
+    func testTapSeekSecondsDefaultsToThirtyWhenUnset() {
+        XCTAssertNil(UserDefaults.standard.object(forKey: key))
+        XCTAssertEqual(InputConfig.tapSeekSeconds, 30, accuracy: 0.0001)
+    }
+
+    func testTapSeekSecondsReflectsStoredSetting() {
+        UserDefaults.standard.set(SkipInterval.tenSeconds.rawValue, forKey: key)
+        XCTAssertEqual(InputConfig.tapSeekSeconds, 10, accuracy: 0.0001)
+    }
+
+    // MARK: End-to-end through the input coordinator
+
+    func testStepSeekUsesConfiguredSkipLength() {
+        UserDefaults.standard.set(SkipInterval.fifteenSeconds.rawValue, forKey: key)
+
+        let coordinator = PlaybackInputCoordinator()
+        let target = MockTarget()
+        coordinator.target = target
+
+        coordinator.handle(action: .stepSeek(forward: true), source: .siriMicroGamepad)
+
+        let until = Date().addingTimeInterval(InputConfig.seekCoalesceInterval + 0.08)
+        RunLoop.main.run(until: until)
+
+        XCTAssertEqual(target.received.count, 1)
+        guard case .seekRelative(let seconds) = target.received.first?.0 else {
+            return XCTFail("Expected a coalesced seekRelative action")
+        }
+        XCTAssertEqual(seconds, 15, accuracy: 0.0001)
+    }
+
+    // MARK: Helpers
+
+    private final class MockTarget: PlaybackInputTarget {
+        var isScrubbingForInput = false
+        private(set) var received: [(PlaybackInputAction, PlaybackInputSource)] = []
+
+        func handleInputAction(_ action: PlaybackInputAction, source: PlaybackInputSource) {
+            received.append((action, source))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **Skip Length** setting (Settings → Playback) so a single Left/Right press can skip **5, 10, 15, or 30 seconds** instead of a fixed 30. Default stays 30, so existing behavior is unchanged. The chosen value drives the tap skip everywhere it is used today: the VOD player, the Control Center skip buttons, and the Live TV multiview jump.

Closes #233.

## Details

- New `SkipInterval` enum + picker page, following the existing Autoplay Countdown settings pattern (no new plumbing).
- `InputConfig.tapSeekSeconds` now reads the `skipSeconds` preference (default 30) instead of a hardcoded constant.
- Options are limited to magnitudes that ship numbered `goforward`/`gobackward` SF Symbols (5/10/15/30), so the on-screen seek indicator always shows the number.

## Testing

- New unit tests cover the option set, the unset default (30), the stored round-trip, and an end-to-end check that a tap skip dispatches the configured amount.
- Build and tests pass on the tvOS Simulator.

## Demo

https://github.com/user-attachments/assets/4d06a895-3e74-43d0-82c3-30e7b97b855d

<img width="1438" height="791" alt="Screenshot 2026-07-22 at 5 14 05 PM" src="https://github.com/user-attachments/assets/9e59f8cb-1155-438a-a524-e5b71fd2b10f" />
<img width="1454" height="818" alt="Screenshot 2026-07-22 at 5 14 15 PM" src="https://github.com/user-attachments/assets/ae687733-a642-4aa5-8221-2e5bfc2fe203" />






<!-- drag rivulet-skip-length.mp4 into this box to attach the clip -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)