### PR TITLE
Plex Live TV: direct-play the tuned session, and group the guide

### DIFF
--- a/Rivulet/Services/LiveTV/PlexLiveTVProvider.swift
+++ b/Rivulet/Services/LiveTV/PlexLiveTVProvider.swift
@@ -152,12 +152,33 @@ actor PlexLiveTVProvider: LiveTVProvider {
             throw error
         }
 
+        // Favourites are account-level, not per-DVR, so this is ONE call for the
+        // whole lineup. Rank is array position: that is the order the user
+        // arranged, and the merged channel list is sorted by number, which would
+        // otherwise throw it away. Best effort — an account with none, or a call
+        // that fails, simply yields no Favourites tab.
+        //
+        // NOT `self.authToken`. This provider is constructed with
+        // `selectedServerToken`, and a server token is rejected by the provider
+        // hosts — the same account-vs-server trap the Discover endpoints
+        // document. Read the account token directly for this one call.
+        var favouriteRanks: [String: Int] = [:]
+        if let accountToken = await PlexAuthManager.shared.authToken {
+            for (index, identifier) in await networkManager
+                .getFavoriteChannelIdentifiers(authToken: accountToken)
+                .enumerated() {
+                favouriteRanks[identifier] = index
+            }
+        }
+
         // Convert to UnifiedChannel
         let channels = plexChannels.map { plexChannel in
-            plexChannel.toUnifiedChannel(
+            let rank = plexChannel.channelIdentifier.flatMap { favouriteRanks[$0] }
+            return plexChannel.toUnifiedChannel(
                 sourceId: sourceId,
                 serverURL: serverURL,
-                authToken: authToken
+                authToken: authToken,
+                favouriteRank: rank
             )
         }
 
@@ -373,7 +394,10 @@ actor PlexLiveTVProvider: LiveTVProvider {
         }
 
         components.queryItems = queryItems
-        let newURL = components.url ?? originalURL
+        // Reassigning queryItems decoded the profile's %2B separators back to
+        // raw '+'. Without this the rebuilt URL reaches PMS with spaces between
+        // the client-profile clauses. See finalizedLiveURL.
+        let newURL = PlexLiveTVChannel.finalizedLiveURL(components) ?? originalURL
 
         // Log session ID regeneration (GitHub #64 - DVB diagnostics)
         let breadcrumb = Breadcrumb(level: .info, category: "plex_livetv")
@@ -480,6 +504,9 @@ actor PlexLiveTVProvider: LiveTVProvider {
                     if let ratingKey = tune.ratingKey {
                         items.append(URLQueryItem(name: "rivuletLiveRatingKey", value: ratingKey))
                     }
+                    if let scan = tune.videoScanType {
+                        items.append(URLQueryItem(name: "rivuletLiveScanType", value: scan))
+                    }
                     items.append(URLQueryItem(name: "X-Plex-Token", value: authToken))
                     dp.queryItems = items
                     if let url = dp.url { return url }
@@ -499,12 +526,14 @@ actor PlexLiveTVProvider: LiveTVProvider {
             if let ratingKey = tune.ratingKey {
                 items.append(URLQueryItem(name: "rivuletLiveRatingKey", value: ratingKey))
             }
-            start?.queryItems = items
-            if let escapedQuery = start?.percentEncodedQuery?
-                .replacingOccurrences(of: "+", with: "%2B") {
-                start?.percentEncodedQuery = escapedQuery
+            // Carried on the URL rather than threaded through LiveTVDataStore,
+            // matching how the ratingKey above already reaches the keepalive.
+            // `AetherPlayer.needsDeinterlacing` reads it back.
+            if let scan = tune.videoScanType {
+                items.append(URLQueryItem(name: "rivuletLiveScanType", value: scan))
             }
-            return start?.url ?? base
+            start?.queryItems = items
+            return start.flatMap { PlexLiveTVChannel.finalizedLiveURL($0) } ?? base
         } catch {
             SentryBridge.capture(error: error) { scope in
                 scope.setTag(value: "plex_livetv", key: "component")

--- a/Rivulet/Services/Plex/Playback/AetherPlayer.swift
+++ b/Rivulet/Services/Plex/Playback/AetherPlayer.swift
@@ -655,7 +655,12 @@ final class AetherPlayer: PlayerProtocol {
     /// rejects AVPlayer's request pattern).
     func loadLive(url: URL, headers: [String: String]?, forceEngineDemux: Bool = false) async throws {
         let isHLS = Self.liveRoute(for: url, forceEngineDemux: forceEngineDemux) == .nativeHLS
-        let options = LoadOptions(
+        // Forced onto the engine demuxer AND the source is a playlist: the Plex
+        // direct-play case. See the ingest branch below.
+        let usesHLSIngest = !isHLS && Self.isHLSURL(url)
+
+        func makeOptions(nativeRemoteHLS: Bool) -> LoadOptions {
+            LoadOptions(
             suppressDisplayCriteria: false,
             httpHeaders: headers ?? [:],
             // Same rich config as VOD, plus the live-specific flags.
@@ -665,7 +670,7 @@ final class AetherPlayer: PlayerProtocol {
             isLive: true,
             // ~30-minute DVR rewind window (engine retains it disk-backed).
             dvrWindowSeconds: 1800,
-            nativeRemoteHLS: isHLS,
+            nativeRemoteHLS: nativeRemoteHLS,
             preserveASSMarkup: true,
             probesize: 5 * 1024 * 1024,
             maxAnalyzeDuration: 5_000_000,
@@ -678,7 +683,11 @@ final class AetherPlayer: PlayerProtocol {
             // captions on 801 without that flag, so auto-detect returns nothing.
             // Region-default to 801 for AU, otherwise auto-detect.
             teletextPage: Self.regionTeletextPage()
-        )
+            )
+        }
+
+        let options = makeOptions(nativeRemoteHLS: isHLS)
+
         // Same reason as the VOD path: a zap is new content, and broadcast
         // mixes 4:3 SD with 16:9 HD channel to channel, so a reused slot must
         // not measure the new channel against the old one's picture rect.
@@ -696,9 +705,49 @@ final class AetherPlayer: PlayerProtocol {
             // (Engine flag is labeled test-only but is the exact switch for
             // this; reset immediately after dispatch. Not applied to the
             // native-HLS shortcut, which never enters the demux dispatch.)
-            if !isHLS { AetherEngine.setForceSoftwarePathForTesting(true) }
-            defer { if !isHLS { AetherEngine.setForceSoftwarePathForTesting(false) } }
-            try await engine.load(url: url, startPosition: nil, options: options)
+            //
+            // ...but only where the channel actually needs it. A 720p or
+            // 1080p50 broadcast has no fields to weave and should not pay for
+            // the deinterlacing path. PMS reports the scan type on the tune, so
+            // the answer is known before the load — see `needsDeinterlacing`.
+            let forceSoftware = !isHLS && Self.needsDeinterlacing(url)
+            if forceSoftware { AetherEngine.setForceSoftwarePathForTesting(true) }
+            defer { if forceSoftware { AetherEngine.setForceSoftwarePathForTesting(false) } }
+
+            // A Plex direct-play part key is an HLS PLAYLIST
+            // (/livetv/sessions/{uuid}/{consumer}/index.m3u8), not the raw
+            // transport stream the engine's raw live path expects. Handing it
+            // an m3u8 body fails closed by design (AE#140), and the host's
+            // fallback then re-tuned and landed on nativeRemoteHLS — so every
+            // granted direct play was quietly played by AVPlayer, which cannot
+            // decode mp2 or DVB teletext. Those two are the entire reason for
+            // wanting direct play here, so the grant was being thrown away.
+            //
+            // HLSLiveIngestReader demuxes the playlist's underlying MPEG-TS, so
+            // teletext and broadcast audio reach the engine and our own caption
+            // renderer. It is also why this route costs ONE tune: the old path
+            // needed a second grab to discover it had to fall back.
+            if usesHLSIngest {
+                do {
+                    try await engine.load(
+                        source: .custom(HLSLiveIngestReader(playlistURL: url), formatHint: "mpegts"),
+                        options: options
+                    )
+                } catch is HLSIngestError {
+                    // Encryption or an fMP4 playlist the ingest reader will not
+                    // open. Retry natively on the SAME session rather than
+                    // throwing: letting the host fall back costs another tune,
+                    // and on a single-tuner box that competes with the grab we
+                    // are already holding.
+                    try await engine.load(
+                        url: url,
+                        startPosition: nil,
+                        options: makeOptions(nativeRemoteHLS: true)
+                    )
+                }
+            } else {
+                try await engine.load(url: url, startPosition: nil, options: options)
+            }
         } catch {
             // The caller left the slot / retuned while the load was in flight.
             // Rethrow untouched so the type survives; wrapping it in a
@@ -720,6 +769,25 @@ final class AetherPlayer: PlayerProtocol {
     /// is inert on `.nativeHLS`.
     static func liveRoute(for url: URL, forceEngineDemux: Bool) -> LiveJoinRoute {
         (isHLSURL(url) && !forceEngineDemux) ? .nativeHLS : .loopback
+    }
+
+    /// Whether this live source has to take the deinterlacing path.
+    ///
+    /// Reads `rivuletLiveScanType`, which `PlexLiveTVProvider` puts on the URL
+    /// from the tune response — the same carry-on-the-URL trick the keepalive's
+    /// ratingKey uses, so nothing has to be threaded through LiveTVDataStore.
+    ///
+    /// **Absence means yes.** Only an explicit "progressive" from the server
+    /// opts out. A missing or unrecognised value keeps the previous behaviour,
+    /// because a needless software decode costs some CPU while a missed
+    /// deinterlace is combing the user can see — and broadcast H.264 is known
+    /// to mis-signal progressive, which is why we do not read the codec's own
+    /// field order here.
+    static func needsDeinterlacing(_ url: URL) -> Bool {
+        guard let scan = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?.first(where: { $0.name == "rivuletLiveScanType" })?.value?
+            .lowercased() else { return true }
+        return scan != "progressive"
     }
 
     private static func isHLSURL(_ url: URL) -> Bool {

--- a/Rivulet/Views/LiveTV/GuideLayoutView.swift
+++ b/Rivulet/Views/LiveTV/GuideLayoutView.swift
@@ -40,17 +40,50 @@ struct GuideLayoutView: View {
         return dataStore.channels
     }
 
-    /// Distinct, sorted M3U group titles used as category tabs.
+    /// Tab title for the source's own favourites list. Not a `groupTitle` — a
+    /// favourite keeps its tuner group too, and this tab sorts by the order the
+    /// user arranged rather than by channel number.
+    static let favouritesTab = "Plex Favourites"
+
+    /// Tabs that lead the bar regardless of the alphabet, in this order. A list
+    /// the user curated outranks a source's own grouping — burying "Favourites"
+    /// under F is the kind of correctness that reads as a bug.
+    private static let pinnedGroups = [favouritesTab]
+
+    /// Distinct group titles used as category tabs: pinned ones first, then
+    /// everything else alphabetically. Fed by an M3U's `group-title` and, for
+    /// Plex sources, by the DVR's user-set tuner name.
     private var groupTitles: [String] {
-        let groups = sourceChannels.compactMap {
-            $0.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
-        }.filter { !$0.isEmpty }
-        return Array(Set(groups)).sorted()
+        let groups = Set(
+            sourceChannels
+                .compactMap { $0.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+        )
+        var available = groups
+        // Offered only when the source actually reported favourites, so a
+        // server without them shows no empty tab.
+        if sourceChannels.contains(where: \.isFavourite) {
+            available.insert(Self.favouritesTab)
+        }
+        let pinned = Self.pinnedGroups.filter(available.contains)
+        let rest = available.subtracting(pinned).sorted()
+        return pinned + rest
     }
 
     /// Channels shown in the grid: source-filtered, then category-filtered.
     private var channels: [UnifiedChannel] {
         guard let group = selectedGroup else { return sourceChannels }
+
+        // Favourites is a view over the flag, not a group match, and it keeps
+        // the source's arrangement instead of the merged channel-number sort
+        // every other tab inherits. Unranked favourites fall to the end rather
+        // than to the front, which is what an unset rank of 0 would do.
+        if group == Self.favouritesTab {
+            return sourceChannels
+                .filter(\.isFavourite)
+                .sorted { ($0.favouriteRank ?? .max) < ($1.favouriteRank ?? .max) }
+        }
+
         return sourceChannels.filter {
             $0.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines) == group
         }

--- a/Rivulet/Views/LiveTV/LiveTVAetherPlayerViewController.swift
+++ b/Rivulet/Views/LiveTV/LiveTVAetherPlayerViewController.swift
@@ -1270,7 +1270,11 @@ final class LiveTVAetherPlayerViewController: UIViewController {
         }
         items[index] = URLQueryItem(name: "directPlay", value: "0")
         components.queryItems = items
-        return components.url ?? url
+        // Reassigning queryItems decodes the client profile's %2B clause
+        // separators back to raw '+', which PMS reads as spaces. Visible in the
+        // wild: a retry URL logged with ')+add-' where the first attempt had
+        // ')%2Badd-'. See PlexLiveTVChannel.finalizedLiveURL.
+        return PlexLiveTVChannel.finalizedLiveURL(components) ?? url
     }
 
     override func viewDidLayoutSubviews() {

--- a/RivuletCore/LiveTV/LiveTVProvider.swift
+++ b/RivuletCore/LiveTV/LiveTVProvider.swift
@@ -51,6 +51,18 @@ struct UnifiedChannel: Identifiable, Hashable, Sendable {
     let groupTitle: String?
     let isHD: Bool
 
+    /// Marked a favourite on the source (Plex "Favourite Channels").
+    ///
+    /// Separate from `groupTitle` rather than being another group name, for two
+    /// reasons the group field cannot express: a favourite stays in its tuner's
+    /// group as well, and the guide has to honour the ORDER the user arranged
+    /// on the source, which is not channel-number order.
+    let isFavourite: Bool
+
+    /// Position within the source's favourites list. Lower sorts first; nil
+    /// falls to the end, ordered by channel number as usual.
+    let favouriteRank: Int?
+
     init(
         id: String,
         sourceType: LiveTVSourceType,
@@ -62,7 +74,9 @@ struct UnifiedChannel: Identifiable, Hashable, Sendable {
         streamURL: URL? = nil,
         tvgId: String? = nil,
         groupTitle: String? = nil,
-        isHD: Bool = false
+        isHD: Bool = false,
+        isFavourite: Bool = false,
+        favouriteRank: Int? = nil
     ) {
         self.id = id
         self.sourceType = sourceType
@@ -75,6 +89,8 @@ struct UnifiedChannel: Identifiable, Hashable, Sendable {
         self.tvgId = tvgId
         self.groupTitle = groupTitle
         self.isHD = isHD
+        self.isFavourite = isFavourite
+        self.favouriteRank = favouriteRank
     }
 
     /// Create a unique identifier combining source and channel

--- a/RivuletCore/Models/Plex/PlexLiveTVModels.swift
+++ b/RivuletCore/Models/Plex/PlexLiveTVModels.swift
@@ -73,6 +73,15 @@ nonisolated struct PlexLiveTVChannel: Codable, Identifiable, Sendable {
     let channelNumber: String?
     let streamURL: String?  // HDHomeRun stream URL
 
+    /// Name of the lineup whose DVR carried this channel, used to group the
+    /// guide the way an M3U's `group-title` does. Assigned by the fetch, which
+    /// is the only place that knows which DVR it just queried — and left nil
+    /// when there is only one, since a lone tab would duplicate All Channels.
+    var tunerName: String?
+
+    /// Key of that DVR. Assigned alongside `tunerName`.
+    var dvrKey: String?
+
     var id: String { ratingKey }
 
     /// Parse channel number as Int
@@ -195,6 +204,53 @@ nonisolated struct PlexDVR: Codable, Sendable {
     let lineup: String?
     let epgIdentifier: String?
     let Device: [PlexDVRDevice]?
+
+    /// Name for this tuner's guide group.
+    ///
+    /// The lineup carries it already, in its fragment — no extra request:
+    ///
+    ///     lineup://tv.plex.providers.epg.cloud/5fc76c88…#Freeview - Perth (58 channels)
+    ///                                                   └──────── this ────────┘
+    ///
+    /// That is the name the user picked their lineup by, so it wins over the
+    /// hardware description. The trailing "(58 channels)" is a count Plex
+    /// appends for its own picker and is dropped — it goes stale the moment a
+    /// channel is enabled or hidden.
+    ///
+    /// `key` is deliberately NOT in the chain: "161" is a worse heading than no
+    /// heading, and nil leaves the channels ungrouped rather than filed under a
+    /// number.
+    var guideGroupName: String? {
+        func cleaned(_ value: String?) -> String? {
+            guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !trimmed.isEmpty else { return nil }
+            return trimmed
+        }
+
+        let makeModel = [cleaned(make), cleaned(model)]
+            .compactMap { $0 }
+            .joined(separator: " ")
+
+        // Annotated: a bare literal mixing String? with the non-optional
+        // `makeModel` infers [Any] and the whole expression stops compiling.
+        let candidates: [String?] = [Self.lineupName(from: lineup), friendlyName, device, makeModel]
+        return candidates.lazy.compactMap(cleaned).first
+    }
+
+    /// Human-readable half of a lineup string, or nil if it carries none.
+    static func lineupName(from lineup: String?) -> String? {
+        guard let lineup, let hash = lineup.firstIndex(of: "#") else { return nil }
+        let raw = String(lineup[lineup.index(after: hash)...])
+        // The value arrives percent-encoded when it has been through a query.
+        let decoded = raw.removingPercentEncoding ?? raw
+        let trimmed = decoded.replacingOccurrences(
+            of: #"\s*\(\d+\s+channels?\)\s*$"#,
+            with: "",
+            options: [.regularExpression, .caseInsensitive]
+        )
+        let name = trimmed.trimmingCharacters(in: .whitespacesAndNewlines)
+        return name.isEmpty ? nil : name
+    }
 }
 
 struct PlexDVRDevice: Sendable {
@@ -266,12 +322,7 @@ extension PlexLiveTVChannel {
             authToken: authToken
         )
         // Consensus wire form: '+' profile-clause separators travel as %2B.
-        if let escapedQuery = components?.percentEncodedQuery?
-            .replacingOccurrences(of: "+", with: "%2B") {
-            components?.percentEncodedQuery = escapedQuery
-        }
-
-        let resultURL = components?.url
+        let resultURL = components.flatMap { Self.finalizedLiveURL($0) }
 
         // Log transcode URL building result (GitHub #64 - DVB diagnostics)
         if let url = resultURL {
@@ -353,6 +404,32 @@ extension PlexLiveTVChannel {
         ]
     }
 
+    /// Finalise a live-session URL, applying the clause-separator encoding that
+    /// every one of these URLs needs and that nothing enforces.
+    ///
+    /// `X-Plex-Client-Profile-Extra` joins its clauses with a raw `+`. That is a
+    /// legal query character, so `URLComponents` does NOT percent-encode it, and
+    /// a strict parser on the far end reads it as a space — the clause boundary
+    /// is gone and PMS parses a malformed profile. It has to travel as `%2B`.
+    ///
+    /// Forgetting is silent: the URL still forms and still looks right, the
+    /// server just negotiates against garbage. It was already missed once, in
+    /// `PlexLiveTVProvider.buildStreamURL`, which re-parses an
+    /// already-correct URL to swap the session UUID — reading `queryItems`
+    /// decodes `%2B` back to `+`, and re-serialising left it raw. Route every
+    /// build and REBUILD of one of these URLs through here.
+    ///
+    /// (`%2C` needs no such care: it survives the round trip because the `%`
+    /// itself gets encoded to `%25`, and decoded back, symmetrically.)
+    static func finalizedLiveURL(_ components: URLComponents) -> URL? {
+        var components = components
+        if let escaped = components.percentEncodedQuery?
+            .replacingOccurrences(of: "+", with: "%2B") {
+            components.percentEncodedQuery = escaped
+        }
+        return components.url
+    }
+
     /// X-Plex-Client-Profile-Extra for live sessions, in the canonical
     /// header-form: clauses joined by raw '+', comma lists pre-encoded as %2C
     /// (the PMS OpenAPI spec's own example uses exactly this shape). The whole
@@ -363,21 +440,40 @@ extension PlexLiveTVChannel {
             // Direct-play profiles: AetherEngine demuxes raw MPEG-TS HLS and
             // software-decodes MPEG-2 / mp2, so declare the raw broadcast
             // codecs and let the server grant passthrough when it can.
-            "add-direct-play-profile(type=videoProfile&protocol=hls&container=mpegts&videoCodec=h264%2Chevc%2Cmpeg2video&audioCodec=aac%2Cac3%2Ceac3%2Cmp2%2Cmp3)",
-            "add-direct-play-profile(type=videoProfile&protocol=http&container=mpegts&videoCodec=h264%2Chevc%2Cmpeg2video&audioCodec=aac%2Cac3%2Ceac3%2Cmp2%2Cmp3)",
+            //
+            // Video is deliberately left at the three codecs broadcast actually
+            // uses. Audio is the full set FFmpegBuild decodes, because a channel
+            // whose only mismatch is its audio would otherwise be converted over
+            // something the client could have taken as-is — and DTS in
+            // particular shows up on cable and satellite feeds.
+            //
+            // `subtitleCodec=dvb_teletext` is the reason this matters most: it
+            // tells PMS we can take teletext untouched, so it has no cause to
+            // convert the page to WebVTT. Without it, a stream that would
+            // otherwise direct-play can be pulled into a conversion purely by
+            // its subtitles, and the teletext the caption renderer wants is gone.
+            "add-direct-play-profile(type=videoProfile&protocol=hls&container=mpegts&videoCodec=h264%2Chevc%2Cmpeg2video&audioCodec=aac%2Cac3%2Ceac3%2Cmp2%2Cmp3%2Cdts%2Ctruehd%2Cflac%2Calac%2Copus%2Cvorbis%2Cpcm&subtitleCodec=dvb_teletext)",
+            "add-direct-play-profile(type=videoProfile&protocol=http&container=mpegts&videoCodec=h264%2Chevc%2Cmpeg2video&audioCodec=aac%2Cac3%2Ceac3%2Cmp2%2Cmp3%2Cdts%2Ctruehd%2Cflac%2Calac%2Copus%2Cvorbis%2Cpcm&subtitleCodec=dvb_teletext)",
 
             // Direct-stream target: keep mp2/mp3 so a remux COPIES broadcast
             // audio instead of re-encoding it (the engine decodes mp2 fine).
-            "add-transcode-target(type=videoProfile&context=streaming&protocol=hls&container=mpegts&videoCodec=h264%2Chevc%2Cmpeg2video&audioCodec=aac%2Cac3%2Ceac3%2Cmp2%2Cmp3&replace=true)",
+            "add-transcode-target(type=videoProfile&context=streaming&protocol=hls&container=mpegts&videoCodec=h264%2Chevc%2Cmpeg2video&audioCodec=aac%2Cac3%2Ceac3%2Cmp2%2Cmp3%2Cdts%2Ctruehd%2Cflac%2Calac%2Copus%2Cvorbis%2Cpcm&replace=true)",
 
-            // Subtitle transcode target.
+            // Subtitle transcode target. Only reached when direct play was
+            // refused for some other reason; the clause above is what keeps
+            // teletext out of this path in the first place.
             "add-transcode-target(type=subtitleProfile&context=streaming&protocol=hls&container=webvtt&subtitleCodec=webvtt)",
         ]
         return clauses.joined(separator: "+")
     }
 
     /// Convert to UnifiedChannel
-    func toUnifiedChannel(sourceId: String, serverURL: String, authToken: String) -> UnifiedChannel {
+    func toUnifiedChannel(
+        sourceId: String,
+        serverURL: String,
+        authToken: String,
+        favouriteRank: Int? = nil
+    ) -> UnifiedChannel {
         let channelId = UnifiedChannel.makeId(
             sourceType: .plex,
             sourceId: sourceId,
@@ -467,8 +563,12 @@ extension PlexLiveTVChannel {
             logoURL: logoURL,
             streamURL: streamURLValue,
             tvgId: channelIdentifier ?? ratingKey,
-            groupTitle: nil,
-            isHD: isHD
+            // Groups the guide by tuner, the same field an M3U fills from
+            // `group-title`. nil reads as "ungrouped" rather than a new tab.
+            groupTitle: tunerName,
+            isHD: isHD,
+            isFavourite: favouriteRank != nil,
+            favouriteRank: favouriteRank
         )
     }
 }

--- a/RivuletCore/Plex/PlexNetworkManager.swift
+++ b/RivuletCore/Plex/PlexNetworkManager.swift
@@ -2071,9 +2071,13 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
             headers: plexHeaders(authToken: authToken)
         )
 
-        guard let dvr = dvrContainer.MediaContainer.Dvr?.first,
-              let lineup = dvr.lineup,
-              let dvrKey = dvr.key else {
+        // Every DVR, not just the first. A server with two tuners exposes two
+        // DVRs with separate lineups, and taking `.first` silently dropped one
+        // lineup's channels entirely — the guide simply never showed them.
+        let dvrs = (dvrContainer.MediaContainer.Dvr ?? []).filter {
+            $0.lineup != nil && $0.key != nil
+        }
+        guard !dvrs.isEmpty else {
             print("🌐 PlexNetwork: No DVR or lineup found for Live TV")
             // Log missing DVR/lineup (GitHub #64 - DVB diagnostics)
             let breadcrumb = Breadcrumb(level: .warning, category: "plex_livetv")
@@ -2091,28 +2095,9 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
         // No direct tuner (HDHomeRun) handoff: raw tuner URLs are LAN-only
         // and bypass the server's session/tuner management entirely.
 
-        // Extract provider path using DVR key (e.g., tv.plex.providers.epg.xmltv:28)
-        let providerPath = extractProviderPath(from: lineup, dvrKey: dvrKey)
-
         // Grid requires time parameters to return data
         let now = Int(Date().timeIntervalSince1970)
         let sixHoursLater = now + (6 * 3600)
-
-        guard var components = URLComponents(string: "\(serverURL)/\(providerPath)/grid") else {
-            print("🌐 PlexNetwork: Could not build grid URL from lineup: \(lineup)")
-            throw PlexAPIError.invalidURL
-        }
-
-        components.queryItems = [
-            URLQueryItem(name: "type", value: "1,4"),
-            URLQueryItem(name: "sort", value: "beginsAt"),
-            URLQueryItem(name: "beginsAt<=", value: "\(sixHoursLater)"),
-            URLQueryItem(name: "endsAt>=", value: "\(now)")
-        ]
-
-        guard let gridURL = components.url else {
-            throw PlexAPIError.invalidURL
-        }
 
         // The grid returns programs with channel info in each program's Media array
         nonisolated struct GridContainer: Codable {
@@ -2135,16 +2120,55 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
             let channelVcn: String?  // Visual channel number
         }
 
-        let container: GridContainer = try await request(
-            gridURL,
-            headers: plexHeaders(authToken: authToken)
-        )
-
-        // Extract unique channels from all programs' Media arrays
+        // Extract unique channels from all programs' Media arrays, across every
+        // DVR. Dedupe is by channel identifier and FIRST WINS: a channel two
+        // tuners both carry is attributed to whichever DVR the server listed
+        // first, rather than appearing twice under two groups.
         var seenChannels = Set<String>()
         var channels: [PlexLiveTVChannel] = []
 
-        for program in container.MediaContainer.Metadata ?? [] {
+        for dvr in dvrs {
+            guard let lineup = dvr.lineup, let dvrKey = dvr.key else { continue }
+
+            // Extract provider path using DVR key (e.g., tv.plex.providers.epg.xmltv:28)
+            let providerPath = extractProviderPath(from: lineup, dvrKey: dvrKey)
+            // Named only when there is something to tell apart. One tuner means
+            // its tab would list exactly what All Channels already does, so the
+            // grouping stays off and the bar is just Favourites + All Channels.
+            let tunerName = dvrs.count > 1 ? dvr.guideGroupName : nil
+
+            guard var components = URLComponents(string: "\(serverURL)/\(providerPath)/grid") else {
+                print("🌐 PlexNetwork: Could not build grid URL from lineup: \(lineup)")
+                continue
+            }
+            components.queryItems = [
+                URLQueryItem(name: "type", value: "1,4"),
+                URLQueryItem(name: "sort", value: "beginsAt"),
+                URLQueryItem(name: "beginsAt<=", value: "\(sixHoursLater)"),
+                URLQueryItem(name: "endsAt>=", value: "\(now)")
+            ]
+            guard let gridURL = components.url else { continue }
+
+            // One unreachable DVR must not cost the user every other tuner's
+            // channels, so a failure here is logged and skipped rather than
+            // thrown. Only a total wipeout surfaces, as an empty list.
+            let container: GridContainer
+            do {
+                container = try await request(gridURL, headers: plexHeaders(authToken: authToken))
+            } catch {
+                let breadcrumb = Breadcrumb(level: .warning, category: "plex_livetv")
+                breadcrumb.message = "Grid fetch failed for one DVR; continuing with the rest"
+                breadcrumb.data = [
+                    "dvr_key": dvrKey,
+                    "tuner_name": tunerName ?? "unnamed",
+                    "provider_path": providerPath,
+                    "dvr_count": dvrs.count
+                ]
+                SentryBridge.addBreadcrumb(breadcrumb)
+                continue
+            }
+
+            for program in container.MediaContainer.Metadata ?? [] {
             for media in program.Media ?? [] {
                 guard let channelId = media.channelIdentifier,
                       !seenChannels.contains(channelId) else {
@@ -2180,10 +2204,15 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
                     channelNumber: channelNumber,
                     // No direct tuner handoff — all Plex Live TV plays through
                     // the server (tune → /livetv/sessions).
-                    streamURL: nil
+                    streamURL: nil,
+                    // Groups the guide by tuner. Assigned here because this is
+                    // the only point that knows which DVR served the lineup.
+                    tunerName: tunerName,
+                    dvrKey: dvrKey
                 )
 
                 channels.append(channel)
+            }
             }
         }
 
@@ -2196,6 +2225,45 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
         SentryBridge.addBreadcrumb(summaryBreadcrumb)
 
         return channels
+    }
+
+    /// Channel identifiers the user has favourited, in the order they arranged
+    /// them in Plex's own guide.
+    ///
+    /// This lives on the ACCOUNT, not the server — `epg.provider.plex.tv`, a
+    /// fourth provider host alongside the three in the Discover section. That is
+    /// why nothing under `/livetv/dvrs/…` carries a favourite flag, and why one
+    /// list can span a local tuner and Plex's free channels. Account token, like
+    /// every other provider call.
+    ///
+    /// `FavoriteChannel[].id` is the same `channelIdentifier` the grid and the
+    /// tune endpoint use, so no mapping is needed. Array order is the user's
+    /// order and is the whole point: favourites are arranged by hand, and the
+    /// merged channel list is sorted by number, which would destroy it.
+    func getFavoriteChannelIdentifiers(authToken: String) async -> [String] {
+        guard let url = URL(string: "https://epg.provider.plex.tv/settings/favoriteChannels") else {
+            return []
+        }
+
+        var headers = plexHeaders(authToken: authToken)
+        headers["Accept"] = "application/json"
+        // Plex Web sends this on every provider call.
+        headers["X-Plex-Provider-Version"] = "5.1"
+
+        do {
+            let data = try await requestData(url, headers: headers)
+            let container = try JSONDecoder().decode(PlexFavoriteChannelContainer.self, from: data)
+            let ids = (container.MediaContainer.FavoriteChannel ?? []).map(\.id)
+            return ids
+        } catch {
+            // Best effort: an account with no favourites and a call that failed
+            // both mean the same thing here — no Favourites tab.
+            let breadcrumb = Breadcrumb(level: .warning, category: "plex_livetv")
+            breadcrumb.message = "Favourite channels unavailable"
+            breadcrumb.data = ["error": String(describing: error)]
+            SentryBridge.addBreadcrumb(breadcrumb)
+            return []
+        }
     }
 
     /// Tune a Plex Live TV channel and return its playback handshake values.
@@ -2238,6 +2306,7 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
 
         var headers = plexHeaders(authToken: authToken)
         headers["Accept"] = "application/json"
+
         let data = try await requestData(url, method: "POST", headers: headers)
 
         // The response shape varies between PMS versions and EPG providers:
@@ -2338,6 +2407,31 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
             return nil
         }
 
+        /// Scan type of the first VIDEO stream (Stream.streamType == 1) anywhere
+        /// in the tune payload. PMS reports this on the dashboard, and the tune
+        /// response already carries the stream tree — so the interlaced/progressive
+        /// question is answerable at tune time, before the engine is asked to load.
+        ///
+        /// Walks rather than decodes, for the same reason the session key does:
+        /// the nesting varies by PMS version and EPG provider.
+        func firstVideoScanType(in node: Any) -> String? {
+            if let dict = node as? [String: Any] {
+                let isVideoStream = (dict["streamType"] as? Int) == 1
+                    || (dict["streamType"] as? String) == "1"
+                if isVideoStream, let scan = dict["scanType"] as? String, !scan.isEmpty {
+                    return scan.lowercased()
+                }
+                for value in dict.values {
+                    if let scan = firstVideoScanType(in: value) { return scan }
+                }
+            } else if let array = node as? [Any] {
+                for value in array {
+                    if let scan = firstVideoScanType(in: value) { return scan }
+                }
+            }
+            return nil
+        }
+
         // The Part key inside the grab is the DIRECT-PLAY stream: the DVR's
         // own HLS of the raw broadcast (/livetv/sessions/<uuid>/<tuner>/index.m3u8),
         // served without the universal transcoder.
@@ -2359,13 +2453,15 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
             throw PlexAPIError.invalidResponse
         }
 
+        let scanType = firstVideoScanType(in: mediaContainer)
         let sessionUUID = sessionPath.split(separator: "/").dropFirst(2).first.map(String.init)
             ?? sessionIdentifier
         return PlexLiveTVTuneResult(
             sessionUUID: sessionUUID,
             sessionPath: sessionPath,
             sessionIdentifier: sessionIdentifier,
-            ratingKey: firstNumericRatingKey(in: mediaContainer)
+            ratingKey: firstNumericRatingKey(in: mediaContainer),
+            videoScanType: scanType
         )
     }
 
@@ -2399,9 +2495,9 @@ class PlexNetworkManager: NSObject, @unchecked Sendable {
         )
         // Consensus wire form for the profile: '+' clause separators must be
         // %2B (a raw '+' in a query decodes as a space on strict parsers).
-        components.percentEncodedQuery = components.percentEncodedQuery?
-            .replacingOccurrences(of: "+", with: "%2B")
-        guard let url = components.url else { throw PlexAPIError.invalidURL }
+        guard let url = PlexLiveTVChannel.finalizedLiveURL(components) else {
+            throw PlexAPIError.invalidURL
+        }
 
         var request = URLRequest(url: url)
         request.setValue("application/json", forHTTPHeaderField: "Accept")
@@ -2950,6 +3046,27 @@ extension PlexNetworkManager: URLSessionDelegate {
 // MARK: - Live TV Tune Result
 
 /// Result of tuning a Plex Live TV channel.
+/// Account-level favourite channels (`epg.provider.plex.tv/settings/favoriteChannels`).
+nonisolated struct PlexFavoriteChannelContainer: Codable, Sendable {
+    let MediaContainer: PlexFavoriteChannelMediaContainer
+}
+
+nonisolated struct PlexFavoriteChannelMediaContainer: Codable, Sendable {
+    let size: Int?
+    let FavoriteChannel: [PlexFavoriteChannel]?
+}
+
+nonisolated struct PlexFavoriteChannel: Codable, Sendable {
+    /// Matches `channelIdentifier` on the grid and the tune endpoint.
+    let id: String
+    /// `server://{machineIdentifier}/{providerPath}` — which server and DVR the
+    /// favourite belongs to. Unused for now: ids already carry the provider's
+    /// own channel id, so a cross-server collision would be the same channel.
+    let source: String?
+    let title: String?
+    let vcn: String?
+}
+
 nonisolated struct PlexLiveTVTuneResult: Sendable {
     /// The livetv session uuid (derived from the session path).
     let sessionUUID: String
@@ -2962,6 +3079,12 @@ nonisolated struct PlexLiveTVTuneResult: Sendable {
     /// Numeric ratingKey of the live-session metadata item the tune created.
     /// The /:/timeline keepalive needs it to resolve the playing item.
     let ratingKey: String?
+
+    /// Scan type PMS reported for the video stream ("interlaced" / "progressive"),
+    /// or nil when this PMS/provider does not report one. Decides whether the
+    /// channel needs the deinterlacing path; nil must be treated as "assume
+    /// interlaced", since combing is far worse than a decode we didn't need.
+    let videoScanType: String?
 }
 
 /// Universal-transcoder verdict for a tuned live session.

--- a/RivuletTests/Unit/Services/PlexLiveTunerGroupTests.swift
+++ b/RivuletTests/Unit/Services/PlexLiveTunerGroupTests.swift
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+// Copyright (C) 2025-2026 Bain Gurley
+
+//
+//  PlexLiveTunerGroupTests.swift
+//  RivuletTests
+//
+//  Guide grouping for Plex Live TV: tuner group naming and the favourites tab.
+//
+
+import XCTest
+@testable import Rivulet
+
+final class PlexLiveTunerGroupTests: XCTestCase {
+
+    private func makeDVR(
+        key: String? = "159",
+        friendlyName: String? = nil,
+        device: String? = nil,
+        model: String? = nil,
+        make: String? = nil
+    ) -> PlexDVR {
+        PlexDVR(
+            key: key, uuid: nil, friendlyName: friendlyName, device: device,
+            model: model, make: make, status: nil, lineup: "lineup://tv.plex.providers.epg.xmltv/x",
+            epgIdentifier: nil, Device: nil
+        )
+    }
+
+    // MARK: - Tuner name
+
+    /// The lineup fragment is the name the user chose their guide by, so it
+    /// beats the hardware description.
+    func test_lineupNameWins() {
+        let dvr = PlexDVR(
+            key: "161", uuid: nil, friendlyName: "Lounge Tuner", device: "TBS6209",
+            model: "6209", make: "TBS", status: nil,
+            lineup: "lineup://tv.plex.providers.epg.cloud/5fc7#Freeview - Perth (58 channels)",
+            epgIdentifier: nil, Device: nil
+        )
+        XCTAssertEqual(dvr.guideGroupName, "Freeview - Perth")
+    }
+
+    /// Plex appends a channel count for its own picker. It goes stale the moment
+    /// a channel is hidden, so it is not part of the name.
+    func test_lineupChannelCountSuffixIsDropped() {
+        XCTAssertEqual(
+            PlexDVR.lineupName(from: "lineup://x/y#Freeview - Perth (58 channels)"),
+            "Freeview - Perth"
+        )
+        XCTAssertEqual(PlexDVR.lineupName(from: "lineup://x/y#My Guide"), "My Guide")
+    }
+
+    func test_lineupNameHandlesPercentEncodingAndAbsence() {
+        XCTAssertEqual(
+            PlexDVR.lineupName(from: "lineup://x/y#Freeview%20-%20Perth%20(58%20channels)"),
+            "Freeview - Perth"
+        )
+        XCTAssertNil(PlexDVR.lineupName(from: "lineup://x/y"))
+        XCTAssertNil(PlexDVR.lineupName(from: "lineup://x/y#   "))
+        XCTAssertNil(PlexDVR.lineupName(from: nil))
+    }
+
+    func test_friendlyNameWinsWhenTheLineupIsUnnamed() {
+        let dvr = makeDVR(friendlyName: "Lounge Tuner", device: "TBS6209", make: "TBS", model: "6209")
+        XCTAssertEqual(dvr.guideGroupName, "Lounge Tuner")
+    }
+
+    func test_fallsBackThroughDeviceThenMakeModel() {
+        XCTAssertEqual(makeDVR(device: "TBS6209").guideGroupName, "TBS6209")
+        XCTAssertEqual(makeDVR(make: "TBS", model: "6209").guideGroupName, "TBS 6209")
+    }
+
+    /// A numeric DVR key is a worse heading than none at all, so an unnamed
+    /// tuner must leave its channels ungrouped rather than filed under "159".
+    func test_unnamedTunerHasNoGroup() {
+        XCTAssertNil(makeDVR().guideGroupName)
+    }
+
+    func test_blankNamesAreTreatedAsAbsent() {
+        XCTAssertEqual(makeDVR(friendlyName: "   ", device: "TBS6209").guideGroupName, "TBS6209")
+        XCTAssertNil(makeDVR(friendlyName: "", device: "  ").guideGroupName)
+    }
+
+    // MARK: - Channel → guide group
+
+    private func makeChannel(tunerName: String?) -> PlexLiveTVChannel {
+        PlexLiveTVChannel(
+            ratingKey: "ABC", key: "/tv.plex.providers.epg.xmltv:159/metadata/ABC",
+            guid: nil, type: "channel", title: "ABC", summary: nil, thumb: nil, art: nil,
+            year: nil, channelCallSign: "ABC", channelIdentifier: "ABC", channelShortTitle: nil,
+            channelThumb: nil, channelTitle: "ABC", channelNumber: "2", streamURL: nil,
+            tunerName: tunerName
+        )
+    }
+
+    func test_tunerNameBecomesTheGuideGroup() {
+        let unified = makeChannel(tunerName: "Lounge Tuner")
+            .toUnifiedChannel(sourceId: "s", serverURL: "https://example.invalid:32400", authToken: "t")
+        XCTAssertEqual(unified.groupTitle, "Lounge Tuner")
+    }
+
+    /// The guide reads nil as "ungrouped", which is the behaviour Plex sources
+    /// had before this existed — so an unnamed DVR is a no-op, not a new tab.
+    func test_noTunerNameLeavesTheChannelUngrouped() {
+        let unified = makeChannel(tunerName: nil)
+            .toUnifiedChannel(sourceId: "s", serverURL: "https://example.invalid:32400", authToken: "t")
+        XCTAssertNil(unified.groupTitle)
+    }
+}


### PR DESCRIPTION
Attempt to make Plex Live TV more robust

We now request a few more compatible codecs from plex to reduce server-side remuxing and look at what plex tells us its sending back to decide on how we play content back.

Also added some grouping support for multiple tuners and for plex favourites

Let me know if there's anything that doesn't fit @l984-451 

Claude Summary:

# Plex Live TV: direct-play the tuned session, and group the guide

Plex grants direct play on a tuned live session and Rivulet was throwing the
grant away — falling back to AVPlayer, which cannot decode the mp2 audio or DVB
teletext that direct play exists to preserve. This makes the grant reachable,
and while in the same code, fixes a URL-encoding bug that had been corrupting
the client profile on one of four build sites.

Also groups the guide by tuner and adds a Favourites tab, which is why the diff
spans both playback and the guide.

---

## Playback

### The client profile declares what the engine can actually decode

Audio gains `dts, truehd, flac, alac, opus, vorbis, pcm`, and both direct-play
clauses gain `subtitleCodec=dvb_teletext`.

Video is deliberately **unchanged** at `h264, hevc, mpeg2video`. Broadcast does
not carry anything else, and declaring codecs the container never holds buys
nothing.

The subtitle clause is the one that matters most. The profile previously
declared no subtitle codec for direct play while telling PMS to convert
subtitles to WebVTT, so a stream matching on video and audio could still be
pulled into a conversion purely by its captions — and the teletext the caption
renderer wants would be gone.

### A granted direct play is an HLS playlist, not raw MPEG-TS

The part key PMS returns is
`/livetv/sessions/{uuid}/{consumer}/index.m3u8`. `forceEngineDemux` routed that
to the engine's **raw** live path, which fails closed on a playlist body:

```
[AVIOReader] HLS playlist body on the raw live path (AE#140); failing closed.
             Use LoadOptions.nativeRemoteHLS or HLSLiveIngestReader for m3u8 sources.
```

The host's failure ladder then re-tuned and landed on `nativeRemoteHLS` — so
every granted direct play was quietly played by AVPlayer, with no teletext and
no mp2. It also cost **two tuner grabs** per channel: one to fail, one to fall
back.

`HLSLiveIngestReader` demuxes the playlist's underlying transport stream, so the
cues reach `SubtitleModel` → `CaptionOverlayView` like every other engine path.
If the reader cannot open the playlist (encryption, fMP4) it retries natively on
the **same** session rather than throwing, so the previous behaviour is still the
floor and no second tuner is grabbed.

### The profile's clause separators were being destroyed on rebuild

`X-Plex-Client-Profile-Extra` joins its clauses with `+`, which is a legal query
character and therefore not percent-encoded by `URLComponents` — so it reaches
PMS as a space and the clause boundary is lost. It has to travel as `%2B`.

Three build sites applied that pass. `PlexLiveTVProvider.buildStreamURL` did
not: it re-parses an already-correct URL to swap the session UUID, and reading
`queryItems` decodes `%2B` back to a raw `+`. Visible in a device log as
`…vorbis%252Cpcm)+add-direct-play-profile(…`.

All four now go through one `finalizedLiveURL` helper, so the rule cannot be
missed again.

### Scan type decides the deinterlacing path

`loadLive` forced the software backend on every engine-demux live load, for
deinterlacing. That was written when the engine had no deinterlacer on its
native path; it has had a hardware one since 5.8.4.

PMS reports `scanType` on the video stream in the tune response, so a channel
that is genuinely progressive no longer pays for it. **Absence means
interlaced** — only an explicit `"progressive"` opts out, because a needless
software decode costs CPU while a missed deinterlace is combing the user can
see. It reads the server's scan type rather than the codec's own field order,
which broadcast H.264 is known to mis-signal.

---

## Guide

### Every DVR, not just the first

`fetchChannelsFromGrid` used `Dvr?.first`. A server with two tuners exposes two
DVRs with separate lineups, so one lineup's channels were silently missing from
the guide entirely. One unreachable DVR is now logged and skipped rather than
failing the whole fetch.

### Tuner groups, named from the lineup

The lineup string already carries a human name in its fragment, so no extra
request is needed:

```
lineup://tv.plex.providers.epg.cloud/5fc76c88…#Freeview - Perth (58 channels)
                                               → "Freeview - Perth"
```

Plex's `(58 channels)` suffix is dropped — it is a count for Plex's own picker
and goes stale the moment a channel is hidden. The DVR key is deliberately not a
fallback: "161" is a worse heading than no heading.

Groups appear **only when there is more than one DVR**. With one tuner the tab
would list exactly what All Channels lists.

### Plex Favourites

Favourites are account-level, not server-level —
`epg.provider.plex.tv/settings/favoriteChannels`, a fourth provider host
alongside the three in the Discover section. That is why nothing under
`/livetv/dvrs/…` carries a favourite flag, and why one list can span a local
tuner and Plex's free channels.

`FavoriteChannel[].id` is the same `channelIdentifier` the grid and tune
endpoints use, so no mapping is needed. Array order is the user's own
arrangement and is preserved as `favouriteRank`.

---

## Notes for review

Things that look wrong but aren't, or are easy to break later:

- **The favourites call uses `PlexAuthManager.shared.authToken`, not
  `self.authToken`.** `PlexLiveTVProvider` is constructed with
  `selectedServerToken`, and the provider hosts reject a server token — the same
  account-vs-server trap the Discover endpoints document. `self.authToken` looks
  right and is not.
- **`X-Plex-Provider-Version: 5.1` is required on that call.** Without it the
  endpoint returns a valid `MediaContainer` with no `FavoriteChannel` array
  rather than an error, which reads as "no favourites".
- **Favourites is not a `groupTitle`.** A favourite keeps its tuner group as
  well, and the tab has to honour the arranged order, neither of which a single
  string can express — hence `isFavourite` / `favouriteRank` on
  `UnifiedChannel`. Both are defaulted, so no existing call site changes and the
  IPTV path is untouched.
- **`needsDeinterlacing` treats an absent scan type as interlaced.** That is
  deliberate; do not "simplify" it to a boolean the other way round.
- **Codec lists travel as `%2C`, clauses as `%2B`.** Both look like mistakes.
  Changing either to a raw character makes PMS parse one codec named
  `"h264,hevc,…"` and refuse direct play on every channel, silently.
- **Channel dedupe across DVRs is first-wins**, so a channel two tuners both
  carry is attributed to whichever DVR the server listed first rather than
  appearing twice under two group tabs.

---

## Testing

Observed on device (tvOS 26.5) against a PMS with two DVRs — one XMLTV, one
cloud-EPG — on an HDHomeRun tuner:

- The tune succeeds and PMS reports `scanType=interlaced` for AU FTA channels
- `/decision` returns **direct play** with the widened profile
- Both DVR lineups are fetched, where previously only one was
- The account favourites endpoint returns the expected three channels in order
- The raw `+` corruption was reproduced in a device log before the fix
