### PR TITLE
Match Apple's caption rendering in the subtitle overlay

### DIFF
--- a/Rivulet/Services/Plex/Playback/AetherPlayer.swift
+++ b/Rivulet/Services/Plex/Playback/AetherPlayer.swift
@@ -57,6 +57,23 @@ final class AetherPlayer: PlayerProtocol {
     /// (embedded or sidecar) is selected and the engine has cue data.
     @Published private(set) var isSubtitleActive: Bool = false
 
+    /// The item's presentation size (pixel dimensions after aperture/pixel
+    /// aspect correction), for hosts that must place UI against the VIDEO
+    /// rect rather than the screen — the subtitle overlay measures its bottom
+    /// margin from the picture, so captions on 2.39:1 content sit above the
+    /// letterbox rather than down in the black bar.
+    ///
+    /// `.zero` until an item reports one, and on the software path (no
+    /// AVPlayer). Callers treat `.zero` as "assume the video fills the view".
+    @Published private(set) var videoSize: CGSize = .zero
+
+    /// Per-player / per-item observers for `videoSize`. Held separately from
+    /// `cancellables` because they are replaced whenever the engine swaps its
+    /// inner AVPlayer or item (audio-track switch, background reopen, the
+    /// failure ladder), not torn down with the session.
+    private var videoItemCancellable: AnyCancellable?
+    private var videoSizeCancellable: AnyCancellable?
+
     /// True while playback is stalled waiting for media. Combines
     /// engine.$isBuffering with a direct timeControlStatus observation on the
     /// engine's inner AVPlayer: the engine's flag only updates inside its
@@ -244,6 +261,7 @@ final class AetherPlayer: PlayerProtocol {
                 avp?.isMuted = self.isMuted
                 self.currentAVPlayer = avp
                 self.observeTimeControlStatus(of: avp)
+                self.observeVideoSize(of: avp)
             }
             .store(in: &cancellables)
 
@@ -266,6 +284,37 @@ final class AetherPlayer: PlayerProtocol {
     /// engine swaps its player (track switch, background reopen); nil on the
     /// software backend's no-AVPlayer configurations, where the engine's own
     /// flag is the only (and sufficient) signal.
+    /// Tracks `presentationSize` across item swaps. Observed in two hops
+    /// rather than through a `\.currentItem?.presentationSize` key path:
+    /// nested KVO through an optional chain is not reliably delivered, and a
+    /// missed update would leave the overlay measuring against a stale
+    /// aspect ratio for the whole session.
+    private func observeVideoSize(of player: AVPlayer?) {
+        videoSizeCancellable = nil
+        guard let player else {
+            videoItemCancellable = nil
+            videoSize = .zero
+            return
+        }
+        videoItemCancellable = player
+            .publisher(for: \.currentItem)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] item in
+                guard let self else { return }
+                guard let item else {
+                    self.videoSizeCancellable = nil
+                    return
+                }
+                self.videoSizeCancellable = item
+                    .publisher(for: \.presentationSize)
+                    // A zero size is the pre-ready placeholder; publishing it
+                    // would flip the overlay back to full-bounds mid-session.
+                    .filter { $0.width > 0 && $0.height > 0 }
+                    .receive(on: DispatchQueue.main)
+                    .sink { [weak self] size in self?.videoSize = size }
+            }
+    }
+
     private func observeTimeControlStatus(of player: AVPlayer?) {
         timeControlStatusCancellable = player?
             .publisher(for: \.timeControlStatus)

--- a/Rivulet/Services/Plex/Playback/Subtitles/CaptionAppearance.swift
+++ b/Rivulet/Services/Plex/Playback/Subtitles/CaptionAppearance.swift
@@ -100,9 +100,16 @@ enum CaptionAppearance {
     /// `MACaptionAppearanceGetRelativeCharacterSize` already returns the size as a
     /// multiplicative scale factor (≈1.0 at the default), NOT an offset — so it is
     /// used directly. A non-positive value means "unset"; treat that as 1.0.
+    ///
+    /// The bounds are a sanity net against a nonsense value, NOT a style
+    /// decision: they were 0.5...2.0, which silently compressed the ends of
+    /// the system's own range, so captions stopped tracking the Subtitles &
+    /// Captioning size setting at the extremes. Widened to cover anything
+    /// tvOS plausibly reports; the caption is still bounded in practice by
+    /// the overlay's own max width.
     static func fontScale(forRelativeSize relative: CGFloat) -> CGFloat {
         guard relative > 0 else { return 1.0 }
-        return min(max(relative, 0.5), 2.0)
+        return min(max(relative, 0.25), 4.0)
     }
 
     /// Reads the current system caption style from MediaAccessibility.

--- a/Rivulet/Views/Components/WhatsNewView.swift
+++ b/Rivulet/Views/Components/WhatsNewView.swift
@@ -141,6 +141,7 @@ struct WhatsNewView: View {
 
     static let changelogs: [(version: String, features: [String])] = [
         ("1.0.4 (71)", [
+            "Subtitles now match the way Apple TV draws its own captions, with the same text size, tighter background behind each line, and the same distance from the picture. On letterboxed films they sit on the image instead of down in the black bar",
             "Updated AetherEngine to 5.23.11",
             "Playback starts and seeks more reliably: resuming part way in is faster, jumping far ahead no longer stalls, and titles with TrueHD or DTS-HD MA audio no longer sit on Loading forever",
             "Fixed picture and colour problems on several kinds of file, including Dolby Vision Profile 5 titles that played with a green or purple tint and widescreen content that looked squashed",

--- a/Rivulet/Views/LiveTV/LiveTVAetherPlayerViewController.swift
+++ b/Rivulet/Views/LiveTV/LiveTVAetherPlayerViewController.swift
@@ -1092,7 +1092,10 @@ final class LiveTVAetherPlayerViewController: UIViewController {
         AetherSubtitleOverlayView(
             model: subtitleModel,
             style: captionStyle,
-            controlsVisible: railVisible  // lift captions above the glass rail
+            controlsVisible: railVisible,  // lift captions above the glass rail
+            // Broadcast is usually 16:9, but a 4:3 or 2.39:1 channel gets its
+            // captions on the picture rather than in the pillar/letterbox.
+            videoSize: aetherPlayer?.videoSize ?? .zero
         )
     }
 
@@ -1111,6 +1114,14 @@ final class LiveTVAetherPlayerViewController: UIViewController {
                 if self.nativeLegibleActive && cues.isEmpty { return }
                 self.subtitleModel.update(cues: cues)
             }
+            .store(in: &cancellables)
+
+        // The overlay is a rebuilt-on-demand root view, so a videoSize change
+        // has to force a rebuild — nothing observes the player from SwiftUI.
+        aether.$videoSize
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.rebuildSubtitleOverlay() }
             .store(in: &cancellables)
 
         aether.$sourceTime

--- a/Rivulet/Views/Player/Aether/AetherSubtitleOverlayView.swift
+++ b/Rivulet/Views/Player/Aether/AetherSubtitleOverlayView.swift
@@ -9,12 +9,14 @@
 //  Mounted in UniversalPlayerView above the video surface, below the
 //  UIKit transport bar hosted by PlayerContainerViewController.
 //
-//  controlsVisible insets (matched to SubtitleOverlayView on the AVPlayer
-//  routes, so subtitles sit at the same height on every route):
-//    true  -> 368 pt bottom padding (rail bottom inset 84 + railHeight 260
-//             + 24 gap; clears the 3a glass rail)
-//    false -> 100 pt bottom padding (same resting height as the AVPlayer
-//             route's SubtitleOverlayView, mirroring native caption placement)
+//  Sizing and placement mirror AVPlayer's own caption rendering:
+//    - point size = a fraction of the PRESENTATION height x the system's
+//      relative-character-size multiplier
+//    - the resting bottom margin is a fraction of the PICTURE height, so a
+//      letterboxed film is captioned on the image, not in its black bar
+//    - with the rail up, the screen-anchored rail clearance (368 pt = rail
+//      bottom inset 84 + railHeight 260 + 24 gap) wins instead
+//  See the Metrics block below for the derivations.
 //
 
 import SwiftUI
@@ -31,21 +33,120 @@ struct AetherSubtitleOverlayView: View {
     /// True when the player rail is visible; lifts text above it.
     var controlsVisible: Bool
 
-    // Bottom padding constants (pts). controlsVisiblePadding =
-    // PlayerRailView.railHeight (260) + rail bottom inset (84) + 24 gap.
-    // defaultPadding matches SubtitleOverlayView's resting bottomOffset (100)
-    // on the AVPlayer route, which mirrors native AVPlayer caption placement —
-    // 60 sat visibly too close to the screen edge.
+    /// The video's presentation size (`AetherPlayer.videoSize`). `.zero` means
+    /// "unknown" — the overlay then measures against its full bounds, which is
+    /// the pre-existing behaviour and correct for a 16:9 picture filling the
+    /// screen.
+    var videoSize: CGSize = .zero
+
+    // controlsVisiblePadding = PlayerRailView.railHeight (260) + rail bottom
+    // inset (84) + 24 gap; measured from the SCREEN because the rail is
+    // screen-anchored.
     private static let controlsVisiblePadding: CGFloat = 368
-    private static let defaultPadding: CGFloat = 100
+
+    /// Distance from the bottom of the PICTURE to the bottom of the caption
+    /// box, as a fraction of picture height — so letterboxed content keeps
+    /// captions on the image rather than dropping them into the black bar,
+    /// and the placement holds at any presentation size.
+    ///
+    /// Tuned against AVPlayer's own placement (a two-line caption centres at
+    /// roughly 8% of picture height). Bottom-anchored rather than
+    /// centre-anchored, so a third line grows upward instead of shifting the
+    /// whole caption down.
+    private static let videoBottomMarginFraction: CGFloat = 0.06
+
+    // MARK: Apple-matching caption metrics
+    //
+    // Tuned against AVPlayer's own caption rendering (screenshot comparison at
+    // the smallest system caption size). Three differences mattered: Apple
+    // sizes type from the VIDEO height rather than a fixed point size, boxes
+    // the text tightly, and draws one background per LINE rather than one
+    // around the whole cue.
+
+    /// Caption point size as a fraction of the PRESENTATION height (the
+    /// player's own bounds), before the user's relative-size multiplier.
+    ///
+    /// The model is: base fraction × the system's own multiplier. The WebVTT
+    /// caption spec default is 5% (`5vh`); this sits near it, tuned on device
+    /// against AVPlayer's own rendering — at the smallest system caption size
+    /// `MACaptionAppearanceGetRelativeCharacterSize` reports 0.35, and
+    /// 1080 × 0.0529 × 0.35 = 20pt is the match. Every other size follows
+    /// from the multiplier.
+    ///
+    /// Do NOT re-tune this to compensate for a size problem: if captions are
+    /// the wrong size, suspect the multiplier reaching us instead (see
+    /// `CaptionAppearance.fontScale`, whose clamp used to swallow 0.35 and
+    /// silently flatten the bottom of the range).
+    ///
+    /// Deliberately NOT the letterboxed picture height: Apple sizes captions
+    /// from the presentation and only *positions* them against the picture,
+    /// so a 2.39:1 film gets the same type as a 16:9 one rather than shrunken
+    /// type. tvOS always presents 1080 points tall regardless of whether the
+    /// display is 1080p or 4K, so this is stable across outputs.
+    private static let fontHeightFraction: CGFloat = 0.0529
+
+    /// Fallback presentation height, for the degenerate case of a zero-height
+    /// layout pass.
+    private static let assumedVideoHeight: CGFloat = 1080
+
+    // Box geometry is expressed as MULTIPLES OF THE POINT SIZE, not fixed
+    // points, because Apple's caption box grows with the type — at a large
+    // caption size a fixed 4pt radius reads as a hard rectangle against much
+    // bigger glyphs. The ratios below reproduce the previously tuned 4 / 8 / 2
+    // at the smallest setting and scale from there.
+    private static let cornerRadiusRatio: CGFloat = 0.15
+    private static let paddingHRatio: CGFloat = 0.30
+    private static let paddingVRatio: CGFloat = 0.075
+
+    /// Extra leading between the lines of one cue, on top of the font's own
+    /// line height. Zero matches Apple, whose caption lines sit on natural
+    /// leading inside a single background.
+    private static let textLineSpacing: CGFloat = 0
+
+    /// Gap between separate simultaneous cues (two speakers), which SHOULD
+    /// read as distinct blocks.
+    private static let cueSpacing: CGFloat = 4
 
     /// User height adjustment from the OSD stepper (global; positive = higher).
     /// Read as @AppStorage so stepping it re-renders the overlay live.
     @AppStorage(SubtitleAdjustments.heightKey) private var heightUnits: Int = 0
 
-    private var bottomPadding: CGFloat {
-        let base = controlsVisible ? Self.controlsVisiblePadding : Self.defaultPadding
+    /// The picture's rect inside `bounds`, aspect-fit (how both the engine
+    /// surface and AVPlayerLayer place video). Falls back to the full bounds
+    /// when the size is unknown.
+    private func videoRect(in bounds: CGSize) -> CGRect {
+        guard videoSize.width > 0, videoSize.height > 0,
+              bounds.width > 0, bounds.height > 0 else {
+            return CGRect(origin: .zero, size: bounds)
+        }
+        let scale = min(bounds.width / videoSize.width, bounds.height / videoSize.height)
+        let w = videoSize.width * scale
+        let h = videoSize.height * scale
+        return CGRect(x: (bounds.width - w) / 2, y: (bounds.height - h) / 2, width: w, height: h)
+    }
+
+    /// Distance from the bottom of the CONTAINER to the text.
+    ///
+    /// Two anchors compete and the larger wins: the caption must sit
+    /// `videoBottomMargin` above the bottom of the PICTURE (so letterboxed
+    /// content is not captioned into its black bar), and it must clear the
+    /// rail when the rail is up (which is anchored to the SCREEN). Taking the
+    /// max means a 2.39:1 film with the rail hidden lifts by its letterbox,
+    /// while the same film with the rail up still clears the chrome.
+    private func bottomPadding(in bounds: CGSize) -> CGFloat {
+        let rect = videoRect(in: bounds)
+        let letterbox = max(0, bounds.height - rect.maxY)
+        var base = letterbox + rect.height * Self.videoBottomMarginFraction
+        if controlsVisible {
+            base = max(base, Self.controlsVisiblePadding)
+        }
         return max(0, base + SubtitleAdjustments.heightOffset(forUnits: heightUnits))
+    }
+
+    /// Caption point size for this presentation, before per-cue styling.
+    private func baseFontSize(in bounds: CGSize) -> CGFloat {
+        let height = bounds.height > 0 ? bounds.height : Self.assumedVideoHeight
+        return height * Self.fontHeightFraction * style.fontScale
     }
 
     var body: some View {
@@ -73,12 +174,12 @@ struct AetherSubtitleOverlayView: View {
                 // padding hangs invisibly off the bottom edge, so the inset
                 // never lifted the text at all (subs sat glued to the edge and
                 // the rail lift was a no-op).
-                VStack(spacing: 4) {
+                VStack(spacing: Self.cueSpacing) {
                     ForEach(model.activeCues.filter(\.isText), id: \.contentKey) { cue in
                         styledText(cue.body, size: geo.size)
                     }
                 }
-                .padding(.bottom, bottomPadding)
+                .padding(.bottom, bottomPadding(in: geo.size))
                 .frame(width: geo.size.width, height: geo.size.height, alignment: .bottom)
             }
         }
@@ -103,29 +204,19 @@ struct AetherSubtitleOverlayView: View {
 
     // MARK: - Text cue
 
+    /// One cue in ONE rounded box, sized to its longest line.
+    ///
+    /// A multi-line cue keeps its author's line breaks and stays inside a
+    /// single background — the box hugs the widest line and the shorter lines
+    /// centre within it. (An earlier attempt boxed each line separately; that
+    /// reads as detached labels rather than one caption.)
     @ViewBuilder
     private func styledText(_ body: AetherSubtitleCue.Body, size: CGSize) -> some View {
         let maxWidth = max(0, size.width - 240)
-        // System conformance: the user's chosen caption font (via the
-        // MediaAccessibility font descriptor) and text opacity apply, not
-        // just color/size/edge. Base size 42 matches SubtitleOverlayView on
-        // the HLS route so captions render identically across routes.
-        let baseFont = style.font(ofSize: 42 * style.fontScale)
+        let pointSize = baseFontSize(in: size)
+        let baseFont = style.font(ofSize: pointSize)
 
         switch style.edge {
-        case .dropShadow:
-            cueText(body)
-                .font(baseFont)
-                .multilineTextAlignment(.center)
-                .shadow(color: .black.opacity(0.85), radius: 3, x: 0, y: 1)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 4)
-                .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(style.backgroundColor.opacity(style.backgroundOpacity))
-                )
-                .frame(maxWidth: maxWidth)
-
         case .uniform:
             // 8-direction black outline (no per-character stroke on tvOS).
             let offsets: [(CGFloat, CGFloat)] = [
@@ -141,27 +232,39 @@ struct AetherSubtitleOverlayView: View {
                         .font(baseFont)
                         .foregroundStyle(Color.black)
                         .multilineTextAlignment(.center)
+                        .lineSpacing(Self.textLineSpacing)
                         .offset(x: delta.0, y: delta.1)
                 }
                 cueText(body)
                     .font(baseFont)
                     .multilineTextAlignment(.center)
+                    .lineSpacing(Self.textLineSpacing)
             }
             .frame(maxWidth: maxWidth)
 
+        case .dropShadow:
+            boxed(cueText(body).font(baseFont), maxWidth: maxWidth, fontSize: pointSize)
+                .shadow(color: .black.opacity(0.85), radius: 3, x: 0, y: 1)
+
         default:
             // .none / .raised / .depressed: solid background box.
-            cueText(body)
-                .font(baseFont)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 4)
-                .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(style.backgroundColor.opacity(style.backgroundOpacity))
-                )
-                .frame(maxWidth: maxWidth)
+            boxed(cueText(body).font(baseFont), maxWidth: maxWidth, fontSize: pointSize)
         }
+    }
+
+    /// The tight background box Apple draws behind a caption, with padding and
+    /// radius proportional to `fontSize`.
+    private func boxed(_ text: some View, maxWidth: CGFloat, fontSize: CGFloat) -> some View {
+        text
+            .multilineTextAlignment(.center)
+            .lineSpacing(Self.textLineSpacing)
+            .padding(.horizontal, fontSize * Self.paddingHRatio)
+            .padding(.vertical, fontSize * Self.paddingVRatio)
+            .background(
+                RoundedRectangle(cornerRadius: fontSize * Self.cornerRadiusRatio, style: .continuous)
+                    .fill(style.backgroundColor.opacity(style.backgroundOpacity))
+            )
+            .frame(maxWidth: maxWidth)
     }
 
     /// Builds the cue's `Text`, applying the colour policy per run:

--- a/Rivulet/Views/Player/UniversalPlayerView.swift
+++ b/Rivulet/Views/Player/UniversalPlayerView.swift
@@ -945,7 +945,11 @@ struct UniversalPlayerView: View {
                     // (showControls || isScrubbing): the scrub ribbon keeps
                     // the bottom band occupied even when the rail hides, so
                     // captions stay lifted through a scrub.
-                    controlsVisible: viewModel.showControls || viewModel.isScrubbing
+                    controlsVisible: viewModel.showControls || viewModel.isScrubbing,
+                    // Lets the overlay measure its bottom margin from the
+                    // picture rather than the screen, so a letterboxed film
+                    // is not captioned into its black bar.
+                    videoSize: viewModel.videoSize
                 )
                 .ignoresSafeArea()
                 .allowsHitTesting(false)

--- a/Rivulet/Views/Player/UniversalPlayerViewModel.swift
+++ b/Rivulet/Views/Player/UniversalPlayerViewModel.swift
@@ -268,6 +268,11 @@ final class UniversalPlayerViewModel: ObservableObject {
     /// switch, background reopen).
     @Published private(set) var aetherPlayer: AetherPlayer?
 
+    /// The playing item's presentation size, mirrored from `aetherPlayer` so
+    /// SwiftUI actually observes it (see the subscription in the bind block).
+    /// `.zero` before the first frame and on the AVPlayer/hls route.
+    @Published private(set) var videoSize: CGSize = .zero
+
     /// Subtitle manager for custom subtitle rendering.
     let subtitleManager = SubtitleManager()
     private let subtitleClockSync = SubtitleClockSyncController()
@@ -1759,6 +1764,18 @@ final class UniversalPlayerViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] cues in
                 self?.aetherSubtitleModel.update(cues: cues)
+            }
+            .store(in: &cancellables)
+
+        // Mirrored onto the view model because AetherPlayer is not an
+        // ObservableObject: a SwiftUI view reading `aetherPlayer.videoSize`
+        // directly would never re-render, since `$aetherPlayer` only fires
+        // when the PLAYER changes, not its properties.
+        player.$videoSize
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] size in
+                self?.videoSize = size
             }
             .store(in: &cancellables)
 


### PR DESCRIPTION
Size, box and placement now follow AVPlayer's own caption rendering instead of fixed point values.

Size is a fraction of the presentation height times the system's relative-character-size multiplier, so it tracks Subtitles & Captioning across the whole range. The multiplier previously did not: the clamp in CaptionAppearance was 0.5...2.0, and tvOS reports 0.35 at the smallest setting, so the bottom of the range was silently flattened.

The box hugs the text more tightly, and its padding and corner radius scale with the point size rather than staying fixed, so a large caption size no longer draws big glyphs in a small hard-edged box.

The resting bottom margin is measured from the picture rather than the screen, so letterboxed content is captioned on the image instead of in its black bar. AetherPlayer publishes the item's presentation size for this; when it is unknown (the software path has no AVPlayer) the overlay falls back to its full bounds, which is the previous behaviour. With the rail up, the screen-anchored rail clearance still wins.

This should be pretty much an exact mimic visually and placement wise for the Native AVPlayer sub renderer - while keeping additional options like delay and height adjustment toggles.