### PR TITLE
Release trickplay thumbnails on item end; merge live TV channels off main

### DIFF
--- a/Rivulet/Services/LiveTV/LiveTVDataStore.swift
+++ b/Rivulet/Services/LiveTV/LiveTVDataStore.swift
@@ -319,15 +319,22 @@ class LiveTVDataStore: ObservableObject {
     private func updateSourceInfo() async {
         var infos: [LiveTVSourceInfo] = []
 
+        // One pass instead of a filter per provider: on a large lineup the
+        // per-provider filter is O(providers × channels) on the main actor,
+        // a second main-thread sweep right behind the channel load.
+        var channelCounts: [String: Int] = [:]
+        for channel in channels {
+            channelCounts[channel.sourceId, default: 0] += 1
+        }
+
         for (id, provider) in providers {
             let isConnected = await provider.isConnected
-            let channelCount = channels.filter { $0.sourceId == id }.count
 
             infos.append(LiveTVSourceInfo(
                 id: id,
                 sourceType: provider.sourceType,
                 displayName: provider.displayName,
-                channelCount: channelCount,
+                channelCount: channelCounts[id] ?? 0,
                 isConnected: isConnected,
                 lastSync: nil  // TODO: Track last sync time
             ))
@@ -337,6 +344,61 @@ class LiveTVDataStore: ObservableObject {
     }
 
     // MARK: - Channel Loading
+
+    /// Fetch every provider in parallel and merge the results into one sorted
+    /// lineup.
+    ///
+    /// `nonisolated` so both callers below can run it off the main actor. On a
+    /// large M3U this is 100k+ channels, and the sort falls through to Unicode
+    /// string collation because most playlists omit `tvg-chno` — enough work to
+    /// stall the focus engine if it lands on the main thread.
+    private nonisolated static func fetchAndMergeChannels(
+        from providerEntries: [(key: String, value: any LiveTVProvider)],
+        refreshing: Bool
+    ) async -> (channels: [UnifiedChannel], errors: [String]) {
+        var allChannels: [UnifiedChannel] = []
+        var errors: [String] = []
+
+        await withTaskGroup(of: (String, Result<[UnifiedChannel], Error>).self) { group in
+            for (id, provider) in providerEntries {
+                group.addTask {
+                    do {
+                        let channels = refreshing
+                            ? try await provider.refreshChannels()
+                            : try await provider.fetchChannels()
+                        return (id, .success(channels))
+                    } catch {
+                        return (id, .failure(error))
+                    }
+                }
+            }
+
+            for await (sourceId, result) in group {
+                switch result {
+                case .success(let channels):
+                    allChannels.append(contentsOf: channels)
+                case .failure(let error):
+                    errors.append("\(sourceId): \(error.localizedDescription)")
+                    print("📺 LiveTVDataStore: ❌ Failed to load from \(sourceId): \(error)")
+                }
+            }
+        }
+
+        // Sort channels by number, then name
+        allChannels.sort { c1, c2 in
+            if let n1 = c1.channelNumber, let n2 = c2.channelNumber {
+                return n1 < n2
+            } else if c1.channelNumber != nil {
+                return true
+            } else if c2.channelNumber != nil {
+                return false
+            } else {
+                return c1.name < c2.name
+            }
+        }
+
+        return (allChannels, errors)
+    }
 
     /// Load channels from all sources
     func loadChannels() async {
@@ -350,62 +412,28 @@ class LiveTVDataStore: ObservableObject {
         isLoadingChannels = true
         channelsError = nil
 
-        // Snapshot providers up-front so the task body doesn't touch the
-        // @MainActor-bound dictionary (same reason as loadEPG below). Without
-        // this the task has to inherit MainActor, which puts the sort at the
-        // bottom of this function on the main thread.
+        // Snapshot providers up-front so the task body never touches the
+        // @MainActor-bound dictionary.
         let providerEntries = Array(providers)
 
         // Detached, not `Task {}`: a Task created inside a @MainActor method
-        // inherits MainActor isolation, so the merge + sort of every channel
-        // (100k+ on a large M3U) would run on the main thread while the home
-        // screen is loading. The MainActor.run below is the only main hop.
+        // inherits MainActor isolation, which would put the merge and sort back
+        // on the main thread while the home screen is still loading. Priority
+        // does not change isolation, so `Task(priority:)` is not a substitute.
+        // The MainActor.run below is the only main hop.
         channelLoadTask = Task.detached { [providerEntries] in
-            var allChannels: [UnifiedChannel] = []
-            var errors: [String] = []
+            let merged = await Self.fetchAndMergeChannels(from: providerEntries, refreshing: false)
 
-            // Fetch from all providers in parallel
-            await withTaskGroup(of: (String, Result<[UnifiedChannel], Error>).self) { group in
-                for (id, provider) in providerEntries {
-                    group.addTask {
-                        do {
-                            let channels = try await provider.fetchChannels()
-                            return (id, .success(channels))
-                        } catch {
-                            return (id, .failure(error))
-                        }
-                    }
-                }
-
-                for await (sourceId, result) in group {
-                    switch result {
-                    case .success(let channels):
-                        allChannels.append(contentsOf: channels)
-                    case .failure(let error):
-                        errors.append("\(sourceId): \(error.localizedDescription)")
-                        print("📺 LiveTVDataStore: ❌ Failed to load from \(sourceId): \(error)")
-                    }
-                }
-            }
-
-            // Sort channels by number, then name
-            allChannels.sort { c1, c2 in
-                if let n1 = c1.channelNumber, let n2 = c2.channelNumber {
-                    return n1 < n2
-                } else if c1.channelNumber != nil {
-                    return true
-                } else if c2.channelNumber != nil {
-                    return false
-                } else {
-                    return c1.name < c2.name
-                }
-            }
+            // A cancelled (superseded) task must NOT publish: its partial
+            // results would clobber whatever the newer loadChannels wrote, and
+            // that newer task owns isLoadingChannels from here on.
+            guard !Task.isCancelled else { return }
 
             await MainActor.run {
-                self.channels = allChannels
+                self.channels = merged.channels
                 self.isLoadingChannels = false
-                if !errors.isEmpty {
-                    self.channelsError = errors.joined(separator: "\n")
+                if !merged.errors.isEmpty {
+                    self.channelsError = merged.errors.joined(separator: "\n")
                 }
             }
 
@@ -422,49 +450,17 @@ class LiveTVDataStore: ObservableObject {
         isLoadingChannels = true
         channelsError = nil
 
-        var allChannels: [UnifiedChannel] = []
-        var errors: [String] = []
+        // Detached for the same reason as loadChannels — this one is reached
+        // from a Settings action, so the freeze would be squarely on a tap.
+        let providerEntries = Array(providers)
+        let merged = await Task.detached { [providerEntries] in
+            await Self.fetchAndMergeChannels(from: providerEntries, refreshing: true)
+        }.value
 
-        // Refresh from all providers in parallel
-        await withTaskGroup(of: (String, Result<[UnifiedChannel], Error>).self) { group in
-            for (id, provider) in providers {
-                group.addTask {
-                    do {
-                        let channels = try await provider.refreshChannels()
-                        return (id, .success(channels))
-                    } catch {
-                        return (id, .failure(error))
-                    }
-                }
-            }
-
-            for await (sourceId, result) in group {
-                switch result {
-                case .success(let channels):
-                    allChannels.append(contentsOf: channels)
-                case .failure(let error):
-                    errors.append("\(sourceId): \(error.localizedDescription)")
-                }
-            }
-        }
-
-        // Sort channels
-        allChannels.sort { c1, c2 in
-            if let n1 = c1.channelNumber, let n2 = c2.channelNumber {
-                return n1 < n2
-            } else if c1.channelNumber != nil {
-                return true
-            } else if c2.channelNumber != nil {
-                return false
-            } else {
-                return c1.name < c2.name
-            }
-        }
-
-        channels = allChannels
+        channels = merged.channels
         isLoadingChannels = false
-        if !errors.isEmpty {
-            channelsError = errors.joined(separator: "\n")
+        if !merged.errors.isEmpty {
+            channelsError = merged.errors.joined(separator: "\n")
         }
 
         await updateSourceInfo()
@@ -495,18 +491,23 @@ class LiveTVDataStore: ObservableObject {
         // Snapshot providers so we can gather XMLTV channel logos after the EPG
         // fetch without touching the @MainActor providers dictionary post-suspension.
         let providerList = Array(providers.values)
+        let providersById = providers
 
-        epgLoadTask = Task {
+        // Grouping has to read `channels`, so it stays here on the main actor;
+        // the merge of every source's programs below does not, and is the part
+        // that scales with the lineup.
+        let channelsBySource = Dictionary(grouping: channels, by: { $0.sourceId })
+
+        // Detached for the same reason as loadChannels: `Task {}` would inherit
+        // MainActor and put the EPG merge on the main thread.
+        epgLoadTask = Task.detached { [channelsBySource, providersById, providerList, sourceNames] in
             var allEPG: [String: [UnifiedProgram]] = [:]
             var issues: [EPGFetchIssue] = []
-
-            // Group channels by source
-            let channelsBySource = Dictionary(grouping: channels, by: { $0.sourceId })
 
             // Fetch EPG from each provider
             await withTaskGroup(of: (String, Result<[String: [UnifiedProgram]], Error>).self) { group in
                 for (sourceId, sourceChannels) in channelsBySource {
-                    guard let provider = providers[sourceId] else {
+                    guard let provider = providersById[sourceId] else {
                         print("📺 LiveTVDataStore: ⚠️ No provider found for sourceId: \(sourceId)")
                         continue
                     }
@@ -678,7 +679,7 @@ class LiveTVDataStore: ObservableObject {
     /// for the guide banner. Keep these deliberately concrete — "EPG server
     /// returned HTTP 404" tells the user where to look, whereas the raw
     /// `error.localizedDescription` is often opaque.
-    static func shortEPGFailureReason(for error: Error) -> String {
+    nonisolated static func shortEPGFailureReason(for error: Error) -> String {
         if let xmltv = error as? XMLTVParseError {
             switch xmltv {
             case .httpError(let code):

--- a/Rivulet/Services/LiveTV/LiveTVDataStore.swift
+++ b/Rivulet/Services/LiveTV/LiveTVDataStore.swift
@@ -350,13 +350,23 @@ class LiveTVDataStore: ObservableObject {
         isLoadingChannels = true
         channelsError = nil
 
-        channelLoadTask = Task {
+        // Snapshot providers up-front so the task body doesn't touch the
+        // @MainActor-bound dictionary (same reason as loadEPG below). Without
+        // this the task has to inherit MainActor, which puts the sort at the
+        // bottom of this function on the main thread.
+        let providerEntries = Array(providers)
+
+        // Detached, not `Task {}`: a Task created inside a @MainActor method
+        // inherits MainActor isolation, so the merge + sort of every channel
+        // (100k+ on a large M3U) would run on the main thread while the home
+        // screen is loading. The MainActor.run below is the only main hop.
+        channelLoadTask = Task.detached { [providerEntries] in
             var allChannels: [UnifiedChannel] = []
             var errors: [String] = []
 
             // Fetch from all providers in parallel
             await withTaskGroup(of: (String, Result<[UnifiedChannel], Error>).self) { group in
-                for (id, provider) in providers {
+                for (id, provider) in providerEntries {
                     group.addTask {
                         do {
                             let channels = try await provider.fetchChannels()
@@ -399,7 +409,7 @@ class LiveTVDataStore: ObservableObject {
                 }
             }
 
-            await updateSourceInfo()
+            await self.updateSourceInfo()
         }
 
         await channelLoadTask?.value

--- a/Rivulet/Services/Plex/PlexThumbnailService.swift
+++ b/Rivulet/Services/Plex/PlexThumbnailService.swift
@@ -48,6 +48,14 @@ final class PlexThumbnailService {
         loadingTasks[partId] = task
 
         let result = await task.value
+
+        // `clearCache` may have released this part while the load was in
+        // flight; it drops the entry from `loadingTasks` to say so. Still hand
+        // back the frame we already have, but don't re-populate the cache
+        // nobody is left holding.
+        guard loadingTasks[partId] == task else {
+            return result?.thumbnail(at: time)
+        }
         loadingTasks[partId] = nil
 
         if let data = result {
@@ -120,7 +128,13 @@ final class PlexThumbnailService {
         loadingTasks[partId] = task
 
         Task {
-            if let result = await task.value {
+            let result = await task.value
+            // The caller may have released this part before the download
+            // finished (short watch, or a skip to the next episode). Writing
+            // the result now would re-fill the cache with nobody left to
+            // release it, so treat a dropped `loadingTasks` entry as a release.
+            guard loadingTasks[partId] == task else { return }
+            if let result {
                 bifCache[partId] = result
             } else {
                 unavailableParts.insert(partId)
@@ -202,10 +216,16 @@ final class PlexThumbnailService {
         return URLSession(configuration: config, delegate: delegate, delegateQueue: nil)
     }
 
-    /// Clear cache for a specific part
+    /// Release the frames held for a part. Also drops any in-flight load, so a
+    /// download that finishes after this call doesn't re-fill the cache.
+    ///
+    /// Deliberately keeps `unavailableParts`: a part with no BIF on the server
+    /// still has none after a release, and re-arming it would re-issue both the
+    /// sd and hd requests every time the item is replayed.
     func clearCache(partId: Int) {
+        loadingTasks[partId]?.cancel()
+        loadingTasks[partId] = nil
         bifCache[partId] = nil
-        unavailableParts.remove(partId)
     }
 
     /// Clear all cached data

--- a/Rivulet/Views/Components/WhatsNewView.swift
+++ b/Rivulet/Views/Components/WhatsNewView.swift
@@ -150,6 +150,8 @@ struct WhatsNewView: View {
             "Subtitles now reappear when you seek onto a line that is already on screen, picture based subtitles with more than one element render in full, and external .sup subtitle files load",
             "Dolby Vision Profile 5 titles no longer play with a green or purple tint, and widescreen content encoded with non square pixels no longer appears squashed",
             "You can now set how far a single Left or Right press skips during playback, from 5 to 30 seconds, in Playback settings",
+            "Watching several episodes in a row no longer builds up memory from each one's scrubbing previews",
+            "Live TV with a large channel list no longer freezes the app while the lineup loads or refreshes",
         ]),
         ("1.0.4 (69)", [
             "New Content Filtering in Playback settings can mute strong language and skip scenes during playback, with per category controls and a quick toggle in the player",

--- a/Rivulet/Views/Player/UniversalPlayerViewModel.swift
+++ b/Rivulet/Views/Player/UniversalPlayerViewModel.swift
@@ -160,6 +160,12 @@ final class UniversalPlayerViewModel: ObservableObject {
     // MARK: - Chapter Thumbnails
     private var chapterThumbnails: [Int: Data] = [:]  // index → image data
 
+    /// Part whose BIF is currently held by PlexThumbnailService. Tracked so the
+    /// outgoing item's BIF can be released on teardown and across episode swaps —
+    /// a BIF holds every trickplay frame of the item, so a binge would otherwise
+    /// accumulate them for the process lifetime.
+    private var preloadedThumbnailPartId: Int?
+
     // MARK: - Skip Marker State
     @Published private(set) var activeMarker: PlexMarker?
     @Published private(set) var showSkipButton = false
@@ -2278,6 +2284,7 @@ final class UniversalPlayerViewModel: ObservableObject {
         subtitleClockSync.stop()
         clearReplayWindow()
         contentFilter.reset()
+        releaseThumbnailCache()
 
         // Clear the active playback route and content from the App Hang scope
         // (RIVULET-41) so a later hang off the player isn't tagged with a stale
@@ -2776,11 +2783,20 @@ final class UniversalPlayerViewModel: ObservableObject {
             return
         }
         // print("🖼️ Preloading BIF thumbnails for part \(partId)")
+        preloadedThumbnailPartId = partId
         PlexThumbnailService.shared.preloadBIF(
             partId: partId,
             serverURL: serverURL,
             authToken: authToken
         )
+    }
+
+    /// Drop the outgoing item's BIF. Safe to call when nothing is cached; a
+    /// later scrub re-fetches on demand.
+    private func releaseThumbnailCache() {
+        guard let partId = preloadedThumbnailPartId else { return }
+        preloadedThumbnailPartId = nil
+        PlexThumbnailService.shared.clearCache(partId: partId)
     }
 
     // MARK: - Track Selection
@@ -4396,6 +4412,9 @@ final class UniversalPlayerViewModel: ObservableObject {
         // schedules a fresh one for the new item if needed.
         insightsRecheckTask?.cancel()
         insightsRecheckTask = nil
+        // Release the outgoing episode's BIF; preloadThumbnails() loads the new
+        // one. Without this a binge retains every episode's trickplay frames.
+        releaseThumbnailCache()
 
         // Re-resolve the title logo for the new episode.
         fetchTitleLogoIfNeeded()


### PR DESCRIPTION
Two independent fixes, one commit each.

## 1. Trickplay thumbnails were never released

**Impact:** unbounded memory growth across a viewing session. Each BIF holds
every trickplay frame of an item (~270 JPEGs for a 45-minute episode), and
`clearCache(partId:)` / `clearAllCache()` had **no callers anywhere** — so a
15-episode session retained all 15. On tvOS that is a jetsam risk, not just
footprint.

Tracks the preloaded part and releases it in two places:

- `stopPlayback()` — normal teardown.
- `playNextEpisode()` — the one that matters. It swaps `metadata` in place and
  never calls `stopPlayback()`, so teardown alone would miss the binge case
  entirely. Sits beside the existing `insightsRecheckTask` cancel, which drops
  outgoing-item state for the same reason.

A later scrub re-fetches on demand.

## 2. Live TV channel merge ran on the main thread

**Impact:** UI freeze two seconds after launch for IPTV users with large
playlists — the merge and sort of every channel blocked the thread that drives
the focus engine, while the home screen was still loading.

`LiveTVDataStore` is `@MainActor`, and a `Task {}` created inside a `@MainActor`
method inherits that isolation, so the sort ran on main. With a large M3U that
is ~1.7M comparisons, falling through to Unicode string collation because most
playlists omit `tvg-chno`. `Task(priority: .background)` does not help —
priority does not change isolation.

The tell: the `await MainActor.run { self.channels = ... }` right after the sort
was a no-op, implying the body was assumed to be off-main.

`loadEPG` in the same file already solves this. This copies that pattern —
snapshot `providers`, use `Task.detached` — and the existing `MainActor.run`
becomes the single real main hop. Network fetches were already concurrent and
are unchanged.

## Testing

`xcodebuild build` and `xcodebuild test` both succeed (full suite);
`swiftlint lint --strict` reports 0 violations. No new warnings in either file.

**Not exercised on device.** Change 2 in particular is worth checking on real
hardware with a large playlist — the Simulator does not reflect tvOS
main-thread behaviour well.

## Review notes

- No changelog entry — did not want to guess the next build key in
  `WhatsNewView.swift`. #1 is arguably user-facing.
- #1 bounds growth per session but adds no LRU cap in `PlexThumbnailService`.
  Happy to put a hard ceiling there instead if you prefer.