### PR TITLE
Season identity on the show detail surface

### DIFF
--- a/Rivulet/Views/Media/MediaDetail/UIKit/BelowFoldCollectionView.swift
+++ b/Rivulet/Views/Media/MediaDetail/UIKit/BelowFoldCollectionView.swift
@@ -85,6 +85,10 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
     /// Selecting the About cards opens the matching popup (synopsis / advisory).
     var onSelectSynopsis: ((MediaItemDetail) -> Void)?
     var onSelectAdvisory: ((ContentAdvisory) -> Void)?
+    /// The loader's seasons, published as soon as they land, with the index of
+    /// the season it resolved as selected. The container builds the season pills
+    /// from this instead of fetching `/children` a second time of its own.
+    var onSeasonsLoaded: (([MediaItem], Int) -> Void)?
 
     /// Which sub-target of the focused episode card is focused (thumb vs
     /// description). Set from the cell's focus reporting.
@@ -127,7 +131,7 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
         backgroundColor = .clear
 
         collectionView = FocusScrollControlledCollectionView(frame: bounds, collectionViewLayout: makeLayout())
-        collectionView.topBand = Self.detailsTopY
+        collectionView.topBand = detailsTopY
         // Disable the collection's own (vertical) scrolling so the focus engine
         // can't spin up its centering "focus scroll animator". We drive all
         // vertical scroll ourselves (slide on entry, didUpdateFocus per section).
@@ -191,7 +195,7 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
         // Small top inset = where episodes land in details (so the focus engine
         // aligns them there). The carousel-stable peek offset is provided by the
         // large TOP INSET on the episodes section (see makeLayout), not by this.
