### PR TITLE
Below-fold info cards

### DIFF
--- a/Rivulet/Views/Media/MediaDetail/UIKit/BelowFoldCollectionView.swift
+++ b/Rivulet/Views/Media/MediaDetail/UIKit/BelowFoldCollectionView.swift
@@ -244,8 +244,12 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
             case .related:
                 // Home-identical shelf: one full-width ShelfRowCell hosting
                 // the posters (margin 40, symmetric peeks, pitch landings).
+                // As the primary row, lift the section by its own header (+ the
+                // section's 8pt pad) so the 40pt peek strip is POSTER, like the
+                // episodes row — the "Related" title rides just above it.
+                let relatedLift = ShelfRowCell.headerHeight + 8
                 return self.homeShelfHostSection(
-                    topInset: isPrimary ? peek : 0,
+                    topInset: isPrimary ? max(0, peek - relatedLift) : 0,
                     sectionBottomInset: isPrimary ? 36 : 56
                 )
             case .cast:

--- a/Rivulet/Views/Media/MediaDetail/UIKit/BelowFoldCollectionView.swift
+++ b/Rivulet/Views/Media/MediaDetail/UIKit/BelowFoldCollectionView.swift
@@ -85,6 +85,9 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
     /// Selecting the About cards opens the matching popup (synopsis / advisory).
     var onSelectSynopsis: ((MediaItemDetail) -> Void)?
     var onSelectAdvisory: ((ContentAdvisory) -> Void)?
+    /// Selecting an Information / Languages / Accessibility card opens that
+    /// section in full (title + every row).
+    var onSelectInfoColumn: ((DetailInfoSection) -> Void)?
 
     /// Which sub-target of the focused episode card is focused (thumb vs
     /// description). Set from the cell's focus reporting.
@@ -241,9 +244,7 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
             case .related:
                 // Home-identical shelf: one full-width ShelfRowCell hosting
                 // the posters (margin 40, symmetric peeks, pitch landings).
-                self.relatedHeaderVisible = !isPrimary
                 return self.homeShelfHostSection(
-                    header: !isPrimary,
                     topInset: isPrimary ? peek : 0,
                     sectionBottomInset: isPrimary ? 36 : 56
                 )
@@ -256,10 +257,10 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
                     header: true
                 )
             case .about: return self.fullWidthSection(height: 370)
-            case .info:  return self.fullWidthSection(height: 460, band: true)
+            // 504 = the old 460 plus the 44pt of padding the info cards add.
+            case .info:  return self.fullWidthSection(height: 504)
             }
         }
-        layout.register(InfoBandDecorationView.self, forDecorationViewOfKind: InfoBandDecorationView.kind)
         return layout
     }
 
@@ -268,21 +269,19 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
     /// with the home shelf's exact geometry and landings. The item spans the
     /// whole (panel + overshoot) collection width; panel alignment happens
     /// inside the cell via panelOvershoot.
-    private func homeShelfHostSection(header: Bool,
-                                      topInset: CGFloat = 0,
+    private func homeShelfHostSection(topInset: CGFloat = 0,
                                       sectionBottomInset: CGFloat = 56) -> NSCollectionLayoutSection {
         // The ShelfRowCell draws its own header (self-aligned with the tiles),
         // so there's NO supplementary header — just one full-width item tall
-        // enough for the optional header + the row.
-        let headerH: CGFloat = header ? 44 : 0
-        let rowHeight = headerH + MediaRowMetrics.posterHeight + MediaRowMetrics.focusGrowthPadding
+        // enough for the header + the row.
+        let rowHeight = ShelfRowCell.headerHeight + MediaRowMetrics.posterHeight + MediaRowMetrics.focusGrowthPadding
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                               heightDimension: .absolute(rowHeight))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: itemSize, subitems: [item])
         let section = NSCollectionLayoutSection(group: group)
         section.contentInsets = .init(
-            top: (header ? 8 : 0) + topInset,
+            top: 8 + topInset,
             leading: 0,
             bottom: sectionBottomInset,
             trailing: 0
@@ -290,9 +289,9 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
         return section
     }
 
-    /// A single full-width block (About / Info columns) — no orthogonal scroll,
+    /// A single full-width block (About / Info cards) — no orthogonal scroll,
     /// left/right gutters matching the rails.
