### PR TITLE
Match Apple's caption rendering, and keep content styling and placement

### DIFF
--- a/Rivulet/Services/Plex/Playback/AetherPlayer.swift
+++ b/Rivulet/Services/Plex/Playback/AetherPlayer.swift
@@ -57,6 +57,23 @@ final class AetherPlayer: PlayerProtocol {
     /// (embedded or sidecar) is selected and the engine has cue data.
     @Published private(set) var isSubtitleActive: Bool = false
 
+    /// The item's presentation size (pixel dimensions after aperture/pixel
+    /// aspect correction), for hosts that must place UI against the VIDEO
+    /// rect rather than the screen — the subtitle overlay measures its bottom
+    /// margin from the picture, so captions on 2.39:1 content sit above the
+    /// letterbox rather than down in the black bar.
+    ///
+    /// `.zero` until an item reports one, and on the software path (no
+    /// AVPlayer). Callers treat `.zero` as "assume the video fills the view".
+    @Published private(set) var videoSize: CGSize = .zero
+
+    /// Per-player / per-item observers for `videoSize`. Held separately from
+    /// `cancellables` because they are replaced whenever the engine swaps its
+    /// inner AVPlayer or item (audio-track switch, background reopen, the
+    /// failure ladder), not torn down with the session.
+    private var videoItemCancellable: AnyCancellable?
+    private var videoSizeCancellable: AnyCancellable?
+
     /// True while playback is stalled waiting for media. Combines
     /// engine.$isBuffering with a direct timeControlStatus observation on the
     /// engine's inner AVPlayer: the engine's flag only updates inside its
@@ -186,25 +203,44 @@ final class AetherPlayer: PlayerProtocol {
                     case .text(let string):
                         body = .text(string)
                     case .richText(let runs):
-                        // Coloured teletext / ASS colour runs (engine 5.7.0+).
-                        // Whether the colour is painted is the renderer's call
-                        // (CaptionStyle.allowsContentColor).
+                        // Styled runs. Since engine 5.26.0 this is not just
+                        // colour: bold / italic / underline / strikethrough,
+                        // font face and size arrive too, and for EVERY text
+                        // format — libavcodec converts SRT, WebVTT and
+                        // teletext into ASS event lines, and the engine now
+                        // parses the whole override set rather than colour
+                        // alone. Whether any of it is painted is the
+                        // renderer's call, per attribute, against the
+                        // CaptionStyle.allowsContent* Video Override states.
                         body = .styledText(runs.map { run in
                             AetherSubtitleCue.StyledRun(
                                 text: run.text,
                                 color: run.color.map {
                                     Color(red: Double($0.r) / 255, green: Double($0.g) / 255, blue: Double($0.b) / 255)
-                                }
+                                },
+                                isBold: run.isBold,
+                                isItalic: run.isItalic,
+                                isUnderlined: run.isUnderlined,
+                                isStruckThrough: run.isStruckThrough,
+                                fontName: run.fontName,
+                                fontSize: run.fontSize
                             )
                         })
                     case .image(let image):
                         body = .image(cgImage: image.cgImage, position: image.position)
                     }
+                    // Placement the source asked for (ASS \an / \pos), nil for
+                    // nearly every cue. Bitmap cues carry their own geometry
+                    // on the image, so placement is text-only upstream.
+                    let placement = cue.placement.map {
+                        AetherSubtitleCue.TextPlacement(alignment: $0.alignment, position: $0.position)
+                    }
                     return AetherSubtitleCue(
                         id: cue.id,
                         startTime: cue.startTime,
                         endTime: cue.endTime,
-                        body: body
+                        body: body,
+                        placement: placement
                     )
                 }
             }
@@ -249,6 +285,7 @@ final class AetherPlayer: PlayerProtocol {
                 avp?.isMuted = self.isMuted
                 self.currentAVPlayer = avp
                 self.observeTimeControlStatus(of: avp)
+                self.observeVideoSize(of: avp)
             }
             .store(in: &cancellables)
 
@@ -265,6 +302,37 @@ final class AetherPlayer: PlayerProtocol {
                 self?.subtitleTracks = tracks.map(Self.translateTrack)
             }
             .store(in: &cancellables)
+    }
+
+    /// Tracks `presentationSize` across item swaps. Observed in two hops
+    /// rather than through a `\.currentItem?.presentationSize` key path:
+    /// nested KVO through an optional chain is not reliably delivered, and a
+    /// missed update would leave the overlay measuring against a stale
+    /// aspect ratio for the whole session.
+    private func observeVideoSize(of player: AVPlayer?) {
+        videoSizeCancellable = nil
+        guard let player else {
+            videoItemCancellable = nil
+            videoSize = .zero
+            return
+        }
+        videoItemCancellable = player
+            .publisher(for: \.currentItem)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] item in
+                guard let self else { return }
+                guard let item else {
+                    self.videoSizeCancellable = nil
+                    return
+                }
+                self.videoSizeCancellable = item
+                    .publisher(for: \.presentationSize)
+                    // A zero size is the pre-ready placeholder; publishing it
+                    // would flip the overlay back to full-bounds mid-session.
+                    .filter { $0.width > 0 && $0.height > 0 }
+                    .receive(on: DispatchQueue.main)
+                    .sink { [weak self] size in self?.videoSize = size }
+            }
     }
 
     /// Watch the inner AVPlayer's transport directly. Replaced whenever the

--- a/Rivulet/Services/Plex/Playback/Subtitles/CaptionAppearance.swift
+++ b/Rivulet/Services/Plex/Playback/Subtitles/CaptionAppearance.swift
@@ -37,8 +37,16 @@ struct CaptionStyle: Equatable, @unchecked Sendable {
     /// Applied on top of the size Apple bases on the presentation (view) height.
     var fontScale: CGFloat
 
+    /// Video Override state for the character size — gates a cue's own
+    /// `fontSize` (ASS `\fs`, SRT `<font size=>`).
+    var allowsContentFontSize: Bool
+
     /// System caption font descriptor. `nil` falls back to the system sans font.
     var fontDescriptor: CTFontDescriptor?
+
+    /// Video Override state for the font — gates a cue's own `fontName` and
+    /// its bold / italic / underline / strikethrough.
+    var allowsContentFont: Bool
 
     /// Text edge (shadow/raised/etc.) style.
     var edge: Edge
@@ -67,7 +75,9 @@ struct CaptionStyle: Equatable, @unchecked Sendable {
         backgroundColor: .black,
         backgroundOpacity: 0.75,
         fontScale: 1.0,
+        allowsContentFontSize: true,
         fontDescriptor: nil,
+        allowsContentFont: true,
         edge: .dropShadow
     )
 
@@ -78,6 +88,8 @@ struct CaptionStyle: Equatable, @unchecked Sendable {
             && lhs.backgroundColor == rhs.backgroundColor
             && lhs.backgroundOpacity == rhs.backgroundOpacity
             && lhs.fontScale == rhs.fontScale
+            && lhs.allowsContentFontSize == rhs.allowsContentFontSize
+            && lhs.allowsContentFont == rhs.allowsContentFont
             && lhs.edge == rhs.edge
             && descriptorsEqual(lhs.fontDescriptor, rhs.fontDescriptor)
     }
@@ -100,9 +112,16 @@ enum CaptionAppearance {
     /// `MACaptionAppearanceGetRelativeCharacterSize` already returns the size as a
     /// multiplicative scale factor (≈1.0 at the default), NOT an offset — so it is
     /// used directly. A non-positive value means "unset"; treat that as 1.0.
+    ///
+    /// The bounds are a sanity net against a nonsense value, NOT a style
+    /// decision: they were 0.5...2.0, which silently compressed the ends of
+    /// the system's own range, so captions stopped tracking the Subtitles &
+    /// Captioning size setting at the extremes. Widened to cover anything
+    /// tvOS plausibly reports; the caption is still bounded in practice by
+    /// the overlay's own max width.
     static func fontScale(forRelativeSize relative: CGFloat) -> CGFloat {
         guard relative > 0 else { return 1.0 }
-        return min(max(relative, 0.5), 2.0)
+        return min(max(relative, 0.25), 4.0)
     }
 
     /// Reads the current system caption style from MediaAccessibility.
@@ -118,9 +137,17 @@ enum CaptionAppearance {
         // Read it straight after the COLOUR call — that read is the "Video
         // Override" state for text colour, and the opacity call below
         // immediately clobbers it.
+        // Each `allowsContent*` below is captured IMMEDIATELY after its own
+        // call, because every MediaAccessibility read overwrites `behavior`.
+        // They gate the content styling the engine now delivers (5.26.0:
+        // bold / italic / underline / strikethrough / font / size on
+        // SubtitleTextRun) the same way `allowsContentColor` has always gated
+        // colour: content wins only where the user allows it to.
+        func contentMayOverride() -> Bool { behavior == .useContentIfAvailable }
+
         let fgUnmanaged = MACaptionAppearanceCopyForegroundColor(.user, &behavior)
         let foreground = Color(fgUnmanaged.takeRetainedValue() as CGColor)
-        let allowsContentColor = (behavior == .useContentIfAvailable)
+        let allowsContentColor = contentMayOverride()
         let rawFgOpacity = Double(MACaptionAppearanceGetForegroundOpacity(.user, &behavior))
         let foregroundOpacity = rawFgOpacity > 0 ? min(rawFgOpacity, 1.0) : 1.0
 
@@ -140,11 +167,13 @@ enum CaptionAppearance {
 
         // Font scale
         let relative = MACaptionAppearanceGetRelativeCharacterSize(.user, &behavior)
+        let allowsContentFontSize = contentMayOverride()
         let scale = fontScale(forRelativeSize: relative)
 
         // Font (system caption font descriptor)
         let fontDescriptor = MACaptionAppearanceCopyFontDescriptorForStyle(.user, &behavior, .default)
             .takeRetainedValue()
+        let allowsContentFont = contentMayOverride()
 
         // Edge style
         let maEdge = MACaptionAppearanceGetTextEdgeStyle(.user, &behavior)
@@ -164,7 +193,9 @@ enum CaptionAppearance {
             backgroundColor: backgroundColor,
             backgroundOpacity: backgroundOpacity,
             fontScale: scale,
+            allowsContentFontSize: allowsContentFontSize,
             fontDescriptor: fontDescriptor,
+            allowsContentFont: allowsContentFont,
             edge: edge
         )
     }

--- a/Rivulet/Services/Plex/Playback/Subtitles/SubtitleOverlayView.swift
+++ b/Rivulet/Services/Plex/Playback/Subtitles/SubtitleOverlayView.swift
@@ -16,13 +16,13 @@ import UIKit
 struct SubtitleOverlayView: View {
     @ObservedObject var subtitleManager: SubtitleManager
 
-    /// Vertical offset from bottom (for player controls)
-    var bottomOffset: CGFloat = 100
+    /// True when the player rail is visible; lifts text clear of it.
+    var controlsVisible: Bool = false
 
-    /// User height adjustment from the OSD stepper (global; positive = higher).
-    /// Same key AetherSubtitleOverlayView reads, so both routes place captions
-    /// identically. @AppStorage so stepping it re-renders the overlay live.
-    @AppStorage(SubtitleAdjustments.heightKey) private var heightUnits: Int = 0
+
+    /// Height adjustment for THIS media, in stepper units. Pushed in by the
+    /// host, same as on AetherSubtitleOverlayView.
+    var heightUnits: Int = 0
 
     /// Current system caption appearance. Replaced wholesale when the user
     /// changes caption settings (via CaptionAppearance.changedNotification).
@@ -64,10 +64,22 @@ struct SubtitleOverlayView: View {
                             }
                         }
                         .padding(.horizontal, 60)
-                        .padding(.bottom, max(0, bottomOffset + SubtitleAdjustments.heightOffset(forUnits: heightUnits)))
+                        // Same floor AetherSubtitleOverlayView uses, so a
+                        // title falling back to the HLS route does not shift
+                        // its captions. This route has no picture rect of its
+                        // own — the transcode fills the view — so the bounds
+                        // stand in for the picture height.
+                        .padding(.bottom, max(0, (controlsVisible
+                                                  ? SubtitleAdjustments.controlsFloor(pictureHeight: geometry.size.height)
+                                                  : geometry.size.height * SubtitleAdjustments.bottomMarginFraction)
+                                                 + SubtitleAdjustments.heightOffset(forUnits: heightUnits)))
                     }
                 }
                 .frame(width: geometry.size.width, height: geometry.size.height)
+                // Same curve as the chrome's own fade and as
+                // AetherSubtitleOverlayView, so the lift looks identical
+                // whichever route a title took.
+                .animation(.easeInOut(duration: 0.25), value: controlsVisible)
             }
         }
         .allowsHitTesting(false)  // Don't interfere with player controls