-        let topInset = Self.detailsTopY
+        let topInset = detailsTopY
         if collectionView.contentInset.top != topInset {
             collectionView.contentInset = UIEdgeInsets(top: topInset, left: 0, bottom: 0, right: 0)
             collectionView.setContentOffset(CGPoint(x: 0, y: -topInset), animated: false)
@@ -216,7 +220,7 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
             // the first section, movies (Trailers first) had a tiny inset, so the
             // slide barely moved and the blur/fade never triggered.
             let isPrimary = (index == 0)
-            let peek = max(0, self.bounds.height - Self.episodePeek - Self.detailsTopY)
+            let peek = max(0, self.bounds.height - Self.episodePeek - self.detailsTopY)
             switch self.sectionKinds[index] {
             // Episodes: LEFT-aligned (ATV+), first card at the metadata inset
             // (leading 128). The collection's small contentInset.top (= detailsTopY)
@@ -486,6 +490,7 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
         loadToken &+= 1
         let token = loadToken
         configuredItem = item
+        setDetailsTopY(forKind: item.kind)
         Task { [weak self] in
             guard let self else { return }
             let content = await self.loader.load(for: item, detail: detail)
@@ -523,6 +528,7 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
         loadToken &+= 1
         let token = loadToken
         configuredItem = item
+        setDetailsTopY(forKind: item.kind)
         let showRef: MediaItemRef?
         switch item.kind {
         case .show: showRef = item.ref
@@ -663,6 +669,15 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
         cachedExtras = content.extras.map { BelowFoldItem.extra($0.id) }
         relatedItems = content.related
         cachedRelated = content.related.isEmpty ? [] : [BelowFoldItem.relatedShelf]
+
+        // Publish the seasons once everything else is ingested, so a handler that
+        // reads back from this view sees a consistent state. The loader has
+        // already resolved which season to open on (the item's own for a season
+        // page, the parent for an episode, the first for a show), so there is
+        // nothing for the container to re-derive — or to re-fetch.
+        let selectedSeasonIndex = content.selectedSeason
+            .flatMap { sel in content.seasons.firstIndex(where: { $0.ref.itemID == sel.ref.itemID }) } ?? 0
+        onSeasonsLoaded?(content.seasons, selectedSeasonIndex)
     }
 
     private var cachedEpisodes: [BelowFoldItem] = []
@@ -798,19 +813,39 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
     }
 
     func resetScroll() {
-        collectionView.setContentOffset(CGPoint(x: 0, y: -Self.detailsTopY), animated: false)
+        collectionView.setContentOffset(CGPoint(x: 0, y: -detailsTopY), animated: false)
     }
 
     /// Screen-y where the first episode lands in details (under the logo + the
     /// season-pills row, per the ATV+ reference). Also the collection's
     /// contentInset.top, so the focus engine aligns the focused episode here.
-    static let detailsTopY: CGFloat = 230
+    /// Per content kind since the season info strip: show-family pages land the
+    /// rail lower to reserve the strip's room between the pills and the rail;
+    /// movies keep the original landing. The REST (peek) position is invariant
+    /// either way — the episodes section's top inset is derived from this, and
+    /// the two cancel at rest (first cards at bounds.height − episodePeek).
+    static let movieDetailsTopY: CGFloat = 230
+    static let showDetailsTopY: CGFloat = 396
+    private(set) var detailsTopY: CGFloat = BelowFoldCollectionView.movieDetailsTopY
+
+    /// Set the details landing for the item kind being configured. On a change
+    /// the layout re-derives the peek inset and `layoutSubviews` re-applies the
+    /// content inset (kind changes only happen at carousel-stable rest).
+    private func setDetailsTopY(forKind kind: MediaKind) {
+        let y: CGFloat = (kind == .show || kind == .season || kind == .episode)
+            ? Self.showDetailsTopY : Self.movieDetailsTopY
+        guard detailsTopY != y else { return }
+        detailsTopY = y
+        collectionView.topBand = y
+        collectionView.collectionViewLayout.invalidateLayout()
+        setNeedsLayout()
+    }
 
     /// The `onScroll` value when the episodes sit at their details-rest (topBand)
     /// position — i.e. where the season-pills row is at its resting Y. Above this
     /// the pills scroll UP with the rail; below it (entry/collapse) they follow it
     /// down. Equals the episodes section's top inset (the carousel peek).
-    var detailsRestOff: CGFloat { max(0, bounds.height - Self.episodePeek - Self.detailsTopY) }
+    var detailsRestOff: CGFloat { max(0, bounds.height - Self.episodePeek - detailsTopY) }
 
     /// Whether focus is on the episodes (top) row vs a lower section. Drives the
     /// Up handler: episodes → pills; lower section → let the engine move up.
@@ -861,7 +896,7 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
         // Scroll so the first episode lands at detailsTopY — which is the focus
         // engine's preferred position (contentInset.top == detailsTopY), so
         // handing focus in afterward causes no re-scroll bounce.
-        let targetY = max(0, bounds.height - Self.episodePeek - 2 * Self.detailsTopY)
+        let targetY = max(0, bounds.height - Self.episodePeek - 2 * detailsTopY)
         guard animated else { setOffsetY(targetY); completion?(); return }
         animateOffsetY(to: targetY, duration: 0.6, completion: completion)
     }
@@ -869,7 +904,7 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
     /// Reverse of slideToDetailsTop: slide the episodes back down to the hero
     /// peek rest (drives the reverse choreography). Completion fires at the end.
     func slideToHeroRest(animated: Bool, completion: (() -> Void)? = nil) {
-        let targetY = -Self.detailsTopY
+        let targetY = -detailsTopY
         guard animated else { setOffsetY(targetY); completion?(); return }
         animateOffsetY(to: targetY, duration: 0.6, completion: completion)
     }

--- a/Rivulet/Views/Media/MediaDetail/UIKit/BelowFoldCollectionView.swift
+++ b/Rivulet/Views/Media/MediaDetail/UIKit/BelowFoldCollectionView.swift
@@ -35,6 +35,9 @@ nonisolated enum BelowFoldSectionKind: Hashable, Sendable {
 
 nonisolated enum BelowFoldItem: Hashable, Sendable {
     case episode(String)
+    /// Boundary marker between seasons in the flat rail, keyed by the season
+    /// ref itemID it introduces. Structural only — never a focus stop.
+    case seasonDivider(String)
     case trailer(String)
     case extra(String)
     case related(String)
@@ -148,6 +151,7 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
         // the current season's first episode (nearest-visible / preferred index).
         collectionView.remembersLastFocusedIndexPath = false
         collectionView.register(EpisodeCollectionCell.self, forCellWithReuseIdentifier: EpisodeCollectionCell.reuseID)
+        collectionView.register(SeasonDividerCell.self, forCellWithReuseIdentifier: SeasonDividerCell.reuseID)
         collectionView.register(TrailerCollectionCell.self, forCellWithReuseIdentifier: TrailerCollectionCell.reuseID)
         collectionView.register(RelatedPosterCell.self, forCellWithReuseIdentifier: RelatedPosterCell.reuseID)
         collectionView.register(ShelfRowCell.self, forCellWithReuseIdentifier: ShelfRowCell.reuseID)
@@ -226,12 +230,7 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
             // (leading 128). The collection's small contentInset.top (= detailsTopY)
             // lets the focus engine land them at ~detailsTopY in details.
             case .episodes:
-                return self.shelfSection(
-                    itemW: Self.episodeWidth,
-                    itemH: Self.episodeHeight,
-                    leading: Self.rowLeading,
-                    gap: 16,
-                    header: false,
+                return self.episodesRailSection(
                     topInset: isPrimary ? peek : 0,
                     sectionBottomInset: 36
                 )
@@ -329,6 +328,40 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
         return section
     }
 
+    /// The episode rail's section. A custom group instead of `shelfSection`'s
+    /// repeating item because the rail mixes widths: full episode cards plus
+    /// slim season dividers. Frames are computed eagerly from `cachedEpisodes`
+    /// (the provider closure re-runs on every data-driven invalidation), so
+    /// layout attributes — and everything that reads them: the orthogonal
+    /// season scroll, pill alignment, initial-episode landing — stay exact,
+    /// which estimated self-sizing would not guarantee.
+    private func episodesRailSection(topInset: CGFloat, sectionBottomInset: CGFloat) -> NSCollectionLayoutSection {
+        let gap: CGFloat = 16
+        var frames: [CGRect] = []
+        var x: CGFloat = 0
+        for railItem in cachedEpisodes {
+            let w: CGFloat
+            if case .seasonDivider = railItem { w = SeasonDividerCell.cardWidth } else { w = Self.episodeWidth }
+            frames.append(CGRect(x: x, y: 0, width: w, height: Self.episodeHeight))
+            x += w + gap
+        }
+        let total = max(x - gap, 1)
+        let group = NSCollectionLayoutGroup.custom(layoutSize: .init(
+            widthDimension: .absolute(total), heightDimension: .absolute(Self.episodeHeight))
+        ) { _ in
+            frames.map { NSCollectionLayoutGroupCustomItem(frame: $0) }
+        }
+        let section = NSCollectionLayoutSection(group: group)
+        section.orthogonalScrollingBehavior = .continuous
+        section.contentInsets = .init(
+            top: topInset,
+            leading: Self.rowLeading,
+            bottom: sectionBottomInset,
+            trailing: Self.rowTrailing
+        )
+        return section
+    }
+
     private func shelfSection(
         itemW: CGFloat,
         itemH: CGFloat,
@@ -393,6 +426,10 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
                         self.focusedEpisodeKind = kind
                     }
                 }
+                return cell
+            case .seasonDivider(let seasonID):
+                let cell = cv.dequeueReusableCell(withReuseIdentifier: SeasonDividerCell.reuseID, for: indexPath) as! SeasonDividerCell
+                cell.configure(label: self.railDividerLabels[seasonID] ?? "·")
                 return cell
             case .trailer(let id):
                 // Trailers reuse the EpisodeCollectionCell so they match episodes
@@ -627,7 +664,7 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
         // the lighter peek load doesn't fetch the seasons list.)
         multiSeason = Set(episodes.compactMap { $0.seasonNumber }).count > 1
         episodesByID = Dictionary(episodes.map { ($0.ref.itemID, $0) }, uniquingKeysWith: { a, _ in a })
-        cachedEpisodes = episodes.map { BelowFoldItem.episode($0.ref.itemID) }
+        cachedEpisodes = buildRailItems(from: episodes)
         // Cast/related/about are loaded only on expand.
         trailersByID = [:]; extrasByID = [:]; relatedByID = [:]; castEntriesByID = [:]
         cachedTrailers = []; cachedExtras = []; cachedRelated = []; cachedCastOrder = []
@@ -664,7 +701,7 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
             cachedCastOrder.append((id, .cast(id)))
         }
         castEntriesByID = entries
-        cachedEpisodes = content.episodes.map { BelowFoldItem.episode($0.ref.itemID) }
+        cachedEpisodes = buildRailItems(from: content.episodes)
         cachedTrailers = content.trailers.map { BelowFoldItem.trailer($0.id) }
         cachedExtras = content.extras.map { BelowFoldItem.extra($0.id) }
         relatedItems = content.related
@@ -680,6 +717,43 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
         onSeasonsLoaded?(content.seasons, selectedSeasonIndex)
     }
 