-    private func fullWidthSection(height: CGFloat, band: Bool = false) -> NSCollectionLayoutSection {
+    private func fullWidthSection(height: CGFloat) -> NSCollectionLayoutSection {
         let item = NSCollectionLayoutItem(layoutSize: .init(
             widthDimension: .fractionalWidth(1), heightDimension: .absolute(height)))
         let group = NSCollectionLayoutGroup.horizontal(
@@ -300,11 +299,6 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
             subitems: [item])
         let section = NSCollectionLayoutSection(group: group)
         section.contentInsets = .init(top: 24, leading: Self.rowLeading, bottom: 56, trailing: Self.rowTrailing)
-        if band {
-            // Full-width darkened band behind the section (spans the section rect,
-            // edge to edge — the columns stay inset via contentInsets).
-            section.decorationItems = [.background(elementKind: InfoBandDecorationView.kind)]
-        }
         return section
     }
 
@@ -418,7 +412,7 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
                 // below-fold's state-dependent translation), and draw the
                 // header in-cell so it aligns with the tiles.
                 cell.screenAlignsLeading = true
-                cell.headerTitle = self.relatedHeaderVisible ? "Related" : nil
+                cell.headerTitle = "Related"
                 cell.configure(
                     kind: .poster,
                     realCount: items.count,
@@ -440,6 +434,9 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
                 return cell
             case .info:
                 let cell = cv.dequeueReusableCell(withReuseIdentifier: InfoColumnsCollectionCell.reuseID, for: indexPath) as! InfoColumnsCollectionCell
+                cell.onSelectColumn = { [weak self] section in
+                    self?.onSelectInfoColumn?(section)
+                }
                 if let d = self.detail { cell.configure(detail: d) }
                 return cell
             }
@@ -586,9 +583,6 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
     private var cachedRelated: [BelowFoldItem] = []
     /// Ordered Related items backing the shelf (index == shelf tile index).
     private var relatedItems: [MediaItem] = []
-    /// Whether the Related row currently draws its in-cell header (false when
-    /// Related is the primary/first section, matching the old `!isPrimary`).
-    private var relatedHeaderVisible = true
     private var cachedCastOrder: [(String, BelowFoldItem)] = []
 
     private func applySnapshot() {

--- a/Rivulet/Views/Media/MediaDetail/UIKit/Cells/AboutInfoCells.swift
+++ b/Rivulet/Views/Media/MediaDetail/UIKit/Cells/AboutInfoCells.swift
@@ -283,7 +283,18 @@ final class InfoColumnsView: UIView {
     /// nil keeps them inert (the episode detail page, which scrolls normally
     /// and has nothing to open).
     var onSelectColumn: ((DetailInfoSection) -> Void)? {
-        didSet { columns.forEach { $0.card.selectable = onSelectColumn != nil } }
+        didSet { updateSelectability() }
+    }
+
+    /// A card is a focus stop only when there IS a handler AND it has rows to
+    /// show — an item with no year / runtime / rating / genres / studio would
+    /// otherwise leave a focusable "Information" card that opens a popup
+    /// containing nothing but its title.
+    private func updateSelectability() {
+        let enabled = onSelectColumn != nil
+        for column in columns {
+            column.card.selectable = enabled && !column.section.rows.isEmpty
+        }
     }
 
     override init(frame: CGRect) {
@@ -369,6 +380,7 @@ final class InfoColumnsView: UIView {
             to: columns[0])
         apply(.init(title: "Languages", rows: langs), cardRows: langs, to: columns[1])
         apply(.init(title: "Accessibility", rows: access), cardRows: access, to: columns[2])
+        updateSelectability()
     }
 
     /// The card renders `cardRows`; `section` is what a Select hands to the popup.

--- a/Rivulet/Views/Media/MediaDetail/UIKit/Cells/AboutInfoCells.swift
+++ b/Rivulet/Views/Media/MediaDetail/UIKit/Cells/AboutInfoCells.swift
@@ -29,14 +29,14 @@ final class AboutCollectionCell: UICollectionViewCell {
     private let header = sectionHeaderLabel("About")
     // Both cards are focusable controls: select the synopsis → description popup;
     // select the advisory → content-rating popup.
-    private let leftCard = AboutCardControl()
+    private let leftCard = DetailCardControl()
     private let titleLabel = UILabel()
     private let genresLabel = UILabel()
     private let synopsisLabel = UILabel()
 
     // Right card = Common Sense Media advisory (inline: age + seal + one-liner;
     // full topic dots + paragraph live in the popup), content-rating fallback.
-    private let rightCard = AboutCardControl()
+    private let rightCard = DetailCardControl()
 
     /// Set by the cell provider; the cell forwards the current data on select.
     var onSelectSynopsis: ((MediaItemDetail) -> Void)?
@@ -214,11 +214,19 @@ final class AboutCollectionCell: UICollectionViewCell {
         leftCard.selectable = !(detail.item.overview ?? "").isEmpty
         rightCard.selectable = advisory?.hasRichDetail ?? false
     }
-    // Focus lives on the two cards (AboutCardControl), not the cell itself.
+    // Focus lives on the two cards (DetailCardControl), not the cell itself.
     override var canBecomeFocused: Bool { false }
 }
 
 // MARK: - Information / Languages / Accessibility columns
+
+/// One labelled section of the detail's info block. Travels from the card that
+/// was selected up to the popup that renders it, so the callback chain carries a
+/// named type rather than an anonymous title/rows tuple.
+struct DetailInfoSection {
+    let title: String
+    let rows: [(String, String)]
+}
 
 final class InfoColumnsCollectionCell: UICollectionViewCell {
     static let reuseID = "InfoColumnsCollectionCell"
@@ -241,35 +249,62 @@ final class InfoColumnsCollectionCell: UICollectionViewCell {
 
     func configure(detail: MediaItemDetail) { columns.configure(detail: detail) }
 
-    override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
-        let focused = context.nextFocusedView === self
-        coordinator.addCoordinatedAnimations { [weak self] in
-            self?.contentView.backgroundColor = UIColor(white: 1, alpha: focused ? 0.05 : 0)
-        }
+    /// Select on a card → open that section in full. Also what makes the cards
+    /// focusable, so the focus-driven below-fold can reach them.
+    var onSelectColumn: ((DetailInfoSection) -> Void)? {
+        get { columns.onSelectColumn }
+        set { columns.onSelectColumn = newValue }
     }
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        contentView.backgroundColor = .clear
-    }
+
+    // Focus lives on the three cards (DetailCardControl), not the cell itself.
+    override var canBecomeFocused: Bool { false }
 }
 
 /// Standalone Information / Languages / Accessibility columns. Reused by the
 /// carousel below-fold cell above AND the episode detail page's below-fold.
 final class InfoColumnsView: UIView {
-    private let information = InfoColumnView()
-    private let languages = InfoColumnView()
-    private let accessibility = InfoColumnView()
+
+    /// One column: its card, the view inside it, and the section it last
+    /// rendered. Bundling these keeps the card, its content, and its Select
+    /// payload from drifting out of step — they used to be three arrays held
+    /// together by index.
+    private final class Column {
+        let card = DetailCardControl()
+        let view = InfoColumnView()
+        var section = DetailInfoSection(title: "", rows: [])
+    }
+
+    private let columns = [Column(), Column(), Column()]
     private let row = UIStackView()
+
+    /// Select on a card → open that section in full. A card's own copy trims
+    /// long values to stay scannable, so the popup is where the complete list
+    /// lives. Setting this makes the cards focusable AND selectable; leaving it
+    /// nil keeps them inert (the episode detail page, which scrolls normally
+    /// and has nothing to open).
+    var onSelectColumn: ((DetailInfoSection) -> Void)? {
+        didSet { columns.forEach { $0.card.selectable = onSelectColumn != nil } }
+    }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
         row.translatesAutoresizingMaskIntoConstraints = false
         row.axis = .horizontal
         row.distribution = .fillEqually
-        row.alignment = .top
-        row.spacing = 48
+        // .fill (not .top) so the three cards are equal height however far their
+        // text wraps — ragged card bottoms read as broken.
+        row.alignment = .fill
+        row.spacing = 24
         addSubview(row)
-        [information, languages, accessibility].forEach { row.addArrangedSubview($0) }
+        for column in columns {
+            column.card.selectable = false   // opt-in via onSelectColumn
+            column.card.onSelect = { [weak self, weak column] in
+                guard let column else { return }
+                self?.onSelectColumn?(column.section)
+            }
+            column.card.embed(column.view)
+            row.addArrangedSubview(column.card)
+        }
         NSLayoutConstraint.activate([
             row.topAnchor.constraint(equalTo: topAnchor),
             row.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -281,14 +316,26 @@ final class InfoColumnsView: UIView {
     required init?(coder: NSCoder) { fatalError() }
 
     func configure(detail: MediaItemDetail) {
-        // Information
-        var info: [(String, String)] = []
-        if let y = detail.item.year { info.append(("Released", "\(y)")) }
-        if let runtime = detail.item.runtime, runtime > 0 { info.append(("Run Time", Self.runtime(runtime))) }
-        if let r = detail.contentRating, !r.isEmpty { info.append(("Rated", r)) }
-        if !detail.genres.isEmpty { info.append(("Genres", detail.genres.prefix(4).joined(separator: ", "))) }
-        if !detail.studios.isEmpty { info.append(("Studio", detail.studios.prefix(2).joined(separator: ", "))) }
-        information.configure(title: "Information", rows: info)
+        // Information. `card` is the trimmed value shown on the card itself,
+        // `full` the untrimmed one the popup gets. Built once as triples so a
+        // new row can't be added to one and forgotten in the other.
+        var information: [(label: String, card: String, full: String)] = []
+        if let y = detail.item.year { information.append(("Released", "\(y)", "\(y)")) }
+        if let runtime = detail.item.runtime, runtime > 0 {
+            let text = Self.runtime(runtime)
+            information.append(("Run Time", text, text))
+        }
+        if let r = detail.contentRating, !r.isEmpty { information.append(("Rated", r, r)) }
+        if !detail.genres.isEmpty {
+            information.append(("Genres",
+                                detail.genres.prefix(4).joined(separator: ", "),
+                                detail.genres.joined(separator: ", ")))
+        }
+        if !detail.studios.isEmpty {
+            information.append(("Studio",
+                                detail.studios.prefix(2).joined(separator: ", "),
+                                detail.studios.joined(separator: ", ")))
+        }
 
         // Languages — from the first media source's tracks.
         let source = detail.mediaSources.first
@@ -305,7 +352,6 @@ final class InfoColumnsView: UIView {
             if !names.isEmpty { langs.append(("Subtitles", names.joined(separator: ", "))) }
         }
         if langs.isEmpty { langs.append(("Audio", "Unknown")) }
-        languages.configure(title: "Languages", rows: langs)
 
         // Accessibility — SDH / AD presence from the tracks.
         var access: [(String, String)] = []
@@ -316,7 +362,21 @@ final class InfoColumnsView: UIView {
         if hasSDH { access.append(("SDH", "Subtitles for the deaf and hard of hearing are available.")) }
         if hasAD { access.append(("AD", "Audio descriptions are available.")) }
         if access.isEmpty { access.append(("", "No accessibility features detected.")) }
-        accessibility.configure(title: "Accessibility", rows: access)
+
+        apply(
+            .init(title: "Information", rows: information.map { ($0.label, $0.full) }),
+            cardRows: information.map { ($0.label, $0.card) },
+            to: columns[0])
+        apply(.init(title: "Languages", rows: langs), cardRows: langs, to: columns[1])
+        apply(.init(title: "Accessibility", rows: access), cardRows: access, to: columns[2])
+    }
+
+    /// The card renders `cardRows`; `section` is what a Select hands to the popup.
+    private func apply(_ section: DetailInfoSection,
+                       cardRows: [(String, String)],
+                       to column: Column) {
+        column.section = section
+        column.view.configure(title: section.title, rows: cardRows)
     }
 
     private func uniqueOrdered(_ values: [String]) -> [String] {
@@ -407,26 +467,19 @@ private func sectionHeaderLabel(_ text: String) -> UILabel {
     return l
 }
 
-/// Full-width darkened band behind the Information / Languages / Accessibility
-/// area. Added as a SECTION BACKGROUND decoration so it spans edge-to-edge
-/// (the full section rect) even though the columns themselves are inset.
-final class InfoBandDecorationView: UICollectionReusableView {
-    static let kind = "infoBand"
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        backgroundColor = UIColor(white: 0, alpha: 0.28)
-    }
-    @available(*, unavailable)
-    required init?(coder: NSCoder) { fatalError() }
-}
+// MARK: - Focusable detail card
 
-// MARK: - Focusable About card
+/// A focusable detail card (About synopsis / advisory, the info columns).
+/// Selecting it opens the matching popup. Focus appearance = subtle brighten +
+/// scale (matches the glass style).
+final class DetailCardControl: UIControl {
+    /// Content inset — the card owns its own padding so every surface using one
+    /// gets the same, rather than restating four numbers per call site.
+    static let contentInsets = UIEdgeInsets(top: 22, left: 24, bottom: 22, right: 24)
 
-/// A focusable About card (synopsis or advisory). Selecting it opens the matching
-/// popup. Focus appearance = subtle brighten + scale (matches the glass style).
-final class AboutCardControl: UIControl {
     var onSelect: (() -> Void)?
-    /// Gates focus/selection — e.g. the advisory card only when CSM is present.
+    /// Gates focus AND selection: a card with nothing to open is skipped by the
+    /// focus engine rather than becoming a dead-end focus target.
     var selectable: Bool = true {
         didSet { if selectable != oldValue { setNeedsFocusUpdate() } }
     }
@@ -441,6 +494,19 @@ final class AboutCardControl: UIControl {
     }
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError() }
+
+    /// Pin a content view inside the card's standard padding.
+    func embed(_ view: UIView) {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(view)
+        let inset = Self.contentInsets
+        NSLayoutConstraint.activate([
+            view.topAnchor.constraint(equalTo: topAnchor, constant: inset.top),
+            view.leadingAnchor.constraint(equalTo: leadingAnchor, constant: inset.left),
+            view.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -inset.right),
+            view.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -inset.bottom),
+        ])
+    }
 
     @objc private func fire() { onSelect?() }
 

--- a/Rivulet/Views/Media/MediaDetail/UIKit/Cells/EpisodeCell.swift
+++ b/Rivulet/Views/Media/MediaDetail/UIKit/Cells/EpisodeCell.swift
@@ -46,7 +46,7 @@ final class EpisodeThumbCardView: TVCardView {
 
     // Consume the Select press in BOTH began/ended so the focused card owns the
     // press cycle — otherwise pressesEnded(.select) is not reliably delivered
-    // (mirrors AboutCardControl).
+    // (mirrors DetailCardControl).
     // TVCardView cancels the Select press internally between pressesBegan and
     // pressesEnded (the Ended becomes pressesCancelled), so an Ended-based
     // handler never runs. Fire onSelect on pressesBegan — the only event that is
@@ -82,7 +82,7 @@ final class EpisodeDescriptionView: UIView {
     }
 
     // Consume the Select press in BOTH began/ended so the focused block owns the
-    // press cycle (mirrors AboutCardControl) — required for reliable delivery.
+    // press cycle (mirrors DetailCardControl) — required for reliable delivery.
     override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
         if presses.contains(where: { $0.type == .select }) { return }
         super.pressesBegan(presses, with: event)

--- a/Rivulet/Views/Media/MediaDetail/UIKit/ExpandedDetailContainerView.swift
+++ b/Rivulet/Views/Media/MediaDetail/UIKit/ExpandedDetailContainerView.swift
@@ -58,6 +58,7 @@ final class ExpandedDetailContainerView: UIView {
     /// Forwarded up to the host VC to present the About popups.
     var onSelectSynopsis: ((MediaItemDetail) -> Void)?
     var onSelectAdvisory: ((ContentAdvisory) -> Void)?
+    var onSelectInfoColumn: ((DetailInfoSection) -> Void)?
 
     private(set) var maxScrollOffset: CGFloat = 0
 
@@ -385,6 +386,9 @@ final class ExpandedDetailContainerView: UIView {
         }
         belowFoldCollection.onSelectSynopsis = { [weak self] d in self?.onSelectSynopsis?(d) }
         belowFoldCollection.onSelectAdvisory = { [weak self] a in self?.onSelectAdvisory?(a) }
+        belowFoldCollection.onSelectInfoColumn = { [weak self] section in
+            self?.onSelectInfoColumn?(section)
+        }
 
         // Logo + season pills sit ABOVE the collection (content scrolls under).
         bringSubviewToFront(smallTitleLogo)

--- a/Rivulet/Views/Media/MediaDetail/UIKit/FocusableActionButton.swift
+++ b/Rivulet/Views/Media/MediaDetail/UIKit/FocusableActionButton.swift
@@ -83,7 +83,7 @@ final class FocusableActionButton: UIControl {
     // On tvOS a bare UIControl's `.primaryActionTriggered` is unreliable for the
     // remote Select press (it's delivered to the FOCUSED view's press handlers).
     // Handle it here too, debounced so primaryActionTriggered + pressesEnded
-    // can't double-fire. Mirrors AboutCardControl.
+    // can't double-fire. Mirrors DetailCardControl.
     private var lastFireTime: CFTimeInterval = 0
     private func fireOnce() {
         let now = CACurrentMediaTime()

--- a/Rivulet/Views/Media/MediaDetail/UIKit/InfoPopupViewController.swift
+++ b/Rivulet/Views/Media/MediaDetail/UIKit/InfoPopupViewController.swift
@@ -17,6 +17,45 @@
 
 import UIKit
 
+/// Card height + scroll insets for a measured content height. Pure so the sizing
+/// can be tested without a device (see InfoPopupCardLayoutTests).
+///
+/// The insets are breathing room for content scrolling in and out of the card's
+/// edges, so they belong ONLY to the overflowing case. Applying the top inset
+/// unconditionally made short content scrollable by 8pt and clipped its last
+/// line — the card fit the content exactly, then the inset pushed it down.
+struct InfoPopupCardLayout {
+    let cardHeight: CGFloat
+    let scrolls: Bool
+    let insetTop: CGFloat
+    let insetBottom: CGFloat
+
+    /// Breathing room for content scrolling in and out of the card's edges.
+    private static let scrollInsetTop: CGFloat = 8
+    private static let scrollInsetBottom: CGFloat = 72
+
+    static func make(contentHeight: CGFloat, pad: CGFloat, screenHeight: CGFloat) -> InfoPopupCardLayout {
+        let natural = contentHeight + 2 * pad
+        let cardHeight = min(natural, screenHeight * 0.85)
+        return make(cardHeight: cardHeight, scrolls: natural > cardHeight + 0.5)
+    }
+
+    /// Forced height: the caller has decided the content is long enough that
+    /// measuring it is unreliable, so the card always scrolls.
+    static func make(fixedHeight: CGFloat, screenHeight: CGFloat) -> InfoPopupCardLayout {
+        make(cardHeight: min(fixedHeight, screenHeight * 0.92), scrolls: true)
+    }
+
+    private static func make(cardHeight: CGFloat, scrolls: Bool) -> InfoPopupCardLayout {
+        InfoPopupCardLayout(
+            cardHeight: cardHeight,
+            scrolls: scrolls,
+            insetTop: scrolls ? scrollInsetTop : 0,
+            insetBottom: scrolls ? scrollInsetBottom : 0
+        )
+    }
+}
+
 final class InfoPopupViewController: UIViewController {
 
     /// Focusable card so the modal owns the remote.
@@ -96,7 +135,8 @@ final class InfoPopupViewController: UIViewController {
             scroll.clipsToBounds = true
             // Breathing room so content scrolling in/out fades within the card,
             // not flush against its edges.
-            scroll.contentInset = UIEdgeInsets(top: 8, left: 0, bottom: 72, right: 0)
+            // Insets are owned by `apply(_:)` once the content is measured.
+            scroll.contentInset = .zero
             blur.contentView.addSubview(scroll)
             scroll.addSubview(content)
             // Card height is set in viewDidLayoutSubviews to the content's
@@ -187,12 +227,7 @@ final class InfoPopupViewController: UIViewController {
         // and pin the card to the requested height, clamped to the screen. Tall
         // content overflows + scrolls; short content just leaves headroom.
         if let h = fixedHeight {
-            let target = min(h, view.bounds.height * 0.92)
-            scroll.contentInset.bottom = 72
-            if abs(cardHeight.constant - target) > 0.5 {
-                cardHeight.constant = target
-                view.setNeedsLayout()
-            }
+            apply(InfoPopupCardLayout.make(fixedHeight: h, screenHeight: view.bounds.height))
             return
         }
         // 2. Card height: measure the content RELIABLY. `scroll.contentSize` is
@@ -207,13 +242,19 @@ final class InfoPopupViewController: UIViewController {
             withHorizontalFittingPriority: .required,
             verticalFittingPriority: .fittingSizeLevel).height
         guard contentH > 1 else { return }
-        let screen = view.bounds.height
-        let desired = min(contentH + 2 * pad, screen * 0.85)
-        // Bottom scroll-inset (breathing room) only when content overflows the card.
-        let scrolls = (contentH + 2 * pad) > desired + 0.5
-        scroll.contentInset.bottom = scrolls ? 72 : 0
-        if abs(cardHeight.constant - desired) > 0.5 {
-            cardHeight.constant = desired
+        apply(InfoPopupCardLayout.make(
+            contentHeight: contentH, pad: pad, screenHeight: view.bounds.height))
+    }
+
+    /// Single writer for the card height and the scroll insets. Both insets
+    /// track the overflow state — leaving the top one applied to content that
+    /// fit pushed it 8pt down and clipped its last line.
+    private func apply(_ layout: InfoPopupCardLayout) {
+        scroll.contentInset.top = layout.insetTop
+        scroll.contentInset.bottom = layout.insetBottom
+        if !layout.scrolls { scroll.contentOffset = .zero }
+        if abs(cardHeight.constant - layout.cardHeight) > 0.5 {
+            cardHeight.constant = layout.cardHeight
             view.setNeedsLayout()
         }
     }
@@ -243,6 +284,15 @@ enum InfoPopupContent {
             stack.addArrangedSubview(label(body, size: 24, weight: .regular, color: .white.withAlphaComponent(0.9), lines: 0))
         }
         return stack
+    }
+
+    /// One below-fold info section (Information / Languages / Accessibility) in
+    /// full. The card it came from trims long values to stay scannable; this is
+    /// the complete list.
+    static func infoColumn(_ section: DetailInfoSection) -> UIView {
+        let column = InfoColumnView()
+        column.configure(title: section.title, rows: section.rows)
+        return column
     }
 
     /// Common Sense advisory: green-check + age, one-liner, per-topic dot meters.
@@ -354,9 +404,7 @@ enum InfoPopupContent {
     private static func addSection(title: String, rows: [(String, String)], to stack: UIStackView) {
         guard !rows.isEmpty else { return }
         if let last = stack.arrangedSubviews.last { stack.setCustomSpacing(30, after: last) }
-        let col = InfoColumnView()
-        col.configure(title: title, rows: rows)
-        stack.addArrangedSubview(col)
+        stack.addArrangedSubview(infoColumn(.init(title: title, rows: rows)))
     }
 
     private static func metaRow(_ detail: MediaItemDetail) -> UIView {

--- a/Rivulet/Views/Media/PreviewCarousel/UIKit/PreviewCarouselViewController.swift
+++ b/Rivulet/Views/Media/PreviewCarousel/UIKit/PreviewCarouselViewController.swift
@@ -325,6 +325,10 @@ final class PreviewCarouselViewController: UIViewController {
             let content = InfoPopupContent.advisory(advisory)
             self?.present(InfoPopupViewController(content: content, width: 720, scrollable: true), animated: true)
         }
+        expandedDetail.onSelectInfoColumn = { [weak self] section in
+            let content = InfoPopupContent.infoColumn(section)
+            self?.present(InfoPopupViewController(content: content, width: 720, scrollable: true), animated: true)
+        }
         // Episode thumb Select → play the episode.
         expandedDetail.onPlayEpisode = { [weak self] episode in
             self?.playMediaItem(episode)

--- a/Rivulet/Views/Media/UIKit/Cells/ShelfRowCell.swift
+++ b/Rivulet/Views/Media/UIKit/Cells/ShelfRowCell.swift
@@ -117,7 +117,7 @@ final class ShelfRowCell: UICollectionViewCell {
         }
     }
 
-    private static let headerHeight: CGFloat = 44
+    static let headerHeight: CGFloat = 44
 
     private let headerLabel: UILabel = {
         let l = UILabel()

--- a/RivuletTests/Unit/InfoPopupCardLayoutTests.swift
+++ b/RivuletTests/Unit/InfoPopupCardLayoutTests.swift
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+// Copyright (C) 2025-2026 Bain Gurley
+
+//
+//  InfoPopupCardLayoutTests.swift
+//  RivuletTests
+//
+//  The info popup sizes its card from the measured content height and only adds
+//  scroll breathing room when the content actually overflows. Pure math, so the
+//  layout behavior that can only be seen on a device rests on a verified core.
+//
+//  Regression: the top inset was applied unconditionally, so a short synopsis
+//  that fit the card exactly still scrolled by 8pt and clipped its last line.
+//
+
+import XCTest
+@testable import Rivulet
+
+final class InfoPopupCardLayoutTests: XCTestCase {
+
+    private let pad: CGFloat = 52
+    private let screen: CGFloat = 1080
+
+    private func layout(_ contentHeight: CGFloat) -> InfoPopupCardLayout {
+        InfoPopupCardLayout.make(contentHeight: contentHeight, pad: pad, screenHeight: screen)
+    }
+
+    func testShortContentHugsAndDoesNotScroll() {
+        // The real measured case: 148pt of synopsis in a 1080pt-tall screen.
+        let l = layout(148)
+        XCTAssertEqual(l.cardHeight, 148 + 2 * pad)
+        XCTAssertFalse(l.scrolls)
+    }
+
+    /// The bug: a permanent 8pt top inset left short content scrollable and cut
+    /// off its last line. Content that fits must have NO inset on either edge.
+    func testShortContentHasNoScrollInsets() {
+        let l = layout(148)
+        XCTAssertEqual(l.insetTop, 0)
+        XCTAssertEqual(l.insetBottom, 0)
+    }
+
+    func testTallContentCapsAtScreenFractionAndScrolls() {
+        let l = layout(2000)
+        XCTAssertEqual(l.cardHeight, screen * 0.85)
+        XCTAssertTrue(l.scrolls)
+    }
+
+    func testTallContentKeepsBreathingRoom() {
+        let l = layout(2000)
+        XCTAssertEqual(l.insetTop, 8)
+        XCTAssertEqual(l.insetBottom, 72)
+    }
+
+    /// Exactly at the cap is not an overflow — no insets, no scroll.
+    func testContentExactlyAtCapDoesNotScroll() {
+        let l = layout(screen * 0.85 - 2 * pad)
+        XCTAssertFalse(l.scrolls)
+        XCTAssertEqual(l.insetTop, 0)
+    }
+
+    // MARK: - Forced height
+
+    /// A caller-forced height always scrolls, so it keeps the breathing room —
+    /// this path used to hardcode its own insets and clamp.
+    func testFixedHeightAlwaysScrollsAndKeepsInsets() {
+        let l = InfoPopupCardLayout.make(fixedHeight: 900, screenHeight: screen)
+        XCTAssertEqual(l.cardHeight, 900)
+        XCTAssertTrue(l.scrolls)
+        XCTAssertEqual(l.insetTop, 8)
+        XCTAssertEqual(l.insetBottom, 72)
+    }
+
+    func testFixedHeightClampsToScreen() {
+        let l = InfoPopupCardLayout.make(fixedHeight: 5000, screenHeight: screen)
+        XCTAssertEqual(l.cardHeight, screen * 0.92)
+    }
+}


### PR DESCRIPTION
## What

Renders the below-fold Information / Languages / Accessibility trio as cards matching the About section, and makes them openable.

Previously these were three bare columns on a darkened band, sitting directly under two proper About cards — the same kind of supporting metadata in two unrelated treatments.

- Information / Languages / Accessibility are now cards with the About card's fill, radius, and focus lift. The darkened band is gone.
- Each is its own focus stop, and Select opens that section in a popup. The card keeps trimming long genre and studio lists to stay scannable; the popup carries the full list.
- The episode detail page shares `InfoColumnsView`, so it gets the cards too (non-focusable there, since it scrolls normally).
- `AboutCardControl` becomes `DetailCardControl`, owning its own content inset so both surfaces stop restating the padding.

Two things fixed along the way:

- **The Related shelf header was silently dropped whenever Related landed first** (a movie with no trailers or extras — the common case). It was suppressed on the primary peek row on purpose, but that means the section loses its label exactly when it's the only thing there. Now always shown.
- **Short info popups scrolled by 8pt and clipped their last line.** The scroll view's top inset was applied once at init and only the bottom one was ever reset, so content that fit the card exactly still sat 8pt low. Both insets now track the overflow state, and the sizing is a pure `InfoPopupCardLayout` with tests.

## Verified

- `xcodebuild build` for tvOS Simulator
- `swiftlint lint --strict` — 0 violations
- Full unit suite passes; 7 new popup-layout tests, each written failing first
- Driven in the Simulator: cards render at equal height with no clipping, Left/Right moves across all three, Select opens the matching section, the Related header appears on a movie with no extras, and the synopsis popup no longer clips

## Not verified

**Focus behaviour has only been seen in the Simulator**, which per `CLAUDE.md` can't be trusted for the focus engine. The three focus stops and the moves between them need a device pass.

## Known follow-ups

- The info section's height is a hardcoded `504` that encodes the cards' internal padding in a file with no other knowledge of them. A title with many audio/subtitle languages could overflow it.
- The card-Select popup and the hero Info button now render different bodies for the same section — `fullInfo` has Region of Origin, container progress, and codec-rich audio; the card has Genres and Studio. Reconciling them is a product decision, so it's deliberately left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
