### PR TITLE
Staged Menu back: return the page to its top row (#19)

### DIFF
--- a/Docs/superpowers/specs/2026-07-10-menu-back-navigation-design.md
+++ b/Docs/superpowers/specs/2026-07-10-menu-back-navigation-design.md
@@ -3,9 +3,26 @@
 Date: 2026-07-10
 Issues: #19 (Back button should scroll back up to top row), #192 (Back button on remote takes you all the way back to Home)
 
-## OUTCOME (2026-07-10) — read this first
+## SUPERSEDED (2026-07-27) — read this first
 
-**Shipped: #192 only. #19 abandoned as platform-blocked.**
+**#19 is no longer platform-blocked. Both stages ship.** Stage 1 is
+`MenuPressInterceptor`, which takes the press at `UIWindow.sendEvent(_:)` and offers it to
+the focused surface; `PlexHomeViewController` consumes it below the top row and declines at
+the top, so the system still performs its native sidebar reveal. Stage 3 is unchanged from
+what shipped for #192.
+
+The 2026-07-10 conclusion below was right about every seam it tested and wrong about the
+one it did not test. `sendEvent(_:)` sits earlier in the event pipeline than `pressesBegan`:
+the window sees the press before the `.sidebarAdaptable` shell consumes it, so returning
+early there withholds it from the system entirely. The dead-seam list is still accurate and
+still worth reading before anyone proposes a fourth approach — it is the reason the
+interceptor sits where it does rather than anywhere more obvious.
+
+Note the asymmetry that made this easy to miss: a `pressesBegan` swizzle **on `UIWindow`**
+was tested and does not see `.menu`, so the window looked ruled out as a class of hook. It
+was not; only that method on it was.
+
+## OUTCOME (2026-07-10) — historical, superseded above
 
 The staged design below assumed the app could intercept the Menu press that moves focus
 from a content grid into the sidebar. It cannot. Empirically confirmed on the tvOS 26

--- a/Rivulet/Views/Components/WhatsNewView.swift
+++ b/Rivulet/Views/Components/WhatsNewView.swift
@@ -141,6 +141,7 @@ struct WhatsNewView: View {
 
     static let changelogs: [(version: String, features: [String])] = [
         ("1.0.4 (70)", [ // confirm build number at release
+            "Pressing Menu now takes you back to the top of the page first, so you no longer lose your place jumping straight out to the sidebar",
             "Opening a movie or show now grows its poster proportionally instead of stretching it out of shape",
             "Settings rows now all use one title size and weight, so each page reads evenly from top to bottom",
             "Updated AetherEngine to 5.23.3. Fixes titles that never finished playing at the very end, resuming near the end of a movie getting stuck on Loading, Dolby Vision being dropped when you resume close to the end, and a crash after several minutes of playback on fast connections. Also: some MP4 movies that opened to a frozen frame now play and use less power, Dolby Vision titles streamed from a slow server no longer jump the scrubber backward or stall when you seek, the Atmos badge is now accurate, long Live TV sessions no longer slowly use up memory until the app closes, and leaving a Dolby Atmos title no longer leaves your receiver looping the last sound",

--- a/Rivulet/Views/Media/PlexHome/UIKit/PlexHomeViewController.swift
+++ b/Rivulet/Views/Media/PlexHome/UIKit/PlexHomeViewController.swift
@@ -4669,7 +4669,11 @@ extension PlexHomeViewController: UICollectionViewDelegate {
         // The staged Menu back has landed; stop routing focus to the top. A
         // directional move clears it too — if the top cell never took focus the
         // flag would otherwise latch and yank focus back on some later,
-        // unrelated update. Mirrors the two exits `needsInitialHeroFocus` has.
+        // unrelated update. `needsInitialHeroFocus` additionally requires the
+        // move to start INSIDE the collection, because it is armed at launch
+        // when focus can arrive from the sidebar. This flag is only ever armed
+        // by handleMenuBack(), which already requires focus inside the
+        // collection, so that conjunct would be dead weight here.
         if wantsTopFocus, nextSectionIndex == topSectionIndex || !context.focusHeading.isEmpty {
             wantsTopFocus = false
         }

--- a/Rivulet/Views/Media/PlexHome/UIKit/PlexHomeViewController.swift
+++ b/Rivulet/Views/Media/PlexHome/UIKit/PlexHomeViewController.swift
@@ -4666,8 +4666,13 @@ extension PlexHomeViewController: UICollectionViewDelegate {
         let kind: HomeSectionKind? = sectionsSnapshot.indices.contains(nextSectionIndex)
             ? sectionsSnapshot[nextSectionIndex].kind
             : nil
-        // The staged Menu back has landed; stop routing focus to the top.
-        if wantsTopFocus, nextSectionIndex == topSectionIndex { wantsTopFocus = false }
+        // The staged Menu back has landed; stop routing focus to the top. A
+        // directional move clears it too — if the top cell never took focus the
+        // flag would otherwise latch and yank focus back on some later,
+        // unrelated update. Mirrors the two exits `needsInitialHeroFocus` has.
+        if wantsTopFocus, nextSectionIndex == topSectionIndex || !context.focusHeading.isEmpty {
+            wantsTopFocus = false
+        }
         // Initial-hero routing ends once the hero has focus, or as soon as
         // the user makes a directional move WITHIN the page (never yank focus
         // mid-navigation). Directional entries from OUTSIDE (the sidebar)

--- a/Rivulet/Views/Media/PlexHome/UIKit/PlexHomeViewController.swift
+++ b/Rivulet/Views/Media/PlexHome/UIKit/PlexHomeViewController.swift
@@ -1227,6 +1227,10 @@ final class PlexHomeViewController: UIViewController {
         applyPendingPreviewRestoreIfNeeded()
         nudgeInitialHeroFocusIfNeeded()
         refreshOnReappearIfNeeded()
+        if let window = view.window {
+            MenuPressInterceptor.install(in: window)
+            MenuPressInterceptor.register(self)
+        }
     }
 
     /// Nonblocking stale-while-revalidate whenever the home surface comes back
@@ -1284,6 +1288,18 @@ final class PlexHomeViewController: UIViewController {
     private var heroSectionIndex: Int? {
         sectionsSnapshot.firstIndex(where: { $0.kind == .hero })
     }
+
+    /// The section a staged Menu back returns to. Every hero-bearing mode
+    /// (home, library, discover) tops out at the hero; Search has no hero, so
+    /// its first section is the top.
+    private var topSectionIndex: Int {
+        heroSectionIndex ?? 0
+    }
+
+    /// Set while a staged Menu back is pulling focus to the top section. Only
+    /// used by modes with no hero — hero modes reuse `needsInitialHeroFocus`
+    /// so focus lands on Play exactly as it does at launch.
+    private var wantsTopFocus = false
 
     /// Ask the engine to re-resolve focus while initial-hero routing is
     /// active. Called from viewDidAppear AND after snapshot applies — on cold
@@ -4237,6 +4253,11 @@ final class PlexHomeViewController: UIViewController {
            let heroCell = collectionView.cellForItem(at: IndexPath(item: 0, section: heroIndex)) {
             return [heroCell]
         }
+        // Staged Menu back on a heroless page (Search) — see returnToTopRow().
+        if wantsTopFocus,
+           let topCell = collectionView.cellForItem(at: IndexPath(item: 0, section: topSectionIndex)) {
+            return [topCell]
+        }
         return super.preferredFocusEnvironments
     }
 }
@@ -4645,6 +4666,8 @@ extension PlexHomeViewController: UICollectionViewDelegate {
         let kind: HomeSectionKind? = sectionsSnapshot.indices.contains(nextSectionIndex)
             ? sectionsSnapshot[nextSectionIndex].kind
             : nil
+        // The staged Menu back has landed; stop routing focus to the top.
+        if wantsTopFocus, nextSectionIndex == topSectionIndex { wantsTopFocus = false }
         // Initial-hero routing ends once the hero has focus, or as soon as
         // the user makes a directional move WITHIN the page (never yank focus
         // mid-navigation). Directional entries from OUTSIDE (the sidebar)
@@ -4747,14 +4770,76 @@ extension PlexHomeViewController: UICollectionViewDelegate {
         // `isScrollEnabled = false` hands us the vertical focus-scroll: the
         // engine no longer masks a nil section by scrolling on its own, so a
         // Down/Up move between orthogonal rows would otherwise fail to centre.
-        var v: UIView? = context.nextFocusedView
-        while let view = v {
-            if let cell = view as? UICollectionViewCell,
+        return sectionIndex(forFocusedView: context.nextFocusedView)
+    }
+
+    /// Walk a focused view's superview chain to its enclosing collection-view
+    /// cell and read that cell's section.
+    private func sectionIndex(forFocusedView view: UIView?) -> Int? {
+        var v: UIView? = view
+        while let current = v {
+            if let cell = current as? UICollectionViewCell,
                let ip = self.collectionView.indexPath(for: cell) {
                 return ip.section
             }
-            v = view.superview
+            v = current.superview
         }
         return nil
+    }
+}
+
+// MARK: - Staged Menu back (issue #19)
+
+extension PlexHomeViewController: MenuBackHandling {
+    /// Stage 1: a Menu press from below the top row snaps the page back to its
+    /// top row instead of opening the sidebar. At the top row this declines, so
+    /// the system performs its native sidebar reveal (stage 2), and from there
+    /// `TVSidebarView.onExitCommand` returns to Home (stage 3).
+    func handleMenuBack() -> Bool {
+        guard isViewLoaded, let window = view.window, window.isKeyWindow else { return false }
+        // Focus must be inside THIS page's collection. When a player, detail
+        // carousel, tile menu or Settings page is up, focus lives inside it —
+        // this page declines and Menu keeps its normal meaning there.
+        guard let focused = UIFocusSystem.focusSystem(for: collectionView)?.focusedItem as? UIView,
+              focused.isDescendant(of: collectionView) else { return false }
+        guard StagedMenuBack.shouldReturnToTop(
+            focusedSection: sectionIndex(forFocusedView: focused),
+            topSection: topSectionIndex
+        ) else { return false }
+
+        returnToTopRow()
+        return true
+    }
+
+    /// Snap to the top row and put focus there.
+    ///
+    /// The jump is deliberate. While the page is scrolled deep the top row's
+    /// cell has been recycled, so focus cannot be routed to a cell that does
+    /// not exist yet — and animating there first loses the race: the focus
+    /// engine re-resolves mid-flight, lands on whatever row is passing, and
+    /// scrolls that back into view (the page ends up one row higher instead of
+    /// at the top). Setting the offset and laying out first creates the cell,
+    /// so the focus request has somewhere to land.
+    private func returnToTopRow() {
+        // Cancel any in-flight focus-scroll so it can't animate back over us.
+        offsetLink?.invalidate()
+        offsetLink = nil
+        collectionView.contentOffset = CGPoint(x: 0, y: -collectionView.adjustedContentInset.top)
+        collectionView.layoutIfNeeded()
+
+        // Hero modes reuse the launch routing so focus lands on Play; Search
+        // has no hero, so `wantsTopFocus` aims at its first section instead.
+        if heroSectionIndex != nil {
+            needsInitialHeroFocus = true
+        } else {
+            wantsTopFocus = true
+        }
+        setNeedsFocusUpdate()
+        updateFocusIfNeeded()
+        // The hero's buttons live in a SwiftUI subview that may not be
+        // focusable until the next runloop turn; re-assert once it is.
+        DispatchQueue.main.async { [weak self] in
+            self?.nudgeInitialHeroFocusIfNeeded()
+        }
     }
 }

--- a/Rivulet/Views/Media/PlexHome/UIKit/PlexHomeViewController.swift
+++ b/Rivulet/Views/Media/PlexHome/UIKit/PlexHomeViewController.swift
@@ -1233,6 +1233,14 @@ final class PlexHomeViewController: UIViewController {
         }
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        // Stop taking Menu presses the moment the page leaves the screen, and
+        // keep the handler list from growing by one per page visited. A fresh
+        // appearance re-registers.
+        MenuPressInterceptor.resign(self)
+    }
+
     /// Nonblocking stale-while-revalidate whenever the home surface comes back
     /// on screen (tab switch back, player/preview dismissal): re-check the
     /// small Continue Watching hub in the background. The data store throttles

--- a/Rivulet/Views/TVNavigation/MenuPressInterceptor.swift
+++ b/Rivulet/Views/TVNavigation/MenuPressInterceptor.swift
@@ -90,6 +90,14 @@ enum MenuPressInterceptor {
         handlers.append(WeakHandler(value: handler))
     }
 
+    /// Drop a surface as it goes away. Only home is a cached controller; every
+    /// library, Discover and Search page builds a fresh one, so without this the
+    /// list grows by one entry per page visited. A stale entry would still
+    /// decline (it checks whether it owns focus), but it would be asked first.
+    static func resign(_ handler: any MenuBackHandling) {
+        handlers.removeAll { $0.value == nil || $0.value === handler }
+    }
+
     /// Offer the press to registered surfaces, most recently registered first.
     /// Each decides for itself whether it currently owns focus, so a surface
     /// sitting under a presented player or detail page declines.

--- a/Rivulet/Views/TVNavigation/MenuPressInterceptor.swift
+++ b/Rivulet/Views/TVNavigation/MenuPressInterceptor.swift
@@ -87,10 +87,6 @@ enum MenuPressInterceptor {
         handlers.append(WeakHandler(value: handler))
     }
 
-    static func resign(_ handler: any MenuBackHandling) {
-        handlers.removeAll { $0.value == nil || $0.value === handler }
-    }
-
     /// Offer the press to registered surfaces, most recently registered first.
     /// Each decides for itself whether it currently owns focus, so a surface
     /// sitting under a presented player or detail page declines.
@@ -121,6 +117,10 @@ enum MenuPressInterceptor {
                 return
             }
             let withhold = MainActor.assumeIsolated { () -> Bool in
+                // Withholding drops the whole event, so a non-Menu press
+                // batched into the same one goes with it. The remote delivers
+                // Menu on its own in practice, and there is no way to forward
+                // a partial UIPressesEvent.
                 let menuPresses = pressesEvent.allPresses.filter { $0.type == .menu }
                 guard !menuPresses.isEmpty else { return false }
                 return swallowState.shouldWithhold(

--- a/Rivulet/Views/TVNavigation/MenuPressInterceptor.swift
+++ b/Rivulet/Views/TVNavigation/MenuPressInterceptor.swift
@@ -31,7 +31,10 @@ struct MenuPressSwallowState {
     ///   - handle: asked once per press, on `.began`. True means consumed.
     /// - Returns: true when this event must be withheld from the system.
     mutating func shouldWithhold(began: Bool, finished: Bool, handle: () -> Bool) -> Bool {
-        if began {
+        // A second `.began` arriving before the first press ends must not
+        // re-ask the handler or overwrite the pending press — the press being
+        // swallowed owns the state until its own terminal phase.
+        if began, !isSwallowing {
             let consumed = handle()
             // A single event carrying both phases needs no follow-up swallow.
             isSwallowing = consumed && !finished

--- a/Rivulet/Views/TVNavigation/MenuPressInterceptor.swift
+++ b/Rivulet/Views/TVNavigation/MenuPressInterceptor.swift
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+// Copyright (C) 2025-2026 Bain Gurley
+
+//
+//  MenuPressInterceptor.swift
+//  Rivulet
+//
+
+import UIKit
+
+// MARK: - Handler
+
+/// A surface that wants first refusal on the remote's Menu press.
+@MainActor
+protocol MenuBackHandling: AnyObject {
+    /// Return true to consume the press; false to let it reach the system.
+    func handleMenuBack() -> Bool
+}
+
+// MARK: - Swallow state
+
+/// Pairs the Menu `.began` we withhold with its matching `.ended`, so the
+/// system never sees half a press. Pure logic, kept out of the swizzle so it
+/// can be tested directly.
+struct MenuPressSwallowState {
+    private(set) var isSwallowing = false
+
+    /// - Parameters:
+    ///   - began: the event carries a Menu press in the `.began` phase.
+    ///   - finished: the event carries a Menu press in `.ended` or `.cancelled`.
+    ///   - handle: asked once per press, on `.began`. True means consumed.
+    /// - Returns: true when this event must be withheld from the system.
+    mutating func shouldWithhold(began: Bool, finished: Bool, handle: () -> Bool) -> Bool {
+        if began {
+            let consumed = handle()
+            // A single event carrying both phases needs no follow-up swallow.
+            isSwallowing = consumed && !finished
+            return consumed
+        }
+        guard isSwallowing else { return false }
+        if finished { isSwallowing = false }
+        return true
+    }
+}
+
+// MARK: - Policy
+
+/// Staged Menu ("back") navigation, stage 1 (issue #19): a Menu press from
+/// below the top row returns the page to its top row instead of opening the
+/// sidebar.
+enum StagedMenuBack {
+    /// True when the press should snap the page back to its top row rather than
+    /// pass through to the system's sidebar reveal.
+    static func shouldReturnToTop(focusedSection: Int?, topSection: Int) -> Bool {
+        guard let focusedSection else { return false }
+        return focusedSection > topSection
+    }
+}
+
+// MARK: - Interceptor
+
+/// Gives the app first refusal on the Menu button.
+///
+/// While focus is in the content area, a Menu press is **not** delivered
+/// through the responder chain: there is no `pressesBegan` on the window or the
+/// focused view controller, no `shouldUpdateFocus`, no `.onExitCommand`, and no
+/// menu-press gesture recognizer anywhere in the hierarchy to intercept — the
+/// `.sidebarAdaptable` sidebar reveal happens above all of it. The one layer
+/// that sees the press first is `UIWindow.sendEvent(_:)`; returning early there
+/// withholds it from the system entirely. (Measured on tvOS 26.5; once focus is
+/// in the sidebar the press does reach the responder chain and `.onExitCommand`,
+/// which is how stage 3 works — see `TVSidebarView.onExitCommand`.)
+@MainActor
+enum MenuPressInterceptor {
+    private static var swizzledClasses = Set<ObjectIdentifier>()
+    private static var handlers: [WeakHandler] = []
+    private static var swallowState = MenuPressSwallowState()
+
+    private struct WeakHandler {
+        weak var value: (any MenuBackHandling)?
+    }
+
+    // MARK: Registration
+
+    static func register(_ handler: any MenuBackHandling) {
+        handlers.removeAll { $0.value == nil || $0.value === handler }
+        handlers.append(WeakHandler(value: handler))
+    }
+
+    static func resign(_ handler: any MenuBackHandling) {
+        handlers.removeAll { $0.value == nil || $0.value === handler }
+    }
+
+    /// Offer the press to registered surfaces, most recently registered first.
+    /// Each decides for itself whether it currently owns focus, so a surface
+    /// sitting under a presented player or detail page declines.
+    private static func offerToHandlers() -> Bool {
+        for entry in handlers.reversed() {
+            if entry.value?.handleMenuBack() == true { return true }
+        }
+        return false
+    }
+
+    // MARK: Install
+
+    /// Swizzles `sendEvent(_:)` on the window's own class, once per class.
+    /// Matches the approach already used for the sidebar focus guard: replacing
+    /// on the concrete subclass leaves plain `UIWindow` untouched.
+    static func install(in window: UIWindow) {
+        let cls: AnyClass = type(of: window)
+        guard swizzledClasses.insert(ObjectIdentifier(cls)).inserted else { return }
+
+        let selector = #selector(UIWindow.sendEvent(_:))
+        let originalIMP = class_getMethodImplementation(cls, selector)
+        typealias OriginalFunc = @convention(c) (AnyObject, Selector, UIEvent) -> Void
+        let originalFunc = unsafeBitCast(originalIMP, to: OriginalFunc.self)
+
+        let block: @convention(block) (AnyObject, UIEvent) -> Void = { obj, event in
+            guard let pressesEvent = event as? UIPressesEvent else {
+                originalFunc(obj, selector, event)
+                return
+            }
+            let withhold = MainActor.assumeIsolated { () -> Bool in
+                let menuPresses = pressesEvent.allPresses.filter { $0.type == .menu }
+                guard !menuPresses.isEmpty else { return false }
+                return swallowState.shouldWithhold(
+                    began: menuPresses.contains { $0.phase == .began },
+                    finished: menuPresses.contains { $0.phase == .ended || $0.phase == .cancelled },
+                    handle: offerToHandlers
+                )
+            }
+            guard !withhold else { return }
+            originalFunc(obj, selector, event)
+        }
+
+        let imp = imp_implementationWithBlock(unsafeBitCast(block, to: AnyObject.self))
+        let method = class_getInstanceMethod(UIWindow.self, selector)!
+        class_replaceMethod(cls, selector, imp, method_getTypeEncoding(method)!)
+    }
+}

--- a/RivuletTests/Unit/StagedMenuBackTests.swift
+++ b/RivuletTests/Unit/StagedMenuBackTests.swift
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+// Copyright (C) 2025-2026 Bain Gurley
+
+//
+//  StagedMenuBackTests.swift
+//  RivuletTests
+//
+
+import XCTest
+@testable import Rivulet
+
+// MARK: - Stage-1 policy
+
+final class StagedMenuBackPolicyTests: XCTestCase {
+
+    func testReturnsToTopFromBelowTheTopSection() {
+        XCTAssertTrue(StagedMenuBack.shouldReturnToTop(focusedSection: 4, topSection: 0))
+    }
+
+    func testPassesThroughAtTheTopSection() {
+        XCTAssertFalse(StagedMenuBack.shouldReturnToTop(focusedSection: 0, topSection: 0))
+    }
+
+    /// Search has no hero, so its top section is 0; hero pages top out at the
+    /// hero's own index.
+    func testHonoursANonZeroTopSection() {
+        XCTAssertFalse(StagedMenuBack.shouldReturnToTop(focusedSection: 2, topSection: 2))
+        XCTAssertTrue(StagedMenuBack.shouldReturnToTop(focusedSection: 3, topSection: 2))
+    }
+
+    /// A section above the top (shouldn't happen, but must not consume the
+    /// press and strand the user with no way back).
+    func testPassesThroughAboveTheTopSection() {
+        XCTAssertFalse(StagedMenuBack.shouldReturnToTop(focusedSection: 1, topSection: 2))
+    }
+
+    func testPassesThroughWhenNoSectionOwnsFocus() {
+        XCTAssertFalse(StagedMenuBack.shouldReturnToTop(focusedSection: nil, topSection: 0))
+    }
+}
+
+// MARK: - Press-phase swallow state
+
+final class MenuPressSwallowStateTests: XCTestCase {
+
+    /// A consumed press must withhold both its `.began` and its `.ended`, or
+    /// the system sees half a press.
+    func testWithholdsBothPhasesOfAConsumedPress() {
+        var state = MenuPressSwallowState()
+        XCTAssertTrue(state.shouldWithhold(began: true, finished: false, handle: { true }))
+        XCTAssertTrue(state.isSwallowing)
+        XCTAssertTrue(state.shouldWithhold(began: false, finished: true, handle: { true }))
+        XCTAssertFalse(state.isSwallowing)
+    }
+
+    func testForwardsBothPhasesOfADeclinedPress() {
+        var state = MenuPressSwallowState()
+        XCTAssertFalse(state.shouldWithhold(began: true, finished: false, handle: { false }))
+        XCTAssertFalse(state.isSwallowing)
+        XCTAssertFalse(state.shouldWithhold(began: false, finished: true, handle: { false }))
+    }
+
+    /// The handler is consulted once per press — on `.began` only. Asking again
+    /// on `.ended` would run the scroll twice.
+    func testHandlerIsAskedOnlyOnBegan() {
+        var state = MenuPressSwallowState()
+        var asked = 0
+        _ = state.shouldWithhold(began: true, finished: false, handle: { asked += 1; return true })
+        _ = state.shouldWithhold(began: false, finished: false, handle: { asked += 1; return true })
+        _ = state.shouldWithhold(began: false, finished: true, handle: { asked += 1; return true })
+        XCTAssertEqual(asked, 1)
+    }
+
+    /// Intermediate phases between began and ended stay withheld.
+    func testWithholdsIntermediatePhases() {
+        var state = MenuPressSwallowState()
+        _ = state.shouldWithhold(began: true, finished: false, handle: { true })
+        XCTAssertTrue(state.shouldWithhold(began: false, finished: false, handle: { true }))
+        XCTAssertTrue(state.isSwallowing)
+    }
+
+    /// A cancelled press ends the swallow just like `.ended` — otherwise the
+    /// state latches and every later Menu press is eaten.
+    func testCancelledPressClearsTheSwallow() {
+        var state = MenuPressSwallowState()
+        _ = state.shouldWithhold(began: true, finished: false, handle: { true })
+        _ = state.shouldWithhold(began: false, finished: true, handle: { true })
+        XCTAssertFalse(state.isSwallowing)
+        // Next press is free to be declined and forwarded.
+        XCTAssertFalse(state.shouldWithhold(began: true, finished: false, handle: { false }))
+    }
+
+    /// A single event carrying both phases must not latch the swallow on.
+    func testSingleEventCarryingBothPhasesDoesNotLatch() {
+        var state = MenuPressSwallowState()
+        XCTAssertTrue(state.shouldWithhold(began: true, finished: true, handle: { true }))
+        XCTAssertFalse(state.isSwallowing)
+    }
+
+    /// A stray `.ended` with no preceding consumed `.began` must be forwarded,
+    /// not eaten.
+    func testStrayEndedIsForwarded() {
+        var state = MenuPressSwallowState()
+        XCTAssertFalse(state.shouldWithhold(began: false, finished: true, handle: { true }))
+    }
+}

--- a/RivuletTests/Unit/StagedMenuBackTests.swift
+++ b/RivuletTests/Unit/StagedMenuBackTests.swift
@@ -103,4 +103,30 @@ final class MenuPressSwallowStateTests: XCTestCase {
         var state = MenuPressSwallowState()
         XCTAssertFalse(state.shouldWithhold(began: false, finished: true, handle: { true }))
     }
+
+    /// A second `.began` arriving before the first press ends must not re-ask
+    /// the handler or take over the pending press's tracking — the press being
+    /// swallowed owns the state until its own terminal phase.
+    func testOverlappingBeganDoesNotReAskOrRetrack() {
+        var state = MenuPressSwallowState()
+        var asked = 0
+        XCTAssertTrue(state.shouldWithhold(began: true, finished: false, handle: { asked += 1; return true }))
+        // Second press begins while the first is still down.
+        XCTAssertTrue(state.shouldWithhold(began: true, finished: false, handle: { asked += 1; return true }))
+        XCTAssertEqual(asked, 1)
+        XCTAssertTrue(state.isSwallowing)
+        // The original press's terminal phase still ends the swallow.
+        XCTAssertTrue(state.shouldWithhold(began: false, finished: true, handle: { true }))
+        XCTAssertFalse(state.isSwallowing)
+    }
+
+    /// The declined case must stay re-askable: no swallow is pending, so a
+    /// following `.began` is a fresh decision.
+    func testBeganAfterADeclinedPressIsAskedAgain() {
+        var state = MenuPressSwallowState()
+        var asked = 0
+        XCTAssertFalse(state.shouldWithhold(began: true, finished: false, handle: { asked += 1; return false }))
+        XCTAssertFalse(state.shouldWithhold(began: true, finished: false, handle: { asked += 1; return false }))
+        XCTAssertEqual(asked, 2)
+    }
 }


### PR DESCRIPTION
Closes #19.

## The issue

Scroll down a few rows on Home (or a library) and the only way back to the top is to scroll all the way up. Pressing Menu jumps straight out to the sidebar instead, so you lose your place. Plex resets to the first item of the first row first, which is what #19 asks for.

This was previously investigated and recorded as platform-blocked. That conclusion was wrong, though its individual findings were all correct — see below.

## The solution

`UIWindow.sendEvent(_:)` receives the press before gesture recognizers and before the responder chain. Returning early there withholds it from the system entirely.

`MenuPressInterceptor` swizzles that method — the same technique already used for the sidebar focus guard in `TVSidebarView` — and offers the press to registered surfaces. Each surface decides for itself whether it currently owns focus, so anything with a player, detail page or Settings on top declines and Menu keeps its normal meaning there.

`PlexHomeViewController` conforms to `MenuBackHandling`: below the top row it consumes the press and returns the page to its top row; at the top row it declines and the press passes through untouched.

## Screencap 
Go down a few rows, click Menu once to return to hero, click Menu again to open sidebar

https://github.com/user-attachments/assets/68b4515c-d438-4fd1-ab1f-7097dc15344e


## Behavior

| Where focus is | Menu does |
|---|---|
| Below the top row on Home | Returns to the top row, focus on the hero's Play. Sidebar stays shut. |
| Below the top row in a library | Same — the surface is mode-agnostic |
| Below the top row on Discover | Same |
| Below the top row on Search (no hero) | Returns to the first section |
| On the hero / top row | Passes through; the system reveals the sidebar |
| In the sidebar, not on Home | Existing behavior: selects Home (#192) |
| In the sidebar, on Home | Unchanged |
| Detail page open | Declines; the detail dismisses as before |
| Player, tile menu, Settings | Declines; unchanged |

So from deep in a page it takes three presses to walk out: top row, then sidebar, then Home.

## Testing

- 12 unit tests covering the stage-1 policy and the press-phase swallow state machine (pairing the withheld `.began` with its `.ended` so the system never sees half a press)
- Full suite passes; SwiftLint clean
- Verified in the tvOS 26.5 simulator against a real Plex library: deep on Home, deep in a library, at the top row, and with a detail page open

## Why it looked impossible

While focus is in the content area, a Menu press never reaches the responder chain. Measured on tvOS 26.5, none of these ever fire for it:

- `pressesBegan` on the content view controller
- `pressesBegan` on the `UIWindow`
- `shouldUpdateFocus(in:)` on the content collection view
- SwiftUI `.onExitCommand`
- any menu-press `UIGestureRecognizer` — a census of the whole hierarchy finds exactly one, and it belongs to `.onExitCommand`, not the sidebar

The `.sidebarAdaptable` sidebar reveal happens above all of that. Every seam checked previously sits *below* the one layer that does see the press first.

## Not covered

- Search mode is implemented but was not exercised in the simulator
- Simulator only so far — this is focus and remote-input behavior, which the simulator does not fully mimic, so it wants a run on an Apple TV before merging
- The separate launch-focus flash (sidebar briefly focused before the hero) is pre-existing on main and untouched here
- The `onExitCommand(perform: nil)` change that would restore exit-to-Home-Screen at the top level is deliberately left out — it is a separate behavior change from this issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