+    /// Build the flat rail: the episodes, with a season divider inserted at each
+    /// boundary. A single-season rail gets none — the divider marks a
+    /// transition, and with one season there is nothing to transition from.
+    private func buildRailItems(from episodes: [MediaItem]) -> [BelowFoldItem] {
+        let seasonIDs = Set(episodes.compactMap { $0.parentRef?.itemID })
+        guard seasonIDs.count > 1 else {
+            railDividerLabels = [:]
+            return episodes.map { .episode($0.ref.itemID) }
+        }
+        var items: [BelowFoldItem] = []
+        var labels: [String: String] = [:]
+        var prevSeasonID: String?
+        var seen: Set<String> = []
+        for ep in episodes {
+            if let sid = ep.parentRef?.itemID {
+                if let prev = prevSeasonID, prev != sid, !seen.contains(sid) {
+                    labels[sid] = Self.dividerLabel(for: ep)
+                    items.append(.seasonDivider(sid))
+                    seen.insert(sid)
+                }
+                prevSeasonID = sid
+            }
+            items.append(.episode(ep.ref.itemID))
+        }
+        railDividerLabels = labels
+        return items
+    }
+
+    private static func dividerLabel(for episode: MediaItem) -> String {
+        guard let n = episode.seasonNumber else { return "·" }
+        return n == 0 ? "SP" : "S\(n)"
+    }
+
+    /// season ref itemID → chip label ("S3" / "SP"), for the divider cells.
+    private var railDividerLabels: [String: String] = [:]
+
+    /// The flat rail's items: episodes plus any season dividers.
     private var cachedEpisodes: [BelowFoldItem] = []
     private var cachedTrailers: [BelowFoldItem] = []
     private var cachedExtras: [BelowFoldItem] = []
@@ -790,7 +864,13 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
            let attrFirst = layout.layoutAttributesForItem(at: IndexPath(item: 0, section: epSection)) {
             delta = attrTarget.frame.minX - attrFirst.frame.minX
         } else {
-            delta = CGFloat(itemIdx) * (Self.episodeWidth + 16)
+            // Fallback for when the attributes aren't built yet. It cannot assume
+            // a fixed pitch any more: the rail mixes episode cards with slimmer
+            // season dividers, so sum the actual widths up to the target.
+            delta = cachedEpisodes.prefix(itemIdx).reduce(CGFloat(0)) { acc, railItem in
+                if case .seasonDivider = railItem { return acc + SeasonDividerCell.cardWidth + 16 }
+                return acc + Self.episodeWidth + 16
+            }
         }
         let maxX = max(base, scroller.contentSize.width - scroller.bounds.width + scroller.contentInset.right)
         let clampedX = min(max(base, base + delta), maxX)
@@ -871,7 +951,16 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
               let current = collectionView.focusedEpisodeIndexPath,
               current.section == epSection else { return false }
         let count = collectionView.numberOfItems(inSection: epSection)
-        let targetItem = current.item + (forward ? 1 : -1)
+        // Step OVER season dividers. They occupy rail indices but are not focus
+        // stops, so a bare ±1 would arm focus on one and the update would land
+        // nowhere.
+        func isDivider(_ i: Int) -> Bool {
+            guard i >= 0, i < cachedEpisodes.count else { return false }
+            if case .seasonDivider = cachedEpisodes[i] { return true }
+            return false
+        }
+        var targetItem = current.item + (forward ? 1 : -1)
+        while isDivider(targetItem) { targetItem += forward ? 1 : -1 }
         guard targetItem >= 0, targetItem < count else { return false }
         armedEpisodeFocusIndexPath = IndexPath(item: targetItem, section: epSection)
         // No manual scroll: the engine scrolls the orthogonal row to the focused
@@ -986,6 +1075,9 @@ final class BelowFoldCollectionView: UIView, UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, canFocusItemAt indexPath: IndexPath) -> Bool {
         switch dataSource.itemIdentifier(for: indexPath) {
         case .episode, .trailer, .extra: return false
+        // Same answer for a different reason: the others defer to focusable
+        // subviews, the divider has none and is never a focus stop at all.
+        case .seasonDivider: return false
         default: return true
         }
     }

--- a/Rivulet/Views/Media/MediaDetail/UIKit/Cells/BelowFoldCells.swift
+++ b/Rivulet/Views/Media/MediaDetail/UIKit/Cells/BelowFoldCells.swift
@@ -363,6 +363,61 @@ final class BelowFoldSectionHeader: UICollectionReusableView {
     func configure(title: String) { titleLabel.text = title }
 }
 