--- a/Rivulet/Views/Components/WhatsNewView.swift
+++ b/Rivulet/Views/Components/WhatsNewView.swift
@@ -141,6 +141,11 @@ struct WhatsNewView: View {
 
     static let changelogs: [(version: String, features: [String])] = [
         ("1.0.4 (74)", [
+            "Subtitles now match the text size, background box and position Apple TV uses for its own captions",
+            "Subtitles keep the styling the content asked for, including bold, italic, underline, colour and size",
+            "Captions a broadcaster places away from the bottom of the picture now appear where they were put",
+            "Subtitles lift clear of the playback controls while they are showing and drop back when they hide",
+            "The subtitle height adjustment is now remembered per title and per channel, like the delay",
             "Marking an item as watched now updates the Play button instead of saying Resume",
             "Marking an item as watched now updates Home and Continue Watching right away",
             "Pausing now registers on your Plex server instead of showing as still playing",

--- a/Rivulet/Views/LiveTV/LiveTVAetherPlayerViewController.swift
+++ b/Rivulet/Views/LiveTV/LiveTVAetherPlayerViewController.swift
@@ -84,7 +84,7 @@ final class LiveTVAetherPlayerViewController: UIViewController {
     /// starts a fresh one so each attempt is measured separately.
     private var joinTelemetry: LiveJoinTelemetry?
 
-    // MARK: Subtitle delay (OSD stepper, sticky per channel)
+    // MARK: Subtitle delay and height (OSD steppers, sticky per channel)
 
     /// User subtitle delay for THIS channel. Engine-cue paths apply it through
     /// SubtitleModel.delaySeconds. The native-legible (remote WebVTT) path is
@@ -92,16 +92,59 @@ final class LiveTVAetherPlayerViewController: UIViewController {
     /// by scheduling the model update instead; a NEGATIVE delay can't pre-show
     /// cues that haven't arrived yet, so it's treated as 0 on that path.
     private var subtitleDelaySeconds: Double = 0
-    private var subtitleDelayKey: String { "live:\(channel.id)" }
+
+    /// This channel's height adjustment, in stepper units. Re-read on every
+    /// channel switch so a switch picks up the incoming channel's own value.
+    private var subtitleHeightUnits: Int = 0
+
+    private var subtitleMediaKey: String { "live:\(channel.id)" }
 
     // MARK: Native HLS legible subtitles (remote WebVTT renditions)
     //
-    // On the nativeRemoteHLS path the engine never demuxes, so its subtitle
-    // track list is empty — the stream's WebVTT renditions live in AVPlayer's
-    // legible media selection group instead. Selecting one isn't enough
-    // either: a bare AVPlayerLayer doesn't paint legible content (only AVKit
-    // does), so cues are pulled out through an AVPlayerItemLegibleOutput and
-    // drawn by the same overlay every other path uses.
+    // On the nativeRemoteHLS path the engine never demuxes: the stream's WebVTT
+    // renditions live in AVPlayer's legible media selection group, and it
+    // publishes no cues of its own. Selecting a rendition isn't enough either —
+    // a bare AVPlayerLayer doesn't paint legible content (only AVKit does), so
+    // cues are pulled out through an AVPlayerItemLegibleOutput and drawn by the
+    // same overlay every other path uses.
+    //
+    // The engine DOES publish that group as `subtitleTracks` (AE#154), so an
+    // empty engine track list no longer distinguishes this path from the demux
+    // one. Route detection lives below; do not reintroduce that test.
+    /// Whether this session took the `nativeRemoteHLS` bypass.
+    ///
+    /// AE#154 made the engine publish the bypass item's legible options as
+    /// `subtitleTracks`, so "the engine track list is empty" no longer
+    /// identifies the native route — it used to, and every branch keyed off it
+    /// silently started taking the demux path, handing subtitle selection to
+    /// the engine (and rendering to AVPlayer). Branch on the routing decision.
+    private var isNativeHLSRoute = false
+
+    /// True when AVPlayer is playing the REMOTE playlist itself, so its legible
+    /// renditions are ours to intercept and the engine has no cues of its own.
+    ///
+    /// Confirmed against the item's URL rather than trusting the routing
+    /// decision alone: the engine can move a bypass session onto the
+    /// live-ingest loopback mid-load (#168, a native mount that builds no video
+    /// track), after which it really is demuxing and really does publish cues.
+    /// It exposes no effective-route property to ask, but the loopback item is
+    /// served from its local HTTP server, which is plainly visible here.
+    private var isPlayingRemoteHLSDirectly: Bool {
+        guard isNativeHLSRoute, let item = aetherPlayer?.currentAVPlayer?.currentItem
+        else { return false }
+        return Self.isRemoteItem(item)
+    }
+
+    /// The loopback item is served by the engine's local HTTP server; a bypass
+    /// item points at the origin.
+    private static func isRemoteItem(_ item: AVPlayerItem) -> Bool {
+        guard let asset = item.asset as? AVURLAsset else { return false }
+        switch asset.url.host?.lowercased() {
+        case "127.0.0.1", "localhost", "::1", nil: return false
+        default: return true
+        }
+    }
+
     private var nativeLegibleGroup: AVMediaSelectionGroup?
     private var nativeLegibleOutput: AVPlayerItemLegibleOutput?
     private var nativeLegibleBridge: LegibleOutputBridge?
@@ -117,6 +160,11 @@ final class LiveTVAetherPlayerViewController: UIViewController {
     /// Deferred clear: roll-up streams emit an EMPTY legible event at every
     /// cue boundary, and clearing on the spot blinks the overlay between cues.
     private var nativeLegibleClearWorkItem: DispatchWorkItem?
+    /// Nested inside the `$currentAVPlayer` sink rather than stored in
+    /// `cancellables`, so it can be replaced when the player is swapped.
+    /// `startPlayback` builds a fresh `AetherPlayer` per session, so the outer
+    /// sink re-subscribes and re-establishes this on every channel switch.
+    private var nativeItemObservation: AnyCancellable?
 
     /// Push-delegate shim: `AVPlayerItemLegibleOutput.setDelegate` does not
     /// retain, so the VC holds this.
@@ -199,6 +247,9 @@ final class LiveTVAetherPlayerViewController: UIViewController {
         ])
         loadingSpinner.startAnimating()
 
+        // ORDER MATTERS: the overlay must be added BEFORE setupChrome, so the
+        // rail and progress bar sit in front of it and captions slide up
+        // behind the chrome rather than over it. Same z-order as VOD.
         mountSubtitleOverlay()
         observeCaptionAppearance()
         setupChrome()
@@ -215,13 +266,15 @@ final class LiveTVAetherPlayerViewController: UIViewController {
 
         // Sticky per-channel subtitle delay (OSD stepper). Re-read per channel:
         // the key is derived from the channel id.
-        subtitleDelaySeconds = SubtitleAdjustments.delay(forKey: subtitleDelayKey)
+        subtitleDelaySeconds = SubtitleAdjustments.delay(forKey: subtitleMediaKey)
+        subtitleHeightUnits = SubtitleAdjustments.heightUnits(forMediaKey: subtitleMediaKey)
         subtitleModel.delaySeconds = subtitleDelaySeconds
 
         let aether = AetherPlayer()
         aetherPlayer = aether
         aether.bind(view: engineSurfaceView)
         bindAetherSubtitles(aether)
+        bindNativeLegibleAttachment(aether)
 
         aether.playbackStatePublisher
             .receive(on: DispatchQueue.main)
@@ -266,10 +319,9 @@ final class LiveTVAetherPlayerViewController: UIViewController {
             // AVPlayer's native HLS path can't decode broadcast mp2 audio
             // or the DVB/teletext subtitles that direct play preserves.
             let forceEngineDemux = url.path.hasPrefix("/livetv/sessions/")
-            joinTelemetry?.resolveFinished(
-                url: url,
-                route: AetherPlayer.liveRoute(for: url, forceEngineDemux: forceEngineDemux)
-            )
+            let route = AetherPlayer.liveRoute(for: url, forceEngineDemux: forceEngineDemux)
+            isNativeHLSRoute = route == .nativeHLS
+            joinTelemetry?.resolveFinished(url: url, route: route)
             startLiveSessionKeepAlive(for: url)
             do {
                 try await aether.loadLive(
@@ -337,6 +389,8 @@ final class LiveTVAetherPlayerViewController: UIViewController {
         nativeLegibleBridge = nil
         nativeLegibleItem = nil
         nativeLegibleGroup = nil
+        isNativeHLSRoute = false
+        nativeItemObservation = nil
         resetNativeLegibleState()
         // Drop the outgoing channel's cues: on a switch the overlay would
         // otherwise keep painting them until the new session publishes.
@@ -457,7 +511,7 @@ final class LiveTVAetherPlayerViewController: UIViewController {
             self.progressBar.alpha = 1
             self.progressBar.transform = .identity
         }
-        rebuildSubtitleOverlay()
+        rebuildSubtitleOverlay(animated: true)
         setNeedsFocusUpdate()
         updateFocusIfNeeded()
         restartAutoHide()
@@ -475,7 +529,7 @@ final class LiveTVAetherPlayerViewController: UIViewController {
             self.progressBar.alpha = 0
             self.progressBar.transform = CGAffineTransform(translationX: 0, y: 24)
         }
-        rebuildSubtitleOverlay()
+        rebuildSubtitleOverlay(animated: true)
         setNeedsFocusUpdate()
         updateFocusIfNeeded()
     }
@@ -541,8 +595,11 @@ final class LiveTVAetherPlayerViewController: UIViewController {
     private func presentSubtitlePanel() {
         guard let aether = aetherPlayer else { return }
 
-        // Engine demux path: tracks come from the engine.
-        if !aether.subtitleTracks.isEmpty {
+        // Engine demux path: tracks come from the engine, and so do cues.
+        // Never taken on the bypass, where the engine's published tracks are
+        // AE#154 mirrors of AVPlayer's legible options and selecting one hands
+        // rendering to AVPlayerLayer instead of our overlay.
+        if !isPlayingRemoteHLSDirectly, !aether.subtitleTracks.isEmpty {
             let list = CardTrackListView(
                 header: "Subtitles",
                 tracks: aether.subtitleTracks,
@@ -665,6 +722,74 @@ final class LiveTVAetherPlayerViewController: UIViewController {
         }
     }
 
+    /// Attach the legible output to every native item, as soon as it exists.
+    ///
+    /// Two things this deliberately does NOT do, both of which broke it before:
+    ///
+    /// It does not run once after `loadLive` returns. `engine.load` returns
+    /// when the native host is mounted, several seconds before the item is
+    /// ready (device: `readyToPlay` at t+4.5s), so a one-shot attach races
+    /// AVFoundation's automatic selection and loses.
+    ///
+    /// It does not wait for a selection to exist, or adopt one.
+    /// `suppressesPlayerRendering` applies to whatever legible option is or
+    /// LATER BECOMES selected, so the output only has to be on the item before
+    /// the first cue is drawn. Gating on a current selection just reintroduced
+    /// the race. Automatic selection is left alone on purpose: it honours the
+    /// system captioning preference and the preferred languages `loadLive`
+    /// passes, and disabling it would mean nothing is ever selected at all.
+    private func bindNativeLegibleAttachment(_ aether: AetherPlayer) {
+        aether.$currentAVPlayer
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] player in
+                guard let self, let player else { return }
+                // Aether swaps the item under us (retune, #93 item-death
+                // revive), and each new item needs its own output.
+                self.nativeItemObservation = player.publisher(for: \.currentItem)
+                    .receive(on: DispatchQueue.main)
+                    .sink { [weak self] item in
+                        guard let self, let item else { return }
+                        self.attachNativeLegible(to: item)
+                    }
+            }
+            .store(in: &cancellables)
+    }
+
+    private func attachNativeLegible(to item: AVPlayerItem) {
+        guard isNativeHLSRoute, Self.isRemoteItem(item), nativeLegibleItem !== item else { return }
+
+        Task { @MainActor [weak self] in
+            // Nothing is attached until the item has loaded successfully, so
+            // this pipeline can never be the reason a stream fails to load.
+            // Cues do not start flowing until playback does, well after
+            // readiness, so there is nothing to miss by waiting.
+            guard await Self.itemBecameReady(item) else { return }
+            guard let self,
+                  self.isNativeHLSRoute,
+                  self.nativeLegibleItem !== item,
+                  item === self.aetherPlayer?.currentAVPlayer?.currentItem else { return }
+
+            self.ensureNativeLegibleOutput(on: item)
+            self.nativeLegibleActive = true
+
+            // Only needed so the subtitle panel can list and switch renditions.
+            // Cue delivery does not depend on it: the output is on the item and
+            // receives whatever automatic selection settles on.
+            guard let group = try? await item.asset.loadMediaSelectionGroup(for: .legible),
+                  !group.options.isEmpty, self.nativeLegibleItem === item else { return }
+            self.nativeLegibleGroup = group
+        }
+    }
+
+    /// Resolves true once `item` is playable, false if it fails first.
+    private static func itemBecameReady(_ item: AVPlayerItem) async -> Bool {
+        if item.status != .unknown { return item.status == .readyToPlay }
+        for await status in item.publisher(for: \.status).values where status != .unknown {
+            return status == .readyToPlay
+        }
+        return false
+    }
+
     private func resetNativeLegibleState() {
         nativeLegibleClearWorkItem?.cancel()
         nativeLegibleClearWorkItem = nil
@@ -744,7 +869,8 @@ final class LiveTVAetherPlayerViewController: UIViewController {
                 id: index,
                 startTime: 0,
                 endTime: .greatestFiniteMagnitude,
-                body: .styledText(line.runs)
+                body: .styledText(line.runs),
+                placement: line.placement
             )
         }
         applyNativeLegible(cues: cues)
@@ -778,9 +904,19 @@ final class LiveTVAetherPlayerViewController: UIViewController {
                 onStep: { [weak self] step in self?.adjustSubtitleDelay(bySteps: step) }),
             CardStepperConfig(
                 title: "Height",
-                value: { SubtitleAdjustments.formattedHeight(SubtitleAdjustments.heightUnits) },
-                onStep: { step in SubtitleAdjustments.setHeightUnits(SubtitleAdjustments.heightUnits + step) }),
+                value: { [weak self] in
+                    SubtitleAdjustments.formattedHeight(self?.subtitleHeightUnits ?? 0)
+                },
+                onStep: { [weak self] step in self?.adjustSubtitleHeight(bySteps: step) }),
         ]
+    }
+
+    /// Steps this channel's subtitle height, applies it live, and persists it.
+    private func adjustSubtitleHeight(bySteps steps: Int) {
+        SubtitleAdjustments.setHeightUnits(subtitleHeightUnits + steps,
+                                           forMediaKey: subtitleMediaKey)
+        subtitleHeightUnits = SubtitleAdjustments.heightUnits(forMediaKey: subtitleMediaKey)
+        rebuildSubtitleOverlay()
     }
 
     /// Steps this channel's subtitle delay, applies it live, and persists it.
@@ -788,24 +924,38 @@ final class LiveTVAetherPlayerViewController: UIViewController {
         let raw = subtitleDelaySeconds + Double(steps) * SubtitleAdjustments.delayStep
         subtitleDelaySeconds = SubtitleAdjustments.roundedDelay(raw)
         subtitleModel.delaySeconds = subtitleDelaySeconds
-        SubtitleAdjustments.setDelay(subtitleDelaySeconds, forKey: subtitleDelayKey)
+        SubtitleAdjustments.setDelay(subtitleDelaySeconds, forKey: subtitleMediaKey)
     }
 
-    /// One legible-output attributed string, split into content-coloured runs.
+    /// One legible-output attributed string: its styled runs plus the
+    /// placement the cue asked for.
     private struct StyledLine: Equatable {
         let runs: [AetherSubtitleCue.StyledRun]
+        var placement: AetherSubtitleCue.TextPlacement?
     }
 
-    /// Converts a legible-output attributed string into styled runs, keeping
-    /// only the content-specified foreground colour
-    /// (`kCMTextMarkupAttribute_ForegroundColorARGB`: [a, r, g, b] in 0...1,
-    /// present iff the WebVTT specified one thanks to `.sourceAndRulesOnly`).
+    /// Converts a legible-output attributed string into styled runs.
+    ///
+    /// This is the ONLY way styling reaches the overlay on the remote-HLS
+    /// path: the rendition belongs to AVPlayer, the engine never demuxes it,
+    /// so nothing arrives on `subtitleCues` and the 5.26.0 / 5.27.0 engine
+    /// styling does not apply here. AVFoundation does surface the full
+    /// text-markup set on the legible output, so the same attributes are
+    /// recovered from it instead — every one present iff the WebVTT actually
+    /// specified it, thanks to `.sourceAndRulesOnly`.
+    ///
     /// Whitespace-only strings return nil; edge whitespace is trimmed so
     /// placement matches the plain-text path.
     private static func styledLine(from attr: NSAttributedString) -> StyledLine? {
         guard !attr.string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
 
         let colorKey = NSAttributedString.Key(kCMTextMarkupAttribute_ForegroundColorARGB as String)
+        let boldKey = NSAttributedString.Key(kCMTextMarkupAttribute_BoldStyle as String)
+        let italicKey = NSAttributedString.Key(kCMTextMarkupAttribute_ItalicStyle as String)
+        let underlineKey = NSAttributedString.Key(kCMTextMarkupAttribute_UnderlineStyle as String)
+        let faceKey = NSAttributedString.Key(kCMTextMarkupAttribute_FontFamilyName as String)
+        let sizeKey = NSAttributedString.Key(kCMTextMarkupAttribute_RelativeFontSize as String)
+
         let ns = attr.string as NSString
         var runs: [AetherSubtitleCue.StyledRun] = []
         attr.enumerateAttributes(in: NSRange(location: 0, length: attr.length)) { attrs, range, _ in
@@ -818,7 +968,23 @@ final class LiveTVAetherPlayerViewController: UIViewController {
                               blue: argb[3].doubleValue,
                               opacity: argb[0].doubleValue)
             }
-            runs.append(AetherSubtitleCue.StyledRun(text: text, color: color))
+            // Relative size is a PERCENTAGE of the default cue size; the
+            // renderer wants ASS play-resolution points, so convert through
+            // the same nominal 16pt the engine's synthesised lines use.
+            var fontSize: Int?
+            if let percent = (attrs[sizeKey] as? NSNumber)?.doubleValue,
+               percent > 0, abs(percent - 100) > 0.5 {
+                fontSize = Int((percent / 100 * 16).rounded())
+            }
+            runs.append(AetherSubtitleCue.StyledRun(
+                text: text,
+                color: color,
+                isBold: (attrs[boldKey] as? NSNumber)?.boolValue ?? false,
+                isItalic: (attrs[italicKey] as? NSNumber)?.boolValue ?? false,
+                isUnderlined: (attrs[underlineKey] as? NSNumber)?.boolValue ?? false,
+                fontName: attrs[faceKey] as? String,
+                fontSize: fontSize
+            ))
         }
 
         if var first = runs.first {
@@ -832,7 +998,63 @@ final class LiveTVAetherPlayerViewController: UIViewController {
         runs.removeAll { $0.text.isEmpty }
         guard !runs.isEmpty else { return nil }
 
-        return StyledLine(runs: runs)
+        return StyledLine(runs: runs, placement: cuePlacement(from: attr))
+    }
+
+    /// The cue's own placement, from the cue-level markup attributes (uniform
+    /// across the string, so read at index 0).
+    ///
+    /// WebVTT `line` is a percentage down the frame and `position` a
+    /// percentage across; `align` gives the column. Mapped to the same ASS
+    /// numpad + normalized-anchor model the engine uses on its own demux
+    /// path, so the overlay places an engine cue and an AVPlayer cue the same
+    /// way. Anchored to the frame edge the line is nearer, matching how the
+    /// engine resolves it (AE 5.27.0) — the spec's default line alignment
+    /// pins the box top, which would hang a two-line cue off the bottom at
+    /// `line:90%`.
+    ///
+    /// nil when the cue asked for nothing, which is the common case and puts
+    /// it in the overlay's default band.
+    private static func cuePlacement(from attr: NSAttributedString) -> AetherSubtitleCue.TextPlacement? {
+        guard attr.length > 0 else { return nil }
+        let attrs = attr.attributes(at: 0, effectiveRange: nil)
+        let lineKey = NSAttributedString.Key(
+            kCMTextMarkupAttribute_OrthogonalLinePositionPercentageRelativeToWritingDirection as String)
+        let posKey = NSAttributedString.Key(
+            kCMTextMarkupAttribute_TextPositionPercentageRelativeToWritingDirection as String)
+        let alignKey = NSAttributedString.Key(kCMTextMarkupAttribute_Alignment as String)
+
+        let linePercent = (attrs[lineKey] as? NSNumber)?.doubleValue
+        let posPercent = (attrs[posKey] as? NSNumber)?.doubleValue
+        let alignment = attrs[alignKey] as? String
+        guard linePercent != nil || posPercent != nil || alignment != nil else { return nil }
+
+        // Column: 0 left, 1 centre, 2 right.
+        var col = 1
+        if let alignment {
+            if alignment == (kCMTextMarkupAlignmentType_Start as String)
+                || alignment == (kCMTextMarkupAlignmentType_Left as String) {
+                col = 0
+            } else if alignment == (kCMTextMarkupAlignmentType_End as String)
+                || alignment == (kCMTextMarkupAlignmentType_Right as String) {
+                col = 2
+            }
+        }
+
+        // Row: numpad 0 bottom, 1 middle, 2 top. Without a line the cue keeps
+        // only its column, so it stays in the default band horizontally
+        // placed — an anchor point needs both axes to mean anything.
+        guard let linePercent else {
+            return AetherSubtitleCue.TextPlacement(alignment: col + 1, position: nil)
+        }
+        let y = min(max(linePercent / 100, 0), 1)
+        let row = y < 0.34 ? 2 : (y < 0.67 ? 1 : 0)
+
+        let x = posPercent.map { min(max($0 / 100, 0), 1) } ?? 0.5
+        return AetherSubtitleCue.TextPlacement(
+            alignment: row * 3 + col + 1,
+            position: CGPoint(x: x, y: y)
+        )
     }
 
     /// The live counterpart of the VOD OSD's season list: every channel in
@@ -1078,8 +1300,19 @@ final class LiveTVAetherPlayerViewController: UIViewController {
         let hosting = UIHostingController(rootView: makeOverlayRootView())
         hosting.view.backgroundColor = .clear
         hosting.view.isUserInteractionEnabled = false
+        // The overlay measures every margin from the SCREEN (the rail is
+        // screen-anchored, and the picture is full-bleed). A hosting controller
+        // applies the safe area to its content by default, which on tvOS is the
+        // ~60pt title-safe margin, so the GeometryReader inside would report the
+        // inset box and every bottom margin would be that much too high — the
+        // rail gap measured about double its intended 5%. VOD's overlay avoids
+        // this with .ignoresSafeArea(); this is the hosting-controller
+        // equivalent, and keeps the rootView's type intact so the generic
+        // parameter above still matches.
+        hosting.safeAreaRegions = []
 
         addChild(hosting)
+        // Added here, below the chrome — see the call site in viewDidLoad.
         view.addSubview(hosting.view)
         hosting.view.frame = view.bounds
         hosting.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
@@ -1092,12 +1325,37 @@ final class LiveTVAetherPlayerViewController: UIViewController {
         AetherSubtitleOverlayView(
             model: subtitleModel,
             style: captionStyle,
-            controlsVisible: railVisible  // lift captions above the glass rail
+            controlsVisible: railVisible,  // lift captions above the glass rail
+            // Broadcast is usually 16:9, but a 4:3 or 2.39:1 channel gets its
+            // captions on the picture rather than in the pillar/letterbox.
+            videoSize: aetherPlayer?.videoSize ?? .zero,
+            // Height is sticky per channel, like the delay stepper.
+            heightUnits: subtitleHeightUnits
         )
     }
 
-    private func rebuildSubtitleOverlay() {
-        subtitleHostingController?.rootView = makeOverlayRootView()
+    /// Swaps the overlay's root view.
+    ///
+    /// `animated` is for the rail-driven lift ONLY. Replacing a hosting
+    /// controller's `rootView` is a UIKit-side assignment, not a SwiftUI
+    /// transaction, so the `.animation(value: controlsVisible)` inside the
+    /// overlay has nothing to attach to and the captions jump to their new
+    /// height instead of sliding. Wrapping the assignment supplies the
+    /// transaction. VOD needs none of this: there `controlsVisible` comes off
+    /// an @Published, so the change already happens inside SwiftUI.
+    ///
+    /// Content-driven rebuilds (a new video size, a caption-settings change)
+    /// stay instant — animating a caption's geometry because the user changed
+    /// their font size would be noise.
+    private func rebuildSubtitleOverlay(animated: Bool = false) {
+        guard let hosting = subtitleHostingController else { return }
+        guard animated else {
+            hosting.rootView = makeOverlayRootView()
+            return
+        }
+        withAnimation(.easeInOut(duration: 0.25)) {
+            hosting.rootView = makeOverlayRootView()
+        }
     }
 
     private func bindAetherSubtitles(_ aether: AetherPlayer) {
@@ -1106,11 +1364,21 @@ final class LiveTVAetherPlayerViewController: UIViewController {
             .sink { [weak self] cues in
                 guard let self else { return }
                 // While a native legible (remote WebVTT) selection drives the
-                // overlay, an empty engine publish must not wipe its cues —
-                // the engine track list is always empty on nativeRemoteHLS.
+                // overlay, an empty engine publish must not wipe its cues: the
+                // engine has no cues of its own on the bypass. Keyed off the
+                // publish being empty rather than the route, so a #168 reroute
+                // onto the loopback (where it really does demux) still lands.
                 if self.nativeLegibleActive && cues.isEmpty { return }
                 self.subtitleModel.update(cues: cues)
             }
+            .store(in: &cancellables)
+
+        // The overlay is a rebuilt-on-demand root view, so a videoSize change
+        // has to force a rebuild — nothing observes the player from SwiftUI.
+        aether.$videoSize
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.rebuildSubtitleOverlay() }
             .store(in: &cancellables)
 
         aether.$sourceTime

--- a/Rivulet/Views/Player/Aether/AetherSubtitleCue.swift
+++ b/Rivulet/Views/Player/Aether/AetherSubtitleCue.swift
@@ -26,6 +26,10 @@ struct AetherSubtitleCue: Identifiable {
     let startTime: Double
     let endTime: Double
     let body: Body
+    /// Content-specified placement, or nil to use the overlay's default band.
+    /// Defaulted so the Live TV legible bridge, which builds cues by hand
+    /// from AVPlayer's attributed strings, does not have to pass it.
+    var placement: TextPlacement? = nil
 
     /// Text dialogue, or a positioned bitmap (PGS / DVB / DVD).
     enum Body {
@@ -42,11 +46,45 @@ struct AetherSubtitleCue: Identifiable {
         case image(cgImage: CGImage, position: CGRect)
     }
 
-    /// One run of a styled text cue. `color` is nil when the content did not
-    /// specify one, in which case the renderer uses the system caption colour.
+    /// One run of a styled text cue, mirroring AetherEngine's
+    /// `SubtitleTextRun`. Every field is CONTENT-specified styling; nil /
+    /// false means the content was silent and the renderer uses the system
+    /// caption value. Whether a content value is painted at all is the
+    /// renderer's call, per attribute, against the matching
+    /// `CaptionStyle.allowsContent*` (the system "Video Override" states).
+    ///
+    /// The engine parses these out of the ASS event line libavcodec produces
+    /// for every text format, so SRT, WebVTT, teletext and ASS all arrive
+    /// here through one path (AE 5.26.0).
     struct StyledRun: Hashable {
         var text: String
         var color: Color?
+        var isBold: Bool = false
+        var isItalic: Bool = false
+        var isUnderlined: Bool = false
+        var isStruckThrough: Bool = false
+        /// Face the content asked for (ASS `\fn`, SRT `<font face=>`).
+        var fontName: String?
+        /// Size the content asked for (ASS `\fs`), in ASS play-resolution
+        /// points — a RELATIVE hint, not a pixel size, so the renderer scales
+        /// it against the script's nominal size rather than using it directly.
+        var fontSize: Int?
+    }
+
+    /// Placement the content asked for (ASS `\an` / `\pos`), mirroring
+    /// AetherEngine's `SubtitleTextPlacement`. nil for nearly every cue,
+    /// meaning the host places it in its usual band.
+    ///
+    /// There is NO system caption setting for position, so no Video Override
+    /// gate applies — a content position is always honoured, and the user's
+    /// Height stepper deliberately does not move it (a sign pinned to the top
+    /// of frame must not drift with an app-level offset).
+    struct TextPlacement: Hashable {
+        /// ASS numpad alignment: 1 bottom-left through 9 top-right, 5 centred.
+        var alignment: Int?
+        /// `\pos` anchor normalized to [0, 1] against the video frame, y from
+        /// the top — the same convention `SubtitleImage.position` uses.
+        var position: CGPoint?
     }
 
     /// Stable content identity: `(startTime, endTime, body)`.
@@ -62,7 +100,7 @@ struct AetherSubtitleCue: Identifiable {
     /// (identical start + end + body) while keeping genuine simultaneous
     /// speakers (identical start, DIFFERENT text) distinct.
     var contentKey: ContentKey {
-        ContentKey(startTime: startTime, endTime: endTime, body: body)
+        ContentKey(startTime: startTime, endTime: endTime, body: body, placement: placement)
     }
 
     /// Hashable projection of a cue's content.
@@ -83,10 +121,12 @@ struct AetherSubtitleCue: Identifiable {
         let startTime: Double
         let endTime: Double
         let body: BodyKey
+        let placement: TextPlacement?
 
-        init(startTime: Double, endTime: Double, body: Body) {
+        init(startTime: Double, endTime: Double, body: Body, placement: TextPlacement?) {
             self.startTime = startTime
             self.endTime = endTime
+            self.placement = placement
             switch body {
             case .text(let string):
                 self.body = .text(string)

--- a/Rivulet/Views/Player/Aether/AetherSubtitleOverlayView.swift
+++ b/Rivulet/Views/Player/Aether/AetherSubtitleOverlayView.swift
@@ -9,12 +9,29 @@
 //  Mounted in UniversalPlayerView above the video surface, below the
 //  UIKit transport bar hosted by PlayerContainerViewController.
 //
-//  controlsVisible insets (matched to SubtitleOverlayView on the AVPlayer
-//  routes, so subtitles sit at the same height on every route):
-//    true  -> 368 pt bottom padding (rail bottom inset 84 + railHeight 260
-//             + 24 gap; clears the 3a glass rail)
-//    false -> 100 pt bottom padding (same resting height as the AVPlayer
-//             route's SubtitleOverlayView, mirroring native caption placement)
+//  Sizing and placement mirror AVPlayer's own caption rendering:
+//    - point size = a fraction of the PRESENTATION height x the system's
+//      relative-character-size multiplier
+//    - the resting bottom margin is a fraction of the PICTURE height, so a
+//      letterboxed film is captioned on the image, not in its black bar
+//    - with the rail up, the same margin is measured off the rail's top edge
+//      (344 pt) instead, so the caption keeps its distance either way; shared
+//      with the HLS-route overlay via SubtitleAdjustments so the routes agree
+//
+//  That margin is a FLOOR every cue obeys (`placementFloor`), including one
+//  that positioned itself: a cue placed into the rail is lifted clear of it.
+//  There is a matching no-go zone at each side (`sideSafeFraction`), because
+//  AVPlayer will not draw to the picture edge either.
+//
+//  Within those, a cue that gave an exact position keeps it. Vertically the
+//  position names the box's TOP edge (WebVTT's default `line-align: start`),
+//  so the box hangs down from it, which is where AVPlayer draws it.
+//  Horizontally the box is centred on the position. A cue that gave only a
+//  coarse band (teletext) takes that band's resting anchor instead.
+//
+//  Only the user's Height stepper is placement-exempt.
+//
+//  See the Metrics block below for the derivations.
 //
 
 import SwiftUI
@@ -31,21 +48,164 @@ struct AetherSubtitleOverlayView: View {
     /// True when the player rail is visible; lifts text above it.
     var controlsVisible: Bool
 
-    // Bottom padding constants (pts). controlsVisiblePadding =
-    // PlayerRailView.railHeight (260) + rail bottom inset (84) + 24 gap.
-    // defaultPadding matches SubtitleOverlayView's resting bottomOffset (100)
-    // on the AVPlayer route, which mirrors native AVPlayer caption placement —
-    // 60 sat visibly too close to the screen edge.
-    private static let controlsVisiblePadding: CGFloat = 368
-    private static let defaultPadding: CGFloat = 100
+    /// The video's presentation size (`AetherPlayer.videoSize`). `.zero` means
+    /// "unknown" — the overlay then measures against its full bounds, which is
+    /// the pre-existing behaviour and correct for a 16:9 picture filling the
+    /// screen.
+    var videoSize: CGSize = .zero
 
-    /// User height adjustment from the OSD stepper (global; positive = higher).
-    /// Read as @AppStorage so stepping it re-renders the overlay live.
-    @AppStorage(SubtitleAdjustments.heightKey) private var heightUnits: Int = 0
+    /// Height adjustment for THIS media, in stepper units. Sticky per title /
+    /// channel like the delay stepper and defaulting to 0.
+    ///
+    /// Pushed in by the host rather than read from defaults here: the key
+    /// changes under a channel switch or a next-episode swap while the view
+    /// keeps its identity, and re-binding a dynamic-key `@AppStorage` across
+    /// that is not something to rely on.
+    var heightUnits: Int = 0
 
-    private var bottomPadding: CGFloat {
-        let base = controlsVisible ? Self.controlsVisiblePadding : Self.defaultPadding
-        return max(0, base + SubtitleAdjustments.heightOffset(forUnits: heightUnits))
+    // MARK: Apple-matching caption metrics
+    //
+    // Tuned against AVPlayer's own caption rendering (screenshot comparison at
+    // the smallest system caption size). Three differences mattered: Apple
+    // sizes type from the VIDEO height rather than a fixed point size, boxes
+    // the text tightly, and draws one background per LINE rather than one
+    // around the whole cue.
+
+    /// Caption point size as a fraction of the PRESENTATION height (the
+    /// player's own bounds), before the user's relative-size multiplier.
+    ///
+    /// The model is: base fraction × the system's own multiplier. The WebVTT
+    /// caption spec default is 5% (`5vh`); this sits near it, tuned on device
+    /// against AVPlayer's own rendering — at the smallest system caption size
+    /// `MACaptionAppearanceGetRelativeCharacterSize` reports 0.35, and
+    /// 1080 × 0.0529 × 0.35 = 20pt is the match. Every other size follows
+    /// from the multiplier.
+    ///
+    /// Do NOT re-tune this to compensate for a size problem: if captions are
+    /// the wrong size, suspect the multiplier reaching us instead (see
+    /// `CaptionAppearance.fontScale`, whose clamp used to swallow 0.35 and
+    /// silently flatten the bottom of the range).
+    ///
+    /// Deliberately NOT the letterboxed picture height: Apple sizes captions
+    /// from the presentation and only *positions* them against the picture,
+    /// so a 2.39:1 film gets the same type as a 16:9 one rather than shrunken
+    /// type. tvOS always presents 1080 points tall regardless of whether the
+    /// display is 1080p or 4K, so this is stable across outputs.
+    private static let fontHeightFraction: CGFloat = 0.0529
+
+    /// Fallback presentation height, for the degenerate case of a zero-height
+    /// layout pass.
+    private static let assumedVideoHeight: CGFloat = 1080
+
+    // Box geometry is expressed as MULTIPLES OF THE POINT SIZE, not fixed
+    // points, because Apple's caption box grows with the type — a fixed radius
+    // reads as a hard rectangle against much bigger glyphs at a large caption
+    // size, and as an over-rounded pill at a small one.
+    //
+    // Radius is tuned by eye against AVPlayer: 0.25 gives 5pt at the smallest
+    // setting (20pt type), against the 8pt fixed radius this replaced. The
+    // padding ratios are deliberately NOT tied to it — they set how tightly the
+    // box hugs the text, which is already matched, so change one without the
+    // other.
+    private static let cornerRadiusRatio: CGFloat = 0.25
+    private static let paddingHRatio: CGFloat = 0.30
+    private static let paddingVRatio: CGFloat = 0.075
+
+    /// Extra leading between the lines of one cue, on top of the font's own
+    /// line height. Zero matches Apple, whose caption lines sit on natural
+    /// leading inside a single background.
+    private static let textLineSpacing: CGFloat = 0
+
+    /// Gap between separate simultaneous cues (two speakers), which SHOULD
+    /// read as distinct blocks.
+    private static let cueSpacing: CGFloat = 4
+
+    /// Where a TOP-band cue lands when its source gave only a coarse band and
+    /// no fine position — teletext through the engine demux, which quantises
+    /// the 24-row grid to three bands and supplies no percentage.
+    ///
+    /// Free to tune, because nothing measurable pins it: the source genuinely
+    /// does not say where in the top third the caption belongs. Set near where
+    /// the same page's proxied WebVTT resolves (it carries an exact `line:`,
+    /// typically around 10%), so the two routes look similar even though only
+    /// one of them can be precise. The bottom band needs no equivalent — it
+    /// rests on the shared floor, which already matched.
+    private static let bandTopFraction: CGFloat = 0.10
+
+    /// Anchor for a LEFT or RIGHT column that came with no fine position —
+    /// teletext through the engine demux, which gives `\anN` but no percentage.
+    ///
+    /// Deliberately the same 10% / 90% the proxy writes into its WebVTT
+    /// (`align:left position:10%`), so the same page lands in the same place
+    /// whichever route it arrived by. Anchoring rather than edge-aligning also
+    /// keeps a short caption off the very edge: the box centres on 10% and is
+    /// then clamped into the safe zone, instead of hugging it.
+    private static let bandSideFraction: CGFloat = 0.10
+
+    /// Horizontal no-go zone at each edge of the PICTURE, as a fraction of its
+    /// width. AVPlayer will not draw a caption to the very edge — it keeps one
+    /// inside a safe inset, the same idea as tvOS's title-safe area — so a cue
+    /// positioned near the side sat visibly closer to the edge for us than for
+    /// AVPlayer until this existed. Matches the 90pt the player chrome insets
+    /// itself by at 1920 wide.
+    private static let sideSafeFraction: CGFloat = 0.05
+
+    /// Nominal ASS font size that a cue's `\fs` is judged against. libavcodec
+    /// synthesises its ASS lines at a 384x288 play resolution whose default
+    /// style is 16pt, so `\fs32` means "twice normal", not "32 points".
+    private static let assNominalFontSize: CGFloat = 16
+
+    /// The picture's rect inside `bounds`, aspect-fit (how both the engine
+    /// surface and AVPlayerLayer place video). Falls back to the full bounds
+    /// when the size is unknown.
+    private func videoRect(in bounds: CGSize) -> CGRect {
+        guard videoSize.width > 0, videoSize.height > 0,
+              bounds.width > 0, bounds.height > 0 else {
+            return CGRect(origin: .zero, size: bounds)
+        }
+        let scale = min(bounds.width / videoSize.width, bounds.height / videoSize.height)
+        let w = videoSize.width * scale
+        let h = videoSize.height * scale
+        return CGRect(x: (bounds.width - w) / 2, y: (bounds.height - h) / 2, width: w, height: h)
+    }
+
+    /// The lowest any caption may sit, as a distance from the bottom of the
+    /// CONTAINER. EVERY cue obeys this, placed or not.
+    ///
+    /// Two anchors compete and the larger wins: the caption must sit
+    /// `SubtitleAdjustments.bottomMarginFraction` of the PICTURE above its
+    /// bottom edge (so letterboxed
+    /// content is not captioned into its black bar), and it must clear the
+    /// rail when the rail is up (which is anchored to the SCREEN). Taking the
+    /// max means a 2.39:1 film with the rail hidden lifts by its letterbox,
+    /// while the same film with the rail up still clears the chrome.
+    ///
+    /// Placed cues obey it too — Live TV is almost entirely placed cues, and
+    /// exempting them is what made its captions sit lower than VOD's. It is a
+    /// floor only: a cue asking to sit higher keeps its own position.
+    private func placementFloor(in bounds: CGSize) -> CGFloat {
+        let rect = videoRect(in: bounds)
+        let letterbox = max(0, bounds.height - rect.maxY)
+        var base = letterbox + rect.height * SubtitleAdjustments.bottomMarginFraction
+        if controlsVisible {
+            // Same margin, measured off the rail's top edge instead of the
+            // picture's bottom, so the caption keeps its distance either way.
+            base = max(base, SubtitleAdjustments.controlsFloor(pictureHeight: rect.height))
+        }
+        return base
+    }
+
+    /// Distance from the bottom of the CONTAINER to an UNPLACED cue: the
+    /// shared floor plus the user's Height stepper, which applies to the
+    /// default band only.
+    private func bottomPadding(in bounds: CGSize) -> CGFloat {
+        max(0, placementFloor(in: bounds) + SubtitleAdjustments.heightOffset(forUnits: heightUnits))
+    }
+
+    /// Caption point size for this presentation, before per-cue styling.
+    private func baseFontSize(in bounds: CGSize) -> CGFloat {
+        let height = bounds.height > 0 ? bounds.height : Self.assumedVideoHeight
+        return height * Self.fontHeightFraction * style.fontScale
     }
 
     var body: some View {
@@ -73,14 +233,40 @@ struct AetherSubtitleOverlayView: View {
                 // padding hangs invisibly off the bottom edge, so the inset
                 // never lifted the text at all (subs sat glued to the edge and
                 // the rail lift was a no-op).
-                VStack(spacing: 4) {
-                    ForEach(model.activeCues.filter(\.isText), id: \.contentKey) { cue in
+                // Unpositioned text cues: the default bottom band, and the
+                // ONLY place the user's Height adjustment applies.
+                VStack(spacing: Self.cueSpacing) {
+                    ForEach(model.activeCues.filter { $0.isText && $0.placement == nil },
+                            id: \.contentKey) { cue in
                         styledText(cue.body, size: geo.size)
                     }
                 }
-                .padding(.bottom, bottomPadding)
+                .padding(.bottom, bottomPadding(in: geo.size))
                 .frame(width: geo.size.width, height: geo.size.height, alignment: .bottom)
+
+                // Cues the SOURCE placed (ASS \an / \pos — signs, top-of-frame
+                // captions the broadcaster moved off on-screen graphics).
+                // Positioned against the picture, and deliberately exempt from
+                // the Height stepper: an authored position must not drift with
+                // an app-level offset.
+                ForEach(model.activeCues.filter { $0.isText && $0.placement != nil },
+                        id: \.contentKey) { cue in
+                    if let placement = cue.placement {
+                        placedCue(cue.body, placement: placement, size: geo.size)
+                    }
+                }
             }
+            // Both bands move only when the rail appears or dismisses, so the
+            // lift reads as the captions sliding out of the chrome's way
+            // rather than snapping. Cues the rail never covered are unaffected
+            // by definition — their geometry doesn't change.
+            //
+            // Matches the chrome's own fade: `UIView.animate(withDuration:)`
+            // with no options is a 0.25s ease-in-out, so the caption travels
+            // on exactly the curve the rail arrives on. Keep these in step —
+            // PlayerContainerViewController.applyChromeVisibility and the Live
+            // TV showRail/hideRail pair are the other half.
+            .animation(.easeInOut(duration: 0.25), value: controlsVisible)
         }
         .allowsHitTesting(false)
     }
@@ -89,10 +275,19 @@ struct AetherSubtitleOverlayView: View {
 
     @ViewBuilder
     private func bitmapCue(cgImage: CGImage, position: CGRect, size: CGSize) -> some View {
-        let frameW = position.width  * size.width
-        let frameH = position.height * size.height
-        let originX = position.minX  * size.width
-        let originY = position.minY  * size.height
+        // `SubtitleImage.position` is normalized against the SOURCE VIDEO
+        // FRAME, not the player's bounds — upstream is explicit that a host
+        // maps it onto the on-screen video rect, and `SubtitleTextPlacement`
+        // shares the convention (AE #233). Multiplying by the full bounds
+        // put PGS/DVB cues wrong on anything letterboxed: a 2.39:1 film
+        // stretched them vertically and pushed them toward the black bar.
+        // Falls back to the full bounds when the video size is unknown,
+        // which is what the old behaviour assumed anyway.
+        let rect = videoRect(in: size)
+        let frameW = position.width  * rect.width
+        let frameH = position.height * rect.height
+        let originX = rect.minX + position.minX * rect.width
+        let originY = rect.minY + position.minY * rect.height
 
         Image(decorative: cgImage, scale: 1, orientation: .up)
             .resizable()
@@ -103,29 +298,23 @@ struct AetherSubtitleOverlayView: View {
 
     // MARK: - Text cue
 
+    /// One cue in ONE rounded box, sized to its longest line.
+    ///
+    /// A multi-line cue keeps its author's line breaks and stays inside a
+    /// single background — the box hugs the widest line and the shorter lines
+    /// centre within it. (An earlier attempt boxed each line separately; that
+    /// reads as detached labels rather than one caption.)
     @ViewBuilder
-    private func styledText(_ body: AetherSubtitleCue.Body, size: CGSize) -> some View {
-        let maxWidth = max(0, size.width - 240)
-        // System conformance: the user's chosen caption font (via the
-        // MediaAccessibility font descriptor) and text opacity apply, not
-        // just color/size/edge. Base size 42 matches SubtitleOverlayView on
-        // the HLS route so captions render identically across routes.
-        let baseFont = style.font(ofSize: 42 * style.fontScale)
+    private func styledText(_ body: AetherSubtitleCue.Body,
+                            size: CGSize,
+                            widthLimit: CGFloat? = nil) -> some View {
+        // `widthLimit` only ever NARROWS the default: a cue placed off-centre
+        // has less room before it runs off the picture than one in the middle.
+        let maxWidth = min(widthLimit ?? .greatestFiniteMagnitude, max(0, size.width - 240))
+        let pointSize = baseFontSize(in: size)
+        let baseFont = style.font(ofSize: pointSize)
 
         switch style.edge {
-        case .dropShadow:
-            cueText(body)
-                .font(baseFont)
-                .multilineTextAlignment(.center)
-                .shadow(color: .black.opacity(0.85), radius: 3, x: 0, y: 1)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 4)
-                .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(style.backgroundColor.opacity(style.backgroundOpacity))
-                )
-                .frame(maxWidth: maxWidth)
-
         case .uniform:
             // 8-direction black outline (no per-character stroke on tvOS).
             let offsets: [(CGFloat, CGFloat)] = [
@@ -135,33 +324,154 @@ struct AetherSubtitleOverlayView: View {
             ]
             ZStack {
                 ForEach(Array(offsets.enumerated()), id: \.offset) { _, delta in
-                    // Outline layers are always solid black, so they use the
-                    // flattened text rather than the per-run colours.
-                    Text(body.plainText)
+                    // Outline layers are always solid black, but keep the
+                    // per-run fonts so the outline tracks styled glyphs.
+                    cueText(body, baseSize: pointSize, forcedColor: .black)
                         .font(baseFont)
-                        .foregroundStyle(Color.black)
                         .multilineTextAlignment(.center)
+                        .lineSpacing(Self.textLineSpacing)
                         .offset(x: delta.0, y: delta.1)
                 }
-                cueText(body)
+                cueText(body, baseSize: pointSize)
                     .font(baseFont)
                     .multilineTextAlignment(.center)
+                    .lineSpacing(Self.textLineSpacing)
             }
             .frame(maxWidth: maxWidth)
 
+        case .dropShadow:
+            boxed(cueText(body, baseSize: pointSize).font(baseFont),
+                  maxWidth: maxWidth, fontSize: pointSize)
+                .shadow(color: .black.opacity(0.85), radius: 3, x: 0, y: 1)
+
         default:
             // .none / .raised / .depressed: solid background box.
-            cueText(body)
-                .font(baseFont)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 4)
-                .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(style.backgroundColor.opacity(style.backgroundOpacity))
-                )
-                .frame(maxWidth: maxWidth)
+            boxed(cueText(body, baseSize: pointSize).font(baseFont),
+                  maxWidth: maxWidth, fontSize: pointSize)
         }
+    }
+
+    /// A cue the source positioned itself, placed against the PICTURE (so a
+    /// letterboxed film's signs land on the image, not in the black bar).
+    ///
+    /// Two kinds of placement arrive here and they are resolved differently:
+    ///
+    /// **With a fine position** (proxied WebVTT `line:` / `position:`, ASS
+    /// `\pos`) the cue is anchored by its CENTRE on that point. That is what
+    /// `kCMTextMarkupAttribute_OrthogonalLinePositionPercentage…` means — a
+    /// percentage locating the centre of the text — so anchoring the same way
+    /// puts a WebVTT cue exactly where AVPlayer draws it. An earlier version
+    /// pinned the box's bottom edge at `1 - line`, which sat roughly half a box
+    /// too high on multi-line cues.
+    ///
+    /// **Without one** (teletext through the engine demux, which quantises the
+    /// grid row to a coarse `\an` and supplies no percentage) the numpad band
+    /// is all there is, so the cue takes that band's natural resting place:
+    /// the shared floor at the bottom, the matching margin at the top, dead
+    /// centre in the middle. It cannot be as precise as the WebVTT case, but it
+    /// lands somewhere captions belong instead of hard against an edge.
+    private func placedCue(_ body: AetherSubtitleCue.Body,
+                           placement: AetherSubtitleCue.TextPlacement,
+                           size: CGSize) -> some View {
+        let rect = videoRect(in: size)
+        // Numpad: rows 7-9 top, 4-6 middle, 1-3 bottom; columns 1/4/7 left,
+        // 2/5/8 centre, 3/6/9 right. 2 (bottom-centre) is the ASS default.
+        let an = placement.alignment ?? 2
+        let col = (an - 1) % 3
+        let row = (an - 1) / 3
+
+        // Clamped so a wild coordinate cannot push a caption off screen.
+        let ax = placement.position.map { min(max($0.x, 0), 1) }
+        let ay = placement.position.map { min(max($0.y, 0), 1) }
+
+        let letterbox = max(0, size.height - rect.maxY)
+        let floor = placementFloor(in: size)
+
+        // Vertical. A fine position wins; the band is the fallback.
+        let vertical: VerticalAlignment = ay != nil ? .center
+            : (row == 2 ? .top : row == 1 ? .center : .bottom)
+        let topInset: CGFloat = (ay == nil && row == 2) ? rect.height * Self.bandTopFraction : 0
+        let bottomInset: CGFloat = (ay == nil && row == 0) ? max(0, floor - letterbox) : 0
+
+        // Centre offset, positive downward.
+        //
+        // The line position names the box's TOP edge, not its centre: WebVTT's
+        // default `line-align` is `start`, so the box hangs DOWN from the
+        // stated line, and AVPlayer draws it there. Anchoring the centre on it
+        // instead sits half a box high — visible as our captions reading a
+        // touch above AVPlayer's on the same stream.
+        //
+        // The box cannot be measured without a layout pass, so half of it is
+        // estimated as a one-line box (line height plus vertical padding). A
+        // taller cue therefore sits slightly high rather than slightly low,
+        // which is the safer way to be wrong.
+        //
+        // The same half-box keeps the floor clamp honest: the lowest the
+        // centre may sit is the floor plus half a box, so the clamp protects
+        // the TEXT rather than just its midpoint.
+        var dy: CGFloat = 0
+        if let ay {
+            let halfBox = baseFontSize(in: size) * 0.7
+            let lowestCentre = max(0, floor - letterbox) + halfBox
+            let requestedCentre = (1 - ay) * rect.height - halfBox
+            dy = rect.height / 2 - max(requestedCentre, lowestCentre)
+        }
+
+        // Horizontal. A column with no fine position (teletext) borrows the
+        // anchor the proxy writes for that column, so both routes resolve
+        // through the identical maths below and land together.
+        let anchorX: CGFloat? = ax
+            ?? (col == 0 ? Self.bandSideFraction
+                : col == 2 ? 1 - Self.bandSideFraction : nil)
+
+        // Everything stays inside the safe inset at each edge.
+        let sideSafe = rect.width * Self.sideSafeFraction
+        let usable = max(0, rect.width - sideSafe * 2)
+        // Smallest half-width worth wrapping into, so a cue anchored near an
+        // edge is nudged inward rather than squeezed to a column one word wide.
+        let minHalf = usable * 0.15
+
+        // Every placed cue is centred on its anchor; the clamp keeps the box
+        // inside the safe region, and the width follows the placement or a cue
+        // pushed to one side keeps wrapping at the full picture width and
+        // overhangs it.
+        var dx: CGFloat = 0
+        var widthLimit: CGFloat?
+        if let anchorX {
+            let lo = sideSafe + minHalf
+            let hi = max(lo, rect.width - sideSafe - minHalf)
+            let centre = min(max(anchorX * rect.width, lo), hi)
+            let half = max(minHalf, min(centre - sideSafe, rect.width - sideSafe - centre))
+            dx = centre - rect.width / 2
+            widthLimit = half * 2
+        }
+
+        return styledText(body, size: size, widthLimit: widthLimit)
+            .padding(.top, topInset)
+            .padding(.bottom, bottomInset)
+            .frame(width: rect.width, height: rect.height,
+                   alignment: Alignment(horizontal: .center, vertical: vertical))
+            .offset(x: rect.minX + dx, y: rect.minY + dy)
+    }
+
+    /// The tight background box Apple draws behind a caption, with padding and
+    /// radius proportional to `fontSize`.
+    private func boxed(_ text: some View, maxWidth: CGFloat, fontSize: CGFloat) -> some View {
+        text
+            .multilineTextAlignment(.center)
+            .lineSpacing(Self.textLineSpacing)
+            .padding(.horizontal, fontSize * Self.paddingHRatio)
+            .padding(.vertical, fontSize * Self.paddingVRatio)
+            .background(
+                RoundedRectangle(cornerRadius: fontSize * Self.cornerRadiusRatio, style: .continuous)
+                    .fill(style.backgroundColor.opacity(style.backgroundOpacity))
+            )
+            // Centring here is correct ONLY because every placed cue is
+            // anchored by its centre and offset into position. `.frame(maxWidth:)`
+            // expands to whatever the parent proposes and centres its child in
+            // that width, so any future edge-aligned path must pass an explicit
+            // alignment or it will silently land in the middle of the picture.
+            .frame(maxWidth: maxWidth)
     }
 
     /// Builds the cue's `Text`, applying the colour policy per run:
@@ -169,24 +479,85 @@ struct AetherSubtitleOverlayView: View {
     ///    content-specified colour wins; runs without one get the user colour.
     ///  - Video Override OFF: every run renders in the user's colour.
     /// The system foreground opacity applies either way.
-    private func cueText(_ body: AetherSubtitleCue.Body) -> Text {
+    /// Builds the cue's `Text`, applying each content attribute only where
+    /// the matching system Video Override allows it:
+    ///  - colour                → `allowsContentColor`
+    ///  - bold/italic/underline/strikethrough, font face → `allowsContentFont`
+    ///  - relative size         → `allowsContentFontSize`
+    /// A gated-off or content-silent attribute renders the system value. The
+    /// system foreground opacity applies either way.
+    ///
+    /// `forcedColor` repaints every run in one colour while KEEPING per-run
+    /// fonts, so the uniform-edge outline layers track styled glyph metrics
+    /// instead of misaligning under a bold or resized run.
+    private func cueText(_ body: AetherSubtitleCue.Body,
+                         baseSize: CGFloat,
+                         forcedColor: Color? = nil) -> Text {
         let userColor = style.foreground.opacity(style.foregroundOpacity)
         switch body {
         case .text(let string):
-            return Text(string).foregroundStyle(userColor)
+            return Text(string).foregroundStyle(forcedColor ?? userColor)
         case .styledText(let runs):
             return runs.reduce(Text(verbatim: "")) { acc, run in
-                let color: Color
-                if style.allowsContentColor, let contentColor = run.color {
-                    color = contentColor.opacity(style.foregroundOpacity)
-                } else {
-                    color = userColor
+                var piece = Text(run.text)
+
+                let contentColor = style.allowsContentColor ? run.color : nil
+                piece = piece.foregroundStyle(
+                    forcedColor ?? contentColor?.opacity(style.foregroundOpacity) ?? userColor)
+
+                // A run's own font only replaces the system caption font when
+                // it actually asks for something; otherwise the outer .font()
+                // modifier applies and the user's face is preserved.
+                if let font = runFont(for: run, baseSize: baseSize) {
+                    piece = piece.font(font)
                 }
-                return acc + Text(run.text).foregroundStyle(color)
+                if style.allowsContentFont {
+                    if run.isUnderlined { piece = piece.underline() }
+                    if run.isStruckThrough { piece = piece.strikethrough() }
+                }
+                return acc + piece
             }
         case .image:
             return Text(verbatim: "")
         }
+    }
+
+    /// The font for one run, or nil when the content asked for nothing and
+    /// the view-level caption font should apply unchanged.
+    private func runFont(for run: AetherSubtitleCue.StyledRun, baseSize: CGFloat) -> Font? {
+        let wantsFace = style.allowsContentFont && (run.isBold || run.isItalic || run.fontName != nil)
+        let scale = contentSizeScale(for: run)
+        guard wantsFace || scale != nil else { return nil }
+
+        let size = baseSize * (scale ?? 1)
+        // A content font FACE is honoured by name; an unknown name falls back
+        // to the system caption font at the same size rather than to a
+        // default that would ignore the user's choice entirely.
+        var font: Font
+        if style.allowsContentFont, let name = run.fontName, !name.isEmpty {
+            font = .custom(name, fixedSize: size)
+        } else {
+            font = style.font(ofSize: size)
+        }
+        if style.allowsContentFont {
+            if run.isBold { font = font.bold() }
+            if run.isItalic { font = font.italic() }
+        }
+        return font
+    }
+
+    /// A run's `\fs` as a multiplier, or nil when it asks for nothing.
+    ///
+    /// `fontSize` is in ASS play-resolution points, so it is meaningful only
+    /// RELATIVE to the script's nominal size — libavcodec's synthesised lines
+    /// use a 384x288 play resolution whose default style is 16pt. Treating it
+    /// as a point size directly would make a `\fs20` line tiny. Clamped so a
+    /// wild value cannot fill the screen.
+    private func contentSizeScale(for run: AetherSubtitleCue.StyledRun) -> CGFloat? {
+        guard style.allowsContentFontSize, let size = run.fontSize, size > 0 else { return nil }
+        let ratio = CGFloat(size) / Self.assNominalFontSize
+        guard abs(ratio - 1) > 0.01 else { return nil }
+        return min(max(ratio, 0.5), 2.0)
     }
 }
 
@@ -205,14 +576,3 @@ private extension AetherSubtitleCue {
     }
 }
 
-private extension AetherSubtitleCue.Body {
-    /// Flattened text, for the uniform-edge outline layers (always solid
-    /// black, so per-run colours are irrelevant there).
-    var plainText: String {
-        switch self {
-        case .text(let string): return string
-        case .styledText(let runs): return runs.map(\.text).joined()
-        case .image: return ""
-        }
-    }
-}

--- a/Rivulet/Views/Player/PlayerContainerViewController.swift
+++ b/Rivulet/Views/Player/PlayerContainerViewController.swift
@@ -1227,11 +1227,13 @@ class PlayerContainerViewController: UIViewController {
                             title: "Delay",
                             value: { [weak vm] in SubtitleAdjustments.formattedDelay(vm?.subtitleDelaySeconds ?? 0) },
                             onStep: { [weak vm] step in vm?.adjustSubtitleDelay(bySteps: step) }),
-                        // Height: global across all media.
+                        // Height: sticky per title, like Delay above.
                         CardStepperConfig(
                             title: "Height",
-                            value: { SubtitleAdjustments.formattedHeight(SubtitleAdjustments.heightUnits) },
-                            onStep: { step in SubtitleAdjustments.setHeightUnits(SubtitleAdjustments.heightUnits + step) }),
+                            value: { [weak vm] in
+                                SubtitleAdjustments.formattedHeight(vm?.subtitleHeightUnits ?? 0)
+                            },
+                            onStep: { [weak vm] step in vm?.adjustSubtitleHeight(bySteps: step) }),
                     ],
                     onSelect: { [weak vm, weak self] id in
                         vm?.selectSubtitleTrack(id: id)

--- a/Rivulet/Views/Player/Subtitles/SubtitleAdjustments.swift
+++ b/Rivulet/Views/Player/Subtitles/SubtitleAdjustments.swift
@@ -8,10 +8,13 @@
 //  User-tunable subtitle timing and placement, surfaced as steppers inside
 //  the OSD Subtitles panel (VOD rail and Live TV rail).
 //
-//  Delay is STICKY PER MEDIA: keyed by the Plex ratingKey for VOD and the
-//  channel id for Live TV, so one channel can hold +3.0s while another stays
-//  at the default. Height is GLOBAL: one offset applied to every overlay,
-//  stored as whole units of `heightUnitPt` and clamped to ±`heightUnitMax`.
+//  Both adjustments are STICKY PER MEDIA: keyed by the Plex ratingKey for VOD
+//  and the channel id for Live TV, so one channel can hold +3.0s and sit two
+//  units higher while another stays at the defaults. Both default to 0.
+//
+//  Height is stored as whole units of `heightUnitPt`, clamped to
+//  ±`heightUnitMax`, and does NOT move a cue that carries its own placement —
+//  an authored position must not drift with an app-level offset.
 //
 
 import Foundation
@@ -57,24 +60,61 @@ enum SubtitleAdjustments {
         return String(format: "%+.1fs", value)
     }
 
-    // MARK: - Height (global)
+    // MARK: - Height (per media)
 
     /// Points moved per stepper press.
     static let heightUnitPt: CGFloat = 10
     /// Stepper range: ±10 units (±100 pt).
     static let heightUnitMax = 10
 
-    /// Overlays read this via @AppStorage so a change re-renders them live;
-    /// keep the literal in sync if this key ever moves.
-    static let heightKey = "subtitleHeightUnits"
-
-    /// Current height offset in UNITS (positive = subtitles sit higher).
-    static var heightUnits: Int {
-        clampUnits(UserDefaults.standard.integer(forKey: heightKey))
+    /// Defaults key holding the height for one media key. A key per media
+    /// rather than one entry in a map, unlike delay, so a media that was never
+    /// adjusted costs nothing and clearing one is a plain remove.
+    private static func heightKey(forMediaKey mediaKey: String) -> String {
+        "subtitleHeightUnits:\(mediaKey)"
     }
 
-    static func setHeightUnits(_ units: Int) {
-        UserDefaults.standard.set(clampUnits(units), forKey: heightKey)
+    /// Height offset in UNITS for a media key (positive = subtitles sit
+    /// higher). 0 when never adjusted.
+    static func heightUnits(forMediaKey mediaKey: String) -> Int {
+        clampUnits(UserDefaults.standard.integer(forKey: heightKey(forMediaKey: mediaKey)))
+    }
+
+    /// Persists `units` for `mediaKey`. A value of 0 removes the entry, so
+    /// defaults never accumulate for media the user only watched.
+    static func setHeightUnits(_ units: Int, forMediaKey mediaKey: String) {
+        let key = heightKey(forMediaKey: mediaKey)
+        let clamped = clampUnits(units)
+        if clamped == 0 {
+            UserDefaults.standard.removeObject(forKey: key)
+        } else {
+            UserDefaults.standard.set(clamped, forKey: key)
+        }
+    }
+
+    // MARK: - Rail clearance
+
+    /// The rail's TOP edge measured from the bottom of the SCREEN:
+    /// `PlayerRailView.railHeight` (260) + its bottom inset (84).
+    static let railTopFromScreenBottom: CGFloat = 344
+
+    /// The margin a caption keeps off whatever it rests above, as a fraction
+    /// of the PICTURE height — the bottom of the picture with the rail hidden,
+    /// the top of the rail with it showing. One number for both, so captions
+    /// keep the same visual distance either way.
+    ///
+    /// Measured against the picture rather than the screen so letterboxed
+    /// content keeps its captions on the image instead of dropping them into
+    /// the black bar, and so the placement holds at any presentation size.
+    /// Tuned against AVPlayer's own placement (a two-line caption centres at
+    /// roughly 8% of picture height).
+    static let bottomMarginFraction: CGFloat = 0.06
+
+    /// The lowest a caption may sit while the rail is showing. Lives here
+    /// because BOTH overlays need it and they must agree: captions should not
+    /// change height when a title falls back from the engine to the HLS route.
+    static func controlsFloor(pictureHeight: CGFloat) -> CGFloat {
+        railTopFromScreenBottom + pictureHeight * bottomMarginFraction
     }
 
     /// "0", "+3", "-2" — the stepper's centre label.
@@ -83,8 +123,11 @@ enum SubtitleAdjustments {
     }
 
     /// Extra bottom padding for the subtitle overlays, derived from the stored
-    /// units. Overlays read the raw units via @AppStorage and convert here, so
+    /// units. Hosts pass the raw units to the overlays, which convert here, so
     /// the units→points rule lives in one place.
+    ///
+    /// Applied to the DEFAULT caption band only. A cue carrying its own
+    /// placement is exempt — see `AetherSubtitleOverlayView.placedCue`.
     static func heightOffset(forUnits units: Int) -> CGFloat {
         CGFloat(clampUnits(units)) * heightUnitPt
     }

--- a/Rivulet/Views/Player/UniversalPlayerView.swift
+++ b/Rivulet/Views/Player/UniversalPlayerView.swift
@@ -936,7 +936,13 @@ struct UniversalPlayerView: View {
                     // (showControls || isScrubbing): the scrub ribbon keeps
                     // the bottom band occupied even when the rail hides, so
                     // captions stay lifted through a scrub.
-                    controlsVisible: viewModel.showControls || viewModel.isScrubbing
+                    controlsVisible: viewModel.showControls || viewModel.isScrubbing,
+                    // Lets the overlay measure its bottom margin from the
+                    // picture rather than the screen, so a letterboxed film
+                    // is not captioned into its black bar.
+                    videoSize: viewModel.videoSize,
+                    // Height is sticky per title, like the delay stepper.
+                    heightUnits: viewModel.subtitleHeightUnits
                 )
                 .ignoresSafeArea()
                 .allowsHitTesting(false)
@@ -946,10 +952,8 @@ struct UniversalPlayerView: View {
             } else if viewModel.player != nil {
                 SubtitleOverlayView(
                     subtitleManager: viewModel.subtitleManager,
-                    // 368 = rail bottom inset 84 + railHeight 260 + 24 gap;
-                    // resting 100 — both match AetherSubtitleOverlayView so
-                    // captions sit at the same height on every route.
-                    bottomOffset: (viewModel.showControls || viewModel.isScrubbing) ? 368 : 100
+                    controlsVisible: viewModel.showControls || viewModel.isScrubbing,
+                    heightUnits: viewModel.subtitleHeightUnits
                 )
                 .ignoresSafeArea()
             }

--- a/Rivulet/Views/Player/UniversalPlayerViewModel.swift
+++ b/Rivulet/Views/Player/UniversalPlayerViewModel.swift
@@ -268,6 +268,11 @@ final class UniversalPlayerViewModel: ObservableObject {
     /// switch, background reopen).
     @Published private(set) var aetherPlayer: AetherPlayer?
 
+    /// The playing item's presentation size, mirrored from `aetherPlayer` so
+    /// SwiftUI actually observes it (see the subscription in the bind block).
+    /// `.zero` before the first frame and on the AVPlayer/hls route.
+    @Published private(set) var videoSize: CGSize = .zero
+
     /// Subtitle manager for custom subtitle rendering.
     let subtitleManager = SubtitleManager()
     private let subtitleClockSync = SubtitleClockSyncController()
@@ -286,8 +291,22 @@ final class UniversalPlayerViewModel: ObservableObject {
 
     // MARK: - Subtitle delay (OSD stepper, sticky per item)
 
-    /// Persistence key for this item's subtitle delay.
-    private var subtitleDelayKey: String { "plex:\(metadata.ratingKey ?? "unknown")" }
+    /// Persistence key for this item's sticky subtitle adjustments (delay and
+    /// height). Shared by both, so a title carries one identity.
+    var subtitleMediaKey: String { "plex:\(metadata.ratingKey ?? "unknown")" }
+
+    /// This item's height adjustment in stepper units. Published so both
+    /// overlays re-render on a step, and reloaded per item like the delay.
+    @Published private(set) var subtitleHeightUnits: Int = 0
+
+    /// Steps the height and persists it for this ratingKey. Applied to BOTH
+    /// routes, same as the delay stepper, so it survives a mid-playback route
+    /// change.
+    func adjustSubtitleHeight(bySteps steps: Int) {
+        SubtitleAdjustments.setHeightUnits(subtitleHeightUnits + steps,
+                                           forMediaKey: subtitleMediaKey)
+        subtitleHeightUnits = SubtitleAdjustments.heightUnits(forMediaKey: subtitleMediaKey)
+    }
 
     /// Current subtitle delay in seconds; positive = subtitles appear later.
     var subtitleDelaySeconds: Double { aetherSubtitleModel.delaySeconds }
@@ -302,15 +321,16 @@ final class UniversalPlayerViewModel: ObservableObject {
         let value = SubtitleAdjustments.roundedDelay(raw)
         aetherSubtitleModel.delaySeconds = value
         subtitleManager.delaySeconds = value
-        SubtitleAdjustments.setDelay(value, forKey: subtitleDelayKey)
+        SubtitleAdjustments.setDelay(value, forKey: subtitleMediaKey)
     }
 
     /// Loads this item's stored delay into both pipelines. Called on every
     /// playback setup, including next-episode swaps on this same instance.
     private func loadStoredSubtitleDelay() {
-        let value = SubtitleAdjustments.delay(forKey: subtitleDelayKey)
+        let value = SubtitleAdjustments.delay(forKey: subtitleMediaKey)
         aetherSubtitleModel.delaySeconds = value
         subtitleManager.delaySeconds = value
+        subtitleHeightUnits = SubtitleAdjustments.heightUnits(forMediaKey: subtitleMediaKey)
     }
 
     // MARK: - Metadata
@@ -1781,6 +1801,18 @@ final class UniversalPlayerViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] cues in
                 self?.aetherSubtitleModel.update(cues: cues)
+            }
+            .store(in: &cancellables)
+
+        // Mirrored onto the view model because AetherPlayer is not an
+        // ObservableObject: a SwiftUI view reading `aetherPlayer.videoSize`
+        // directly would never re-render, since `$aetherPlayer` only fires
+        // when the PLAYER changes, not its properties.
+        player.$videoSize
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] size in
+                self?.videoSize = size
             }
             .store(in: &cancellables)
 


### PR DESCRIPTION
<head></head><h1 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Subtitles: match Apple's caption rendering, and honour content styling and placement</h1><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Rivulet draws its own subtitles rather than letting AVKit do it, because the player chrome is ours. That overlay had drifted a long way from what tvOS actually renders, and it discarded almost everything the content specified.</p><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">This PR closes both gaps, and gives Live TV's native-HLS path the same renderer as every other route.</p><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><strong>11 files, Swift only.</strong><span class="Apple-converted-space"> </span>No project file, no dependency pin, no plist, no entitlement, no licence text.</p><hr style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><h2 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Why</h2><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Four separate problems, all visible on a TV:</p><ol style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><li><p><strong>Captions were the wrong size at the ends of the system size range.</strong><span class="Apple-converted-space"> </span>The scale factor read from MediaAccessibility was clamped to<span class="Apple-converted-space"> </span><code>0.5...2.0</code>, but tvOS reports<span class="Apple-converted-space"> </span><strong>0.35</strong><span class="Apple-converted-space"> </span>at the smallest setting. The clamp silently swallowed it, so the Subtitles &amp; Captioning size slider stopped doing anything near its extremes.</p></li><li><p><strong>They didn't look like tvOS captions.</strong><span class="Apple-converted-space"> </span>A background box per<span class="Apple-converted-space"> </span><em>line</em><span class="Apple-converted-space"> </span>rather than one per cue, a fixed corner radius that reads as a hard rectangle at large sizes, and a bottom margin measured from the screen — so a 2.39:1 film was captioned down in its black bar rather than on the image.</p></li><li><p><strong>Everything the content asked for was thrown away except colour.</strong><span class="Apple-converted-space"> </span>Bold, italic, underline, strikethrough, font face, size, and — most visibly —<span class="Apple-converted-space"> </span><em>position</em>. Broadcasters routinely move captions to the top of frame to avoid covering on-screen graphics; those landed at the bottom, over the graphics.</p></li><li><p><strong>Live TV's native-HLS path had no caption rendering of ours at all.</strong><span class="Apple-converted-space"> </span>On<span class="Apple-converted-space"> </span><code>nativeRemoteHLS</code><span class="Apple-converted-space"> </span>the engine never demuxes, so the stream's WebVTT belongs to AVPlayer. Captions there were drawn by AVPlayer in Apple's style, ignoring every one of the app's own caption settings — a second, inconsistent renderer.</p></li></ol><hr style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><h2 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">What changed</h2><h3 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">1. Caption rendering now matches tvOS</h3>
  | before | after
-- | -- | --
Point size | fixed size × clamped scale | fraction of presentation height × the system's real multiplier
Background | one box per line | one tight box per cue, sized to the longest line
Box geometry | fixed 4 / 8 / 2 pt | proportional to the type, so it scales
Bottom margin | measured from the screen | measured from the picture

<hr style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><h2 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Notes for review</h2><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Things that look wrong but aren't, or are easy to break later.</p><ul style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><li><p><strong><code>CaptionAppearance</code><span class="Apple-converted-space"> </span>reads each<span class="Apple-converted-space"> </span><code>allowsContent*</code><span class="Apple-converted-space"> </span>immediately after its own MediaAccessibility call.</strong><span class="Apple-converted-space"> </span>Every read overwrites the shared<span class="Apple-converted-space"> </span><code>behavior</code><span class="Apple-converted-space"> </span>out-param, so reordering these silently attributes one setting's override state to another. This is load-bearing sequencing, not style.</p></li><li><p><strong>The font-scale clamp widened to<span class="Apple-converted-space"> </span><code>0.25...4.0</code>.</strong><span class="Apple-converted-space"> </span>This was the actual cause of captions not tracking the size setting. The size fraction is tuned against the real multiplier — if captions ever look the wrong size, suspect the multiplier reaching us, not the fraction.</p></li><li><p><strong>Live TV route detection keys off the routing decision, confirmed against the item's URL — not off<span class="Apple-converted-space"> </span><code>subtitleTracks</code><span class="Apple-converted-space"> </span>being empty.</strong><span class="Apple-converted-space"> </span>AE#154 makes the engine mirror AVPlayer's legible options<span class="Apple-converted-space"> </span><em>into</em><span class="Apple-converted-space"> </span><code>subtitleTracks</code>, so the old emptiness test now reports the opposite of what it used to. The URL check also follows an engine-side #168 reroute onto the loopback, which the routing decision alone would miss.</p></li><li><p><strong>The Live TV overlay's hosting controller sets<span class="Apple-converted-space"> </span><code>safeAreaRegions = []</code>.</strong><span class="Apple-converted-space"> </span>Every margin in that overlay is measured from the screen; a hosting controller otherwise applies tvOS's ~60pt title-safe inset to its content, which made the rail gap roughly double its intended size. VOD gets the same effect from<span class="Apple-converted-space"> </span><code>.ignoresSafeArea()</code>.</p></li><li><p><strong>The rail-driven overlay rebuild wraps its<span class="Apple-converted-space"> </span><code>rootView</code><span class="Apple-converted-space"> </span>assignment in<span class="Apple-converted-space"> </span><code>withAnimation</code>.</strong><span class="Apple-converted-space"> </span>That assignment is a UIKit-side write, not a SwiftUI transaction, so the overlay's<span class="Apple-converted-space"> </span><code>.animation(value:)</code><span class="Apple-converted-space"> </span>has nothing to attach to and captions jump rather than slide. VOD needs none of this — there<span class="Apple-converted-space"> </span><code>controlsVisible</code><span class="Apple-converted-space"> </span>comes off an<span class="Apple-converted-space"> </span><code>@Published</code>.</p></li><li><p><strong><code>boxed</code>'s<span class="Apple-converted-space"> </span><code>.frame(maxWidth:)</code><span class="Apple-converted-space"> </span>centres its child, and that is only correct because every placed cue is centre-anchored and offset into position.</strong><span class="Apple-converted-space"> </span>Any future edge-aligned path must pass an explicit alignment there or it will silently land in the middle of the picture. This one cost a debugging cycle.</p></li><li><p><strong>Overlay z-order in Live TV is now explicit.</strong><span class="Apple-converted-space"> </span>It was correct but incidental, resting purely on<span class="Apple-converted-space"> </span><code>mountSubtitleOverlay()</code>running before<span class="Apple-converted-space"> </span><code>setupChrome()</code>. Stated at both ends, matching the precedent<span class="Apple-converted-space"> </span><code>PlayerContainerViewController</code><span class="Apple-converted-space"> </span>already sets.</p></li><li><p><strong><code>AetherPlayer.videoSize</code><span class="Apple-converted-space"> </span>observes<span class="Apple-converted-space"> </span><code>presentationSize</code><span class="Apple-converted-space"> </span>in two hops</strong><span class="Apple-converted-space"> </span>rather than through a<span class="Apple-converted-space"> </span><code>\.currentItem?.presentationSize</code><span class="Apple-converted-space"> </span>key path — nested KVO through an optional chain is not reliably delivered, and a missed update would leave the overlay measuring against a stale aspect ratio for the whole session.</p></li><li><p><strong>The height stepper's value is pushed into the overlays by the host</strong><span class="Apple-converted-space"> </span>rather than read there with a dynamic-key<span class="Apple-converted-space"> </span><code>@AppStorage</code>. The key changes under a channel switch or next-episode swap while the view keeps its identity, and<code>@AppStorage</code><span class="Apple-converted-space"> </span>re-binding across that is not worth relying on.</p></li><li><p><strong>Bitmap cues now map against the video rect</strong>, not the full bounds.<span class="Apple-converted-space"> </span><code>SubtitleImage.position</code><span class="Apple-converted-space"> </span>is normalised against the source frame, so on letterboxed content PGS/DVB cues were being stretched vertically and pushed toward the black bar.</p></li></ul><hr style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><h2 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Fit</h2><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Subtitle fidelity is core to a media client, and this removes a second renderer rather than adding one — after this, one overlay draws every cue on every route, which is less surface to maintain, not more.</p><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">It doesn't duplicate anything the platform gives free: Rivulet deliberately doesn't use AVKit, so nothing else will draw these captions. Where the system does have an opinion — the Subtitles &amp; Captioning settings — this defers to it per attribute rather than overriding it.</p><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">No new user-facing settings. The one behaviour change a user could notice is the Height stepper becoming per-title instead of global, which brings it in line with Delay next to it.</p><hr style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><h2 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Dependencies</h2><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">None.<span class="Apple-converted-space"> </span><code>main</code><span class="Apple-converted-space"> </span>is already on AetherEngine 6.1.3, which covers everything this needs: the styled-run fields (5.26.0), cue placement actually reaching a host (5.28.1 — before that every cue was stripped of it on insert), and the webvtt demuxer for standalone<span class="Apple-converted-space"> </span><code>.vtt</code><span class="Apple-converted-space"> </span>sidecars (FFmpegBuild 2.3.0).</p><hr style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><h2 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Testing</h2><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">tvOS 26.5, on device and Simulator:</p><ul style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><li>DVB-T broadcast teletext (AU FTA, page 801) via the software path — coloured cues, multi-row cues, and cues the broadcaster positions away from the bottom</li><li>HLS fMP4/HEVC channels carrying WebVTT renditions on the native path, compared side by side against AVPlayer's own rendering of the same stream</li><li>The same teletext source reaching the app both ways (raw demux and proxied to WebVTT), to confirm the two routes agree</li><li>VOD with embedded subtitles</li><li>Rail show/hide, for the lift and the animation</li></ul><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Chrome- and focus-adjacent behaviour was checked on device rather than Simulator, per the repo's note that the Simulator does not fully mimic Apple TV.</p><hr style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><h2 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">