### PR TITLE
fix: stop short info popups from scrolling and clipping

### DIFF
--- a/Rivulet/Views/Media/MediaDetail/UIKit/InfoPopupViewController.swift
+++ b/Rivulet/Views/Media/MediaDetail/UIKit/InfoPopupViewController.swift
@@ -17,6 +17,45 @@
 
 import UIKit
 
+/// Card height + scroll insets for a measured content height. Pure so the sizing
+/// can be tested without a device (see InfoPopupCardLayoutTests).
+///
+/// The insets are breathing room for content scrolling in and out of the card's
+/// edges, so they belong ONLY to the overflowing case. Applying the top inset
+/// unconditionally made short content scrollable by 8pt and clipped its last
+/// line — the card fit the content exactly, then the inset pushed it down.
+struct InfoPopupCardLayout {
+    let cardHeight: CGFloat
+    let scrolls: Bool
+    let insetTop: CGFloat
+    let insetBottom: CGFloat
+
+    /// Breathing room for content scrolling in and out of the card's edges.
+    private static let scrollInsetTop: CGFloat = 8
+    private static let scrollInsetBottom: CGFloat = 72
+
+    static func make(contentHeight: CGFloat, pad: CGFloat, screenHeight: CGFloat) -> InfoPopupCardLayout {
+        let natural = contentHeight + 2 * pad
+        let cardHeight = min(natural, screenHeight * 0.85)
+        return make(cardHeight: cardHeight, scrolls: natural > cardHeight + 0.5)
+    }
+
+    /// Forced height: the caller has decided the content is long enough that
+    /// measuring it is unreliable, so the card always scrolls.
+    static func make(fixedHeight: CGFloat, screenHeight: CGFloat) -> InfoPopupCardLayout {
+        make(cardHeight: min(fixedHeight, screenHeight * 0.92), scrolls: true)
+    }
+
+    private static func make(cardHeight: CGFloat, scrolls: Bool) -> InfoPopupCardLayout {
+        InfoPopupCardLayout(
+            cardHeight: cardHeight,
+            scrolls: scrolls,
+            insetTop: scrolls ? scrollInsetTop : 0,
+            insetBottom: scrolls ? scrollInsetBottom : 0
+        )
+    }
+}
+
 final class InfoPopupViewController: UIViewController {
 
     /// Focusable card so the modal owns the remote.
@@ -96,7 +135,8 @@ final class InfoPopupViewController: UIViewController {
             scroll.clipsToBounds = true
             // Breathing room so content scrolling in/out fades within the card,
             // not flush against its edges.
-            scroll.contentInset = UIEdgeInsets(top: 8, left: 0, bottom: 72, right: 0)
+            // Insets are owned by `apply(_:)` once the content is measured.
+            scroll.contentInset = .zero
             blur.contentView.addSubview(scroll)
             scroll.addSubview(content)
             // Card height is set in viewDidLayoutSubviews to the content's
@@ -187,12 +227,7 @@ final class InfoPopupViewController: UIViewController {
         // and pin the card to the requested height, clamped to the screen. Tall
         // content overflows + scrolls; short content just leaves headroom.
         if let h = fixedHeight {
-            let target = min(h, view.bounds.height * 0.92)
-            scroll.contentInset.bottom = 72
-            if abs(cardHeight.constant - target) > 0.5 {
-                cardHeight.constant = target
-                view.setNeedsLayout()
-            }
+            apply(InfoPopupCardLayout.make(fixedHeight: h, screenHeight: view.bounds.height))
             return
         }
         // 2. Card height: measure the content RELIABLY. `scroll.contentSize` is
@@ -207,13 +242,19 @@ final class InfoPopupViewController: UIViewController {
             withHorizontalFittingPriority: .required,
             verticalFittingPriority: .fittingSizeLevel).height
         guard contentH > 1 else { return }
-        let screen = view.bounds.height
-        let desired = min(contentH + 2 * pad, screen * 0.85)
-        // Bottom scroll-inset (breathing room) only when content overflows the card.
-        let scrolls = (contentH + 2 * pad) > desired + 0.5
-        scroll.contentInset.bottom = scrolls ? 72 : 0
-        if abs(cardHeight.constant - desired) > 0.5 {
-            cardHeight.constant = desired
+        apply(InfoPopupCardLayout.make(
+            contentHeight: contentH, pad: pad, screenHeight: view.bounds.height))
+    }
+
+    /// Single writer for the card height and the scroll insets. Both insets
+    /// track the overflow state — leaving the top one applied to content that
+    /// fit pushed it 8pt down and clipped its last line.
+    private func apply(_ layout: InfoPopupCardLayout) {
+        scroll.contentInset.top = layout.insetTop
+        scroll.contentInset.bottom = layout.insetBottom
+        if !layout.scrolls { scroll.contentOffset = .zero }
+        if abs(cardHeight.constant - layout.cardHeight) > 0.5 {
+            cardHeight.constant = layout.cardHeight
             view.setNeedsLayout()
         }
     }

--- a/RivuletTests/Unit/InfoPopupCardLayoutTests.swift
+++ b/RivuletTests/Unit/InfoPopupCardLayoutTests.swift
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+// Copyright (C) 2025-2026 Bain Gurley
+
+//
+//  InfoPopupCardLayoutTests.swift
+//  RivuletTests
+//
+//  The info popup sizes its card from the measured content height and only adds
+//  scroll breathing room when the content actually overflows. Pure math, so the
+//  layout behavior that can only be seen on a device rests on a verified core.
+//
+//  Regression: the top inset was applied unconditionally, so a short synopsis
+//  that fit the card exactly still scrolled by 8pt and clipped its last line.
+//
+
+import XCTest
+@testable import Rivulet
+
+final class InfoPopupCardLayoutTests: XCTestCase {
+
+    private let pad: CGFloat = 52
+    private let screen: CGFloat = 1080
+
+    private func layout(_ contentHeight: CGFloat) -> InfoPopupCardLayout {
+        InfoPopupCardLayout.make(contentHeight: contentHeight, pad: pad, screenHeight: screen)
+    }
+
+    func testShortContentHugsAndDoesNotScroll() {
+        // The real measured case: 148pt of synopsis in a 1080pt-tall screen.
+        let l = layout(148)
+        XCTAssertEqual(l.cardHeight, 148 + 2 * pad)
+        XCTAssertFalse(l.scrolls)
+    }
+
+    /// The bug: a permanent 8pt top inset left short content scrollable and cut
+    /// off its last line. Content that fits must have NO inset on either edge.
+    func testShortContentHasNoScrollInsets() {
+        let l = layout(148)
+        XCTAssertEqual(l.insetTop, 0)
+        XCTAssertEqual(l.insetBottom, 0)
+    }
+
+    func testTallContentCapsAtScreenFractionAndScrolls() {
+        let l = layout(2000)
+        XCTAssertEqual(l.cardHeight, screen * 0.85)
+        XCTAssertTrue(l.scrolls)
+    }
+
+    func testTallContentKeepsBreathingRoom() {
+        let l = layout(2000)
+        XCTAssertEqual(l.insetTop, 8)
+        XCTAssertEqual(l.insetBottom, 72)
+    }
+
+    /// Exactly at the cap is not an overflow — no insets, no scroll.
+    func testContentExactlyAtCapDoesNotScroll() {
+        let l = layout(screen * 0.85 - 2 * pad)
+        XCTAssertFalse(l.scrolls)
+        XCTAssertEqual(l.insetTop, 0)
+    }
+
+    // MARK: - Forced height
+
+    /// A caller-forced height always scrolls, so it keeps the breathing room —
+    /// this path used to hardcode its own insets and clamp.
+    func testFixedHeightAlwaysScrollsAndKeepsInsets() {
+        let l = InfoPopupCardLayout.make(fixedHeight: 900, screenHeight: screen)
+        XCTAssertEqual(l.cardHeight, 900)
+        XCTAssertTrue(l.scrolls)
+        XCTAssertEqual(l.insetTop, 8)
+        XCTAssertEqual(l.insetBottom, 72)
+    }
+
+    func testFixedHeightClampsToScreen() {
+        let l = InfoPopupCardLayout.make(fixedHeight: 5000, screenHeight: screen)
+        XCTAssertEqual(l.cardHeight, screen * 0.92)
+    }
+}


### PR DESCRIPTION
Split out of the below-fold info-cards work so it can be reviewed on its own.

The info popup sized its card to the measured content, but the scroll
view's `contentInset` was set once at construction (`top: 8, bottom: 72`)
and only the bottom inset was ever cleared. So a popup whose content fit
the card exactly still carried the 8pt top inset: the content was pushed
down inside a card sized without it, the card became scrollable by 8pt,
and the last line was clipped.

The card height and both insets now come from one value, `InfoPopupCardLayout`,
with a single writer applying it. The insets are breathing room for content
scrolling in and out of the card's edges, so they belong only to the
overflowing case — non-scrolling popups get neither, and their offset is
reset.

`InfoPopupCardLayout` is a pure struct, so the sizing rules are covered by
unit tests rather than needing a device: short content hugs and doesn't
scroll, content exactly at the cap doesn't scroll, tall content caps at the
screen fraction and keeps its breathing room, and the forced-height path
always scrolls.

7/7 tests pass on the tvOS Simulator; `swiftlint --strict` reports 0
violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)