+// MARK: - Season divider
+
+/// Slim, non-focusable boundary marker between seasons in the flat episode
+/// rail: a broken vertical hairline through the thumb band with a compact
+/// season chip ("S3" / "SP") in the gap. Structure only — the season's full
+/// identity lives in the info strip and the pills. The focus engine skips it
+/// (canBecomeFocused false + the collection's canFocusItemAt exclusion), so
+/// the rail's focus order is unchanged.
+final class SeasonDividerCell: UICollectionViewCell {
+    static let reuseID = "SeasonDividerCell"
+    static let cardWidth: CGFloat = 100
+
+    private let topLine = UIView()
+    private let bottomLine = UIView()
+    private let chip = UILabel()
+
+    override var canBecomeFocused: Bool { false }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        for line in [topLine, bottomLine] {
+            line.translatesAutoresizingMaskIntoConstraints = false
+            line.backgroundColor = UIColor.white.withAlphaComponent(0.18)
+            line.layer.cornerRadius = 1
+            contentView.addSubview(line)
+        }
+        chip.translatesAutoresizingMaskIntoConstraints = false
+        chip.font = .systemFont(ofSize: 29, weight: .semibold)
+        chip.textColor = UIColor.white.withAlphaComponent(0.55)
+        chip.textAlignment = .center
+        contentView.addSubview(chip)
+        NSLayoutConstraint.activate([
+            // Centered on the thumb band (the cell spans the full card height,
+            // text zone included, so the marker aligns with the artwork).
+            chip.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            chip.centerYAnchor.constraint(equalTo: contentView.topAnchor, constant: EpisodeCell.thumbHeight / 2),
+            topLine.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            topLine.widthAnchor.constraint(equalToConstant: 2),
+            topLine.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8),
+            topLine.bottomAnchor.constraint(equalTo: chip.topAnchor, constant: -12),
+            bottomLine.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            bottomLine.widthAnchor.constraint(equalToConstant: 2),
+            bottomLine.topAnchor.constraint(equalTo: chip.bottomAnchor, constant: 12),
+            bottomLine.bottomAnchor.constraint(equalTo: contentView.topAnchor, constant: EpisodeCell.thumbHeight - 8),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("SeasonDividerCell is not Storyboard-backed") }
+
+    func configure(label: String) {
+        chip.text = label
+    }
+}
+
 // MARK: - Helpers
 
 private extension UICollectionViewCell {

--- a/Rivulet/Views/Media/MediaDetail/UIKit/Cells/SeasonPillView.swift
+++ b/Rivulet/Views/Media/MediaDetail/UIKit/Cells/SeasonPillView.swift
@@ -43,7 +43,21 @@ final class SeasonPillView: UIControl {
         if focused { onFocused?() }
     }
 
-    @objc private func handleSelect() { onSelected?() }
+    // Select does not fire .primaryActionTriggered on a plain UIControl on
+    // tvOS, so the wired target never ran and pill Select has never fired.
+    // Consume the press in BOTH began/ended so the focused pill owns the cycle
+    // (mirrors AboutCardControl, a UIControl in this same directory).
+    override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        if presses.contains(where: { $0.type == .select }) { return }
+        super.pressesBegan(presses, with: event)
+    }
+    override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        if presses.contains(where: { $0.type == .select }) {
+            onSelected?()
+            return
+        }
+        super.pressesEnded(presses, with: event)
+    }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -55,7 +69,6 @@ final class SeasonPillView: UIControl {
 
     private func commonInit() {
         translatesAutoresizingMaskIntoConstraints = false
-        addTarget(self, action: #selector(handleSelect), for: .primaryActionTriggered)
         layer.cornerCurve = .continuous
         layer.borderWidth = 1
         layer.borderColor = UIColor.clear.cgColor

--- a/Rivulet/Views/Media/MediaDetail/UIKit/ExpandedDetailContainerView.swift
+++ b/Rivulet/Views/Media/MediaDetail/UIKit/ExpandedDetailContainerView.swift
@@ -116,7 +116,24 @@ final class ExpandedDetailContainerView: UIView {
     private var seasonPills: [SeasonPillView] = []
     private var seasonRefIDs: [String] = []   // parallel to seasonPills (pill → season ref.itemID)
     private var selectedSeasonIndex = 0
-    private var seasonsToken: UInt64 = 0
+
+    /// Season info strip — poster + counts + summary for the season the pills
+    /// are tracking, between the pill row and the episode rail. Display-only and
+    /// never focusable: it follows pill selection and the rail's episode
+    /// tracking, so it adds no focus surface to reason about.
+    private let seasonInfoStrip = UIView()
+    private let stripPoster = UIImageView()
+    private let stripMeta = UILabel()
+    private let stripSummary = UILabel()
+    private static let seasonStripHeight: CGFloat = 132
+    /// The full season items behind the pills. The pills only ever needed the
+    /// labels, so the poster/summary/progress used to be discarded at build.
+    private var seasonItems: [MediaItem] = []
+    private var stripPosterToken: UInt64 = 0
+    /// The season the strip is currently showing (nil = hidden). `selectSeasonPill`
+    /// fires on every episode focus move as the rail tracks seasons, so without a
+    /// same-season no-op the poster load would restart on each one and flicker.
+    private var stripSeasonID: String?
 
     /// Which row of the details has focus. The VC sets this before requesting a
     /// focus update so `belowFoldFocusEnvironment` routes to the right place.
@@ -316,6 +333,43 @@ final class ExpandedDetailContainerView: UIView {
             seasonPillRow.bottomAnchor.constraint(equalTo: pillContent.bottomAnchor, constant: -Self.seasonPillFocusPad),
         ])
 
+        // Season info strip: display-only, under the pills. Hidden until a
+        // season is applied; alpha/transform ride the same scroll choreography
+        // as the pills.
+        seasonInfoStrip.translatesAutoresizingMaskIntoConstraints = false
+        seasonInfoStrip.alpha = 0
+        seasonInfoStrip.isHidden = true
+        addSubview(seasonInfoStrip)
+        stripPoster.translatesAutoresizingMaskIntoConstraints = false
+        stripPoster.contentMode = .scaleAspectFill
+        stripPoster.clipsToBounds = true
+        stripPoster.layer.cornerRadius = 10
+        stripPoster.layer.cornerCurve = .continuous
+        stripPoster.backgroundColor = UIColor.white.withAlphaComponent(0.08)
+        seasonInfoStrip.addSubview(stripPoster)
+        stripMeta.translatesAutoresizingMaskIntoConstraints = false
+        stripMeta.font = .systemFont(ofSize: 26, weight: .semibold)
+        stripMeta.textColor = UIColor.white.withAlphaComponent(0.9)
+        seasonInfoStrip.addSubview(stripMeta)
+        stripSummary.translatesAutoresizingMaskIntoConstraints = false
+        stripSummary.font = .systemFont(ofSize: 24)
+        stripSummary.textColor = UIColor.white.withAlphaComponent(0.65)
+        stripSummary.numberOfLines = 3
+        seasonInfoStrip.addSubview(stripSummary)
+        NSLayoutConstraint.activate([
+            stripPoster.leadingAnchor.constraint(equalTo: seasonInfoStrip.leadingAnchor),
+            stripPoster.topAnchor.constraint(equalTo: seasonInfoStrip.topAnchor),
+            stripPoster.bottomAnchor.constraint(equalTo: seasonInfoStrip.bottomAnchor),
+            stripPoster.widthAnchor.constraint(equalTo: stripPoster.heightAnchor, multiplier: 2.0 / 3.0),
+            stripMeta.topAnchor.constraint(equalTo: seasonInfoStrip.topAnchor, constant: 2),
+            stripMeta.leadingAnchor.constraint(equalTo: stripPoster.trailingAnchor, constant: 24),
+            stripMeta.trailingAnchor.constraint(lessThanOrEqualTo: seasonInfoStrip.trailingAnchor),
+            stripSummary.topAnchor.constraint(equalTo: stripMeta.bottomAnchor, constant: 8),
+            stripSummary.leadingAnchor.constraint(equalTo: stripMeta.leadingAnchor),
+            stripSummary.trailingAnchor.constraint(equalTo: seasonInfoStrip.trailingAnchor),
+            stripSummary.bottomAnchor.constraint(lessThanOrEqualTo: seasonInfoStrip.bottomAnchor),
+        ])
+
         episodesClip.translatesAutoresizingMaskIntoConstraints = false
         episodesClip.clipsToBounds = true
         episodesClip.alpha = 0  // cascades in with the chrome via setCurrent()
@@ -394,6 +448,15 @@ final class ExpandedDetailContainerView: UIView {
             seasonsHeader.trailingAnchor.constraint(equalTo: trailingAnchor),
             // No fixed height/width — the pill row hugs the header (equality pins
             // below), so the chunky pills define both. They were crushed to 44pt.
+
+            // Season info strip: under the pills, on the shared content edge.
+            // Width capped for summary readability. The show-family details
+            // landing (BelowFoldCollectionView.showDetailsTopY) is what reserves
+            // the vertical room this occupies.
+            seasonInfoStrip.topAnchor.constraint(equalTo: seasonsHeader.bottomAnchor, constant: 8),
+            seasonInfoStrip.leadingAnchor.constraint(equalTo: leadingAnchor, constant: PreviewCarouselGeometry.expandedChromeInset),
+            seasonInfoStrip.widthAnchor.constraint(equalToConstant: 1040),
+            seasonInfoStrip.heightAnchor.constraint(equalToConstant: Self.seasonStripHeight),
         ])
 
         buildPlaceholderSections()
@@ -474,15 +537,17 @@ final class ExpandedDetailContainerView: UIView {
         scrollOffset = off
         smallTitleLogo.alpha = belowFoldTitleOpacity
         seasonsHeader.alpha = scrollProgress
-        // The title logo + season pills are overlays, but should scroll WITH the
-        // rail rather than float in place: translate them by the rail's offset
-        // past the details-rest position, so they ride up and out as the user
-        // scrolls into the lower rows (and follow the episodes down on
-        // entry/collapse). This runs synchronously inside the scroll animation,
-        // so it animates in sync with the rail.
+        seasonInfoStrip.alpha = scrollProgress
+        // The title logo + season pills + info strip are overlays, but should
+        // scroll WITH the rail rather than float in place: translate them by the
+        // rail's offset past the details-rest position, so they ride up and out
+        // as the user scrolls into the lower rows (and follow the episodes down
+        // on entry/collapse). This runs synchronously inside the scroll
+        // animation, so it animates in sync with the rail.
         let dy = belowFoldCollection.detailsRestOff - off
         let scroll = CGAffineTransform(translationX: 0, y: dy)
         seasonsHeader.transform = scroll
+        seasonInfoStrip.transform = scroll
         smallTitleLogo.transform = scroll
         onScrollProgress?(scrollProgress)
     }
@@ -499,8 +564,13 @@ final class ExpandedDetailContainerView: UIView {
         guard let item else { return }
         setBelowFoldScrollActive(false)
         belowFoldCollection.alpha = 1
+        // Installed BEFORE configure, which is what fires it: the loader's own
+        // season fetch now feeds the pills and the info strip, where
+        // populateSeasonPills used to run a second /children of its own.
+        belowFoldCollection.onSeasonsLoaded = { [weak self] seasons, selectedIndex in
+            self?.applySeasons(seasons, selectedIndex: selectedIndex)
+        }
         belowFoldCollection.configure(item: item, detail: nil)
-        populateSeasonPills(for: item)
         // Entering details starts on the episodes; the selected pill tracks the
         // focused episode's season (set when an episode takes focus).
         detailsFocusTarget = .episodes
@@ -594,6 +664,7 @@ final class ExpandedDetailContainerView: UIView {
         layoutIfNeeded()  // keep the reserve push locked to the translation (§6)
         smallTitleLogo.alpha = belowFoldTitleOpacity
         seasonsHeader.alpha = scrollProgress
+        seasonInfoStrip.alpha = scrollProgress
         onScrollProgress?(scrollProgress)
     }
 
@@ -687,6 +758,11 @@ final class ExpandedDetailContainerView: UIView {
         // Load the centered item's episodes into the single rail (episodes-only
         // in carousel-stable; cast/related are added on expand).
         if let item { belowFoldCollection.configureEpisodesOnly(item: item) }
+        // The previous item's pills and strip describe a different show; they
+        // rebuild from the loader's seasons on reveal (onSeasonsLoaded). The
+        // episodes-only peek load does not fetch seasons, so nothing refills
+        // them before then.
+        applySeasons([], selectedIndex: 0)
 
         logoLoadToken &+= 1
         let token = logoLoadToken
@@ -801,38 +877,56 @@ final class ExpandedDetailContainerView: UIView {
     func armPillEntryFocus() { belowFoldCollection.pillEntryArmed = true }
     func disarmPillEntryFocus() { belowFoldCollection.pillEntryArmed = false }
 
-    func populateSeasonPills(for item: MediaItem) {
-        seasonsToken &+= 1
-        let token = seasonsToken
-        let showRef: MediaItemRef?
-        switch item.kind {
-        case .show: showRef = item.ref
-        case .episode: showRef = item.grandparentRef
-        case .season: showRef = item.parentRef
-        default: showRef = nil
+    /// Apply the loader's seasons to the pills AND the info strip.
+    ///
+    /// Called from `onSeasonsLoaded`, which fires as soon as the below-fold
+    /// loader has the seasons — it already resolved which one to open on, so
+    /// there is nothing to re-derive here and no second `/children` fetch.
+    func applySeasons(_ seasons: [MediaItem], selectedIndex: Int) {
+        seasonItems = seasons
+        setSeasonPills(seasons.map { SeasonPillView.seasonLabel(for: $0) },
+                       seasonRefIDs: seasons.map { $0.ref.itemID },
+                       selectedIndex: selectedIndex)
+        // The strip shows for ANY season count — a single-season show still gets
+        // its summary and progress even though the pills (a chooser) stay hidden.
+        updateSeasonStrip(seasons.isEmpty ? nil : min(max(0, selectedIndex), seasons.count - 1))
+    }
+
+    /// Fill the info strip from a season (nil hides it). Display-only; the poster
+    /// load is token-guarded like the logo's.
+    private func updateSeasonStrip(_ index: Int?) {
+        guard let index, index >= 0, index < seasonItems.count else {
+            stripSeasonID = nil
+            seasonInfoStrip.isHidden = true
+            return
         }
-        guard let showRef,
-              let provider = MediaProviderRegistry.shared.provider(for: item.ref.providerID) else {
-            setSeasonPills([], seasonRefIDs: [], selectedIndex: 0); return
+        let season = seasonItems[index]
+        // Same-season calls no-op: `selectSeasonPill` fires on every episode
+        // focus move as the rail tracks seasons, and restarting the poster load
+        // on each one would flicker the strip.
+        guard stripSeasonID != season.ref.itemID else { return }
+        stripSeasonID = season.ref.itemID
+        seasonInfoStrip.isHidden = false
+        var meta = SeasonPillView.seasonLabel(for: season)
+        if let cp = season.childProgress, cp.total > 0 {
+            meta += " · \(cp.total) episode\(cp.total == 1 ? "" : "s")"
+            if cp.played >= cp.total {
+                meta += " · all watched"
+            } else if cp.played > 0 {
+                meta += " · \(cp.played) watched"
+            }
         }
+        stripMeta.text = meta
+        stripSummary.text = season.overview
+        stripPosterToken &+= 1
+        let token = stripPosterToken
+        stripPoster.image = nil
+        guard let url = season.artwork.thumbnail ?? season.artwork.poster else { return }
         Task { [weak self] in
-            let seasons = (try? await provider.children(of: showRef)) ?? []
+            let image = await ImageCacheManager.shared.image(for: url)
             await MainActor.run {
-                guard let self, self.seasonsToken == token else { return }
-                // Open on the season the carousel item belongs to: the item's own
-                // season ref for a .season, or the parent season for an .episode.
-                let targetSeasonID: String?
-                switch item.kind {
-                case .season: targetSeasonID = item.ref.itemID
-                case .episode: targetSeasonID = item.parentRef?.itemID
-                default: targetSeasonID = nil
-                }
-                let selected = targetSeasonID.flatMap { id in
-                    seasons.firstIndex(where: { $0.ref.itemID == id })
-                } ?? 0
-                let labels = seasons.map { SeasonPillView.seasonLabel(for: $0) }
-                let refIDs = seasons.map { $0.ref.itemID }
-                self.setSeasonPills(labels, seasonRefIDs: refIDs, selectedIndex: selected)
+                guard let self, self.stripPosterToken == token, let image else { return }
+                self.stripPoster.image = image
             }
         }
     }
@@ -895,6 +989,12 @@ final class ExpandedDetailContainerView: UIView {
         guard index >= 0, index < seasonPills.count else { return }
         selectedSeasonIndex = index
         for (i, pill) in seasonPills.enumerated() { pill.setSelected(i == index) }
+        // The strip follows the selected season, so it is refreshed from the one
+        // place that owns selection — whether that came from a pill taking focus
+        // or from the rail crossing a season boundary. Keeping it here is what
+        // lets the pill's own same-season early return stay as it is: the strip
+        // and `selectedSeasonIndex` can only move together.
+        updateSeasonStrip(index)
         // While focus is in the row the engine scrolls the pill in itself; don't
         // run a second scroll against it. This covers the other direction — the
         // pill following the focused episode's season.

--- a/Rivulet/Views/Media/MediaDetail/UIKit/ExpandedDetailContainerView.swift
+++ b/Rivulet/Views/Media/MediaDetail/UIKit/ExpandedDetailContainerView.swift
@@ -212,6 +212,9 @@ final class ExpandedDetailContainerView: UIView {
         get { belowFoldCollection.onSelectPerson }
         set { belowFoldCollection.onSelectPerson = newValue }
     }
+    /// Season pill Select → open that season's own page. Unwired, the pill falls
+    /// back to re-affirming the season in the rail.
+    var onOpenSeason: ((MediaItem) -> Void)?
 
     /// True briefly after focus first lands on the episodes row (same-press guard
     /// for the episodes→pills jump).
@@ -969,10 +972,17 @@ final class ExpandedDetailContainerView: UIView {
                     self.belowFoldCollection.scrollEpisodesToSeason(seasonRefID: self.seasonRefIDs[i])
                 }
             }
-            // SELECT (press) re-affirms the focused season (rail already moved on
-            // focus). Kept harmless; entering the episodes is done with Down.
+            // SELECT (press) opens that season's own page: full summary, only its
+            // episodes, its extras. Focus already switched the rail's season, so
+            // the press was spare. Unwired, it falls back to re-affirming the
+            // season in the rail. Entering the episodes is still done with Down.
             pill.onSelected = { [weak self] in
-                guard let self, i < self.seasonRefIDs.count else { return }
+                guard let self else { return }
+                if let onOpenSeason = self.onOpenSeason, i < self.seasonItems.count {
+                    onOpenSeason(self.seasonItems[i])
+                    return
+                }
+                guard i < self.seasonRefIDs.count else { return }
                 self.belowFoldCollection.scrollEpisodesToSeason(seasonRefID: self.seasonRefIDs[i])
             }
             seasonPillRow.addArrangedSubview(pill)

--- a/Rivulet/Views/Media/MediaDetail/UIKit/MediaDetailChromeView.swift
+++ b/Rivulet/Views/Media/MediaDetail/UIKit/MediaDetailChromeView.swift
@@ -286,6 +286,26 @@ final class MediaDetailChromeView: UIView {
         return l
     }()
 
+    /// Season pages only: the season's poster, large, leading of the whole text
+    /// column. Hidden for every other kind — movie/show heroes stay
+    /// backdrop-driven.
+    private let seasonPosterView: UIImageView = {
+        let v = UIImageView()
+        v.translatesAutoresizingMaskIntoConstraints = false
+        v.contentMode = .scaleAspectFill
+        v.clipsToBounds = true
+        v.layer.cornerRadius = 14
+        v.layer.cornerCurve = .continuous
+        v.backgroundColor = UIColor.white.withAlphaComponent(0.08)
+        v.isHidden = true
+        return v
+    }()
+    /// The text column's leading: on the chrome edge normally, indented past the
+    /// poster on season pages. Exactly one is active at a time (deactivate before
+    /// activate — both constrain chromeStack.leading).
+    private var chromeLeadingDefault: NSLayoutConstraint!
+    private var chromeLeadingWithPoster: NSLayoutConstraint!
+
     // MARK: - Init
 
     override init(frame: CGRect) {
@@ -341,12 +361,30 @@ final class MediaDetailChromeView: UIView {
         let descMaxWidth = descriptionLabel.widthAnchor.constraint(lessThanOrEqualToConstant: 560)
         descMaxWidth.priority = .required
 
+        addSubview(seasonPosterView)
+        chromeLeadingDefault = chromeStack.leadingAnchor.constraint(equalTo: leadingAnchor)
+        chromeLeadingWithPoster = chromeStack.leadingAnchor.constraint(
+            equalTo: seasonPosterView.trailingAnchor, constant: 48)
+        chromeLeadingDefault.isActive = true
+
         NSLayoutConstraint.activate([
-            // Chrome stack fills self.
-            chromeStack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            // Chrome stack fills self (leading is the default/poster pair above).
             chromeStack.trailingAnchor.constraint(equalTo: trailingAnchor),
             chromeStack.topAnchor.constraint(equalTo: topAnchor),
             chromeStack.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            // Season poster: bottom-aligned with the chrome (the action row),
+            // growing upward to its preferred height; the required top bound
+            // shrinks it on shorter chromes instead of overflowing the hero.
+            seasonPosterView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            seasonPosterView.bottomAnchor.constraint(equalTo: chromeStack.bottomAnchor),
+            seasonPosterView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor),
+            seasonPosterView.widthAnchor.constraint(equalTo: seasonPosterView.heightAnchor, multiplier: 2.0 / 3.0),
+            {
+                let c = seasonPosterView.heightAnchor.constraint(equalToConstant: 480)
+                c.priority = .init(999)
+                return c
+            }(),
 
             // Logo slot: 138pt tall, 620pt max wide.
             logoSlotView.heightAnchor.constraint(equalToConstant: 138),
@@ -456,6 +494,16 @@ final class MediaDetailChromeView: UIView {
         actionButtonsStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
         playButton = nil
         castLabel.text = nil
+        clearSeasonPoster()
+    }
+
+    /// Put the chrome back on its default (posterless) leading. Both call sites
+    /// must run this before deciding whether the new item wants a poster.
+    private func clearSeasonPoster() {
+        seasonPosterView.image = nil
+        seasonPosterView.isHidden = true
+        chromeLeadingWithPoster.isActive = false
+        chromeLeadingDefault.isActive = true
     }
 
     /// Install a width = height × imageAspect constraint on
@@ -522,8 +570,28 @@ final class MediaDetailChromeView: UIView {
         qualityRow.arrangedSubviews.forEach { $0.removeFromSuperview() }
         nextUpLabel.isHidden = true
         nextUpLabel.text = nil
+        clearSeasonPoster()
 
         guard let item = item else { return }
+
+        // Season pages: the season's poster, large, indenting the text column.
+        // Memory-cache probe first for a flash-free frame 0, like the logo.
+        if item.kind == .season, let posterURL = item.artwork.poster ?? item.artwork.thumbnail {
+            seasonPosterView.isHidden = false
+            chromeLeadingDefault.isActive = false
+            chromeLeadingWithPoster.isActive = true
+            if let cached = ImageCacheManager.shared.cachedImage(for: posterURL) {
+                seasonPosterView.image = cached
+            } else {
+                Task { [weak self] in
+                    let image = await ImageCacheManager.shared.image(for: posterURL)
+                    await MainActor.run {
+                        guard let self, self.loadToken == token, let image else { return }
+                        self.seasonPosterView.image = image
+                    }
+                }
+            }
+        }
 
         rebuildGenreRow(item: item, detail: nil)
         rebuildQualityRow(item: item, detail: nil)

--- a/Rivulet/Views/Media/PreviewCarousel/UIKit/PreviewCarouselViewController.swift
+++ b/Rivulet/Views/Media/PreviewCarousel/UIKit/PreviewCarouselViewController.swift
@@ -361,6 +361,18 @@ final class PreviewCarouselViewController: UIViewController {
         expandedDetail.onShowRelatedDetails = { [weak self] item in
             self?.presentStandaloneDetail(item)
         }
+
+        // Season pill Select → that season's own standalone page (full summary,
+        // only its episodes, its extras). Same-season guard: on a season's own
+        // page, re-selecting its pill must not stack a duplicate of the page it
+        // is already on. SIBLING seasons still open — presentStandaloneDetail
+        // walks to the topmost presented controller, so season-to-season hopping
+        // stacks naturally, and each hop keeps the focus-restore contract.
+        expandedDetail.onOpenSeason = { [weak self] season in
+            guard let self else { return }
+            if self.standaloneDetail, self.items.first?.ref == season.ref { return }
+            self.presentStandaloneDetail(season)
+        }
         // Cast / crew cell Select → person detail page (full-screen).
         expandedDetail.onSelectPerson = { [weak self] person in
             guard let self else { return }


### PR DESCRIPTION
Five commits that make it clearer which season you're looking at on a show's detail page. They build on the #261 pill-scroller work rather than replacing any of it — the scroller, `revealSeasonPill` and the focus containment are all yours and untouched.

This has been running on my fork for a while and through several rounds of use on device, which is where most of the smaller decisions below came from.

**1. Season pills deliver Select from the press cycle**

`SeasonPillView` is a plain `UIControl`, and Select doesn't fire `.primaryActionTriggered` on one of those on tvOS — a trap already recorded in seven other files here. The pill was the one plain control still wired that way, so its `onSelected` has never fired.

It went unnoticed because the handler is deliberately redundant: the row switches season on focus, so the press had nothing to add and its absence looked exactly like its presence. It's a prerequisite for commit 4, where Select gains a real job.

Consumes the press in both began/ended, mirroring `AboutCardControl` in the same directory. One behaviour change follows, and it's the handler's documented intent rather than anything new — Select now re-affirms the season by scrolling the rail to it, visible only when coming Up from a mid-season episode.

**2. Season pills and a season info strip from one seasons fetch**

`populateSeasonPills` fetched the show's seasons itself, purely to label the pills — a second `/children` per detail open, when the below-fold loader already fetches the same list and already resolves which season to open on. The pills now come from the loader via a new `onSeasonsLoaded`, and `populateSeasonPills` is gone.

Keeping the season *items* rather than just their labels is what makes the info strip possible: poster, episode count and watched progress, and a three-line summary for the season the pills are tracking. Display-only and never focusable, so it adds no focus surface.

The strip is refreshed from inside `selectSeasonPill` rather than from the pill's focus handler, which keeps it locked to `selectedSeasonIndex` — that's what lets your existing same-season early return stay exactly as it is.

`detailsTopY` becomes per-kind to reserve the strip's room: show-family pages land the rail at 396 where movies keep 230. The rest position is unchanged either way, since the episodes section's top inset derives from the same value and the two cancel at rest.

**3. Season dividers in the flat episode rail**

A show's rail runs every season end to end, so the only cue that a season changed was the S01E01 prefix. This adds a slim, non-focusable marker at each transition.

The rail therefore mixes widths, which the repeating-item shelf section can't express, so the episodes section becomes a custom layout group with eagerly computed frames. That keeps layout attributes exact, which matters because three things read them: the orthogonal season scroll, pill alignment, and the initial-episode landing.

The dividers ride inside `cachedEpisodes`, so the snapshot and every `firstIndex(where:)` lookup stay correct untouched — they already pattern-match `.episode`. Two places needed adjusting: `armAdjacentEpisodeThumb` stepped one rail index at a time and would have armed focus on a divider, and `scrollOrthogonalEpisodes`' pre-attributes fallback assumed a fixed pitch. Single-season rails get no dividers.

**4. Season pill Select opens that season's own page**

Full summary, only its episodes, its extras. Routed through `presentStandaloneDetail`, so season-to-season hopping stacks naturally and each hop keeps the existing focus-restore contract on dismiss. Guarded so a season's own page can't stack a duplicate of itself. Unwired, the pill falls back to its previous behaviour.

**5. Season pages carry the season's poster in the hero**

With the pill opening a season's own page, that page looked exactly like the show's — same backdrop, same logo, nothing saying which season you'd opened. The season's poster goes in the hero, large, leading of the text column.

Strictly additive for every other kind: the chrome's leading is now a pair of constraints with exactly one active, and the default is what every movie and show still gets. Both entry points restore the default before deciding, so a season page followed by a movie can't leave the text column indented past a hidden poster. The poster is bottom-aligned with the action row and grows upward to a preferred 480pt under a required top bound, so a shorter chrome shrinks it rather than overflowing the hero.

---

Six existing files, no new files, so no project file change. Builds for tvOS and the full unit suite passes, including `SeasonPillRowLayoutTests` unmodified. (Three `CredentialRegistryTests` fail for me because I build unsigned and they round-trip the keychain; they fail identically on a clean checkout of `main`.)
