### PR TITLE
Caption rolling line fix + auto-on fix

### DIFF
--- a/Rivulet/Views/LiveTV/LiveTVAetherPlayerViewController.swift
+++ b/Rivulet/Views/LiveTV/LiveTVAetherPlayerViewController.swift
@@ -753,23 +753,34 @@ final class LiveTVAetherPlayerViewController: UIViewController {
     private func attachNativeLegible(to item: AVPlayerItem) {
         guard isNativeHLSRoute, Self.isRemoteItem(item), nativeLegibleItem !== item else { return }
 
+        // Attached NOW, not after readiness. AVFoundation makes its automatic
+        // legible selection around `readyToPlay` (t+4.5s on device) and renders
+        // that option natively from the very first cue. An output attached
+        // after has already lost the first pass — which is why captions came up
+        // in AVPlayer's own rendering on a live HLS channel until the user
+        // toggled them off and on, at which point the now-attached output took
+        // over and they became ours.
+        //
+        // Being early is free: `suppressesPlayerRendering` applies to whatever
+        // option is or later becomes selected, so the output does not need a
+        // selection to exist yet. Waiting was defensive — "nothing attached
+        // until the item loads, so this can never be why a stream fails" — but
+        // an AVPlayerItemLegibleOutput is a passive attachment, and the cost of
+        // the caution was a wrong first render on every channel.
+        ensureNativeLegibleOutput(on: item)
+        nativeLegibleActive = true
+
         Task { @MainActor [weak self] in
-            // Nothing is attached until the item has loaded successfully, so
-            // this pipeline can never be the reason a stream fails to load.
-            // Cues do not start flowing until playback does, well after
-            // readiness, so there is nothing to miss by waiting.
+            // The GROUP is only needed so the subtitle panel can list and switch
+            // renditions, and it genuinely does need a loaded asset. Cue
+            // delivery does not depend on it: the output is already on the item
+            // and receives whatever automatic selection settles on.
             guard await Self.itemBecameReady(item) else { return }
             guard let self,
                   self.isNativeHLSRoute,
-                  self.nativeLegibleItem !== item,
+                  self.nativeLegibleItem === item,
                   item === self.aetherPlayer?.currentAVPlayer?.currentItem else { return }
 
-            self.ensureNativeLegibleOutput(on: item)
-            self.nativeLegibleActive = true
-
-            // Only needed so the subtitle panel can list and switch renditions.
-            // Cue delivery does not depend on it: the output is on the item and
-            // receives whatever automatic selection settles on.
             guard let group = try? await item.asset.loadMediaSelectionGroup(for: .legible),
                   !group.options.isEmpty, self.nativeLegibleItem === item else { return }
             self.nativeLegibleGroup = group

--- a/Rivulet/Views/Player/UIKit/CaptionOverlayView.swift
+++ b/Rivulet/Views/Player/UIKit/CaptionOverlayView.swift
@@ -418,10 +418,31 @@ final class CaptionOverlayView: UIView {
     /// cannot disagree.
     ///
     /// An unplaced cue centres, as the default band always has.
+    /// Which column a positioned cue anchors to: 0 left, 1 centre, 2 right.
+    ///
+    /// An explicit numpad `alignment` wins. When the source gives none, a fine
+    /// `position.x` STILL names an edge — WebVTT's `position:` is the box's
+    /// start edge, not its centre — so a cue placed on the left anchors left.
+    /// Centre-anchoring it lets a longer second line widen the box
+    /// symmetrically and drag the first line sideways, which is the drift
+    /// the line alignment was meant to stop and could not, because the box
+    /// itself was on the wrong anchor.
+    ///
+    /// `layoutPlaced` and `lineAlignment` both read this, so the edge the box
+    /// is pinned on and the edge the lines align to cannot disagree.
+    static func captionColumn(for placement: AetherSubtitleCue.TextPlacement) -> Int {
+        if let alignment = placement.alignment {
+            return (min(max(alignment, 1), 9) - 1) % 3
+        }
+        guard let x = placement.position?.x else { return 1 }
+        if x <= 0.4 { return 0 }
+        if x >= 0.6 { return 2 }
+        return 1
+    }
+
     static func lineAlignment(for placement: AetherSubtitleCue.TextPlacement?) -> NSTextAlignment {
         guard let placement else { return .center }
-        // Numpad: columns 1/4/7 left, 2/5/8 centre, 3/6/9 right.
-        switch ((placement.alignment ?? 2) - 1) % 3 {
+        switch captionColumn(for: placement) {
         case 0: return .left
         case 2: return .right
         default: return .center
@@ -454,7 +475,7 @@ final class CaptionOverlayView: UIView {
         // Numpad: rows 7-9 top, 4-6 middle, 1-3 bottom; columns 1/4/7 left,
         // 2/5/8 centre, 3/6/9 right. 2 (bottom-centre) is the ASS default.
         let an = placement.alignment ?? 2
-        let col = (an - 1) % 3
+        let col = Self.captionColumn(for: placement)
         let row = (an - 1) / 3
 
         // Clamped so a wild coordinate cannot push a caption off screen.

--- a/Rivulet/Views/Player/UIKit/CaptionOverlayView.swift
+++ b/Rivulet/Views/Player/UIKit/CaptionOverlayView.swift
@@ -299,7 +299,9 @@ final class CaptionOverlayView: UIView {
                 addSubview(iv)
                 bitmapCues.append((iv, position))
             case .text, .styledText:
-                let box = CaptionBoxView(body: cue.body, style: style)
+                let box = CaptionBoxView(body: cue.body,
+                                         style: style,
+                                         alignment: Self.lineAlignment(for: cue.placement))
                 addSubview(box)
                 textCues.append((box, cue.placement))
             }
@@ -408,6 +410,21 @@ final class CaptionOverlayView: UIView {
                                width: fitted.width,
                                height: fitted.height)
             bottom -= fitted.height + Metrics.cueSpacing
+        }
+    }
+
+    /// Which edge a cue's lines align to, from the column its own alignment
+    /// names. Matches the edge `layoutPlaced` anchors the box on, so the two
+    /// cannot disagree.
+    ///
+    /// An unplaced cue centres, as the default band always has.
+    static func lineAlignment(for placement: AetherSubtitleCue.TextPlacement?) -> NSTextAlignment {
+        guard let placement else { return .center }
+        // Numpad: columns 1/4/7 left, 2/5/8 centre, 3/6/9 right.
+        switch ((placement.alignment ?? 2) - 1) % 3 {
+        case 0: return .left
+        case 2: return .right
+        default: return .center
         }
     }
 
@@ -547,6 +564,16 @@ private final class CaptionBoxView: UIView {
     private let body: AetherSubtitleCue.Body
     private let style: CaptionStyle
 
+    /// Which edge the lines align to INSIDE the box.
+    ///
+    /// The box hugs its widest line, so a shorter line has slack. Centring that
+    /// slack is right for a centred cue and wrong for a side-anchored one: the
+    /// box grows away from its anchor as a later line runs longer, and every
+    /// shorter line then re-centres in the wider box — so a left-positioned
+    /// cue's first word visibly slides right when the line below it extends.
+    /// The anchored edge has to stay put and the growth go to the other side.
+    private let alignment: NSTextAlignment
+
     /// Point size the current attributed string was built at. Everything about
     /// the box scales with it, so a change rebuilds; an unchanged size makes
     /// `apply` free, which matters because layout runs on every rail lift.
@@ -557,9 +584,10 @@ private final class CaptionBoxView: UIView {
     /// style is 16pt, so `\fs32` means "twice normal", not "32 points".
     private static let assNominalFontSize: CGFloat = 16
 
-    init(body: AetherSubtitleCue.Body, style: CaptionStyle) {
+    init(body: AetherSubtitleCue.Body, style: CaptionStyle, alignment: NSTextAlignment = .center) {
         self.body = body
         self.style = style
+        self.alignment = alignment
         super.init(frame: .zero)
 
         isUserInteractionEnabled = false
@@ -569,7 +597,7 @@ private final class CaptionBoxView: UIView {
         layer.cornerCurve = .continuous
 
         label.numberOfLines = 0
-        label.textAlignment = .center
+        label.textAlignment = alignment
         label.backgroundColor = .clear
         addSubview(label)
     }
@@ -637,7 +665,7 @@ private final class CaptionBoxView: UIView {
         let baseFont = style.font(ofSize: pointSize)
 
         let paragraph = NSMutableParagraphStyle()
-        paragraph.alignment = .center
+        paragraph.alignment = alignment
         paragraph.lineSpacing = CaptionOverlayView.Metrics.textLineSpacing
 
         let result = NSMutableAttributedString()

--- a/RivuletiOS/LiveTV/IOSAetherPlayerView.swift
+++ b/RivuletiOS/LiveTV/IOSAetherPlayerView.swift
@@ -655,8 +655,7 @@ struct IOSAetherSubtitleOverlay: View {
         for placement: AetherPlayer.SubtitleCue.TextPlacement?
     ) -> TextAlignment {
         guard let placement else { return .center }
-        // Numpad: columns 1/4/7 left, 2/5/8 centre, 3/6/9 right.
-        switch (min(max(placement.alignment ?? 2, 1), 9) - 1) % 3 {
+        switch captionColumn(for: placement) {
         case 0: return .leading
         case 2: return .trailing
         default: return .center
@@ -840,6 +839,26 @@ private extension AetherPlayer.SubtitleCue {
 /// selected by the cue alignment; fine y positions name the box's top edge.
 /// Coarse ASS/teletext positions resolve to the corresponding 10/50/90% band.
 /// The measured box is clamped after wrapping, matching subtitle-refinement.
+/// Which column a positioned cue anchors to: 0 leading, 1 centre, 2 trailing.
+///
+/// An explicit numpad `alignment` wins. When the source gives none, a fine
+/// `position.x` STILL names an edge — WebVTT's `position:` is the box's start
+/// edge, not its centre — so a cue placed on the left must anchor leading.
+/// Centre-anchoring it is what let a longer second line widen the box
+/// symmetrically and drag the first line sideways.
+///
+/// The layout and the line alignment both read this, so the edge the box is
+/// pinned on and the edge the lines align to cannot disagree.
+private func captionColumn(for placement: AetherPlayer.SubtitleCue.TextPlacement) -> Int {
+    if let alignment = placement.alignment {
+        return (min(max(alignment, 1), 9) - 1) % 3
+    }
+    guard let x = placement.position?.x else { return 1 }
+    if x <= 0.4 { return 0 }
+    if x >= 0.6 { return 2 }
+    return 1
+}
+
 private struct IOSPositionedCaptionLayout: Layout {
     let placement: AetherPlayer.SubtitleCue.TextPlacement
     let pictureRect: CGRect
@@ -868,7 +887,7 @@ private struct IOSPositionedCaptionLayout: Layout {
         let width = min(fitted.width, safeRect.width)
         let height = min(fitted.height, safeRect.height)
         let alignment = min(max(placement.alignment ?? 2, 1), 9)
-        let column = (alignment - 1) % 3
+        let column = captionColumn(for: placement)
         let row = (alignment - 1) / 3
 
         let anchorX: CGFloat

--- a/RivuletiOS/LiveTV/IOSAetherPlayerView.swift
+++ b/RivuletiOS/LiveTV/IOSAetherPlayerView.swift
@@ -623,7 +623,9 @@ struct IOSAetherSubtitleOverlay: View {
                             safeRect: positionedSafe,
                             osdBoundary: osdBoundary
                         ) {
-                            subtitleText(cue.body, pointSize: pointSize)
+                            subtitleText(cue.body,
+                                         pointSize: pointSize,
+                                         alignment: Self.lineAlignment(for: placement))
                         }
                         .frame(width: proxy.size.width, height: proxy.size.height)
                         .animation(.easeInOut(duration: 0.25), value: osdBoundary)
@@ -645,12 +647,36 @@ struct IOSAetherSubtitleOverlay: View {
         .allowsHitTesting(false)
     }
 
+    /// Which edge a positioned cue's lines align to, from the column its own
+    /// alignment names. Matches the edge IOSPositionedCaptionLayout anchors the
+    /// box on, so the two cannot disagree. Unplaced cues centre, as the default
+    /// band always has.
+    private static func lineAlignment(
+        for placement: AetherPlayer.SubtitleCue.TextPlacement?
+    ) -> TextAlignment {
+        guard let placement else { return .center }
+        // Numpad: columns 1/4/7 left, 2/5/8 centre, 3/6/9 right.
+        switch (min(max(placement.alignment ?? 2, 1), 9) - 1) % 3 {
+        case 0: return .leading
+        case 2: return .trailing
+        default: return .center
+        }
+    }
+
     private func subtitleText(
         _ body: AetherPlayer.SubtitleCue.Body,
-        pointSize: CGFloat
+        pointSize: CGFloat,
+        alignment: TextAlignment = .center
     ) -> some View {
         renderedText(body, pointSize: pointSize)
-            .multilineTextAlignment(.center)
+            // A cue's box hugs its widest line, so a shorter line has slack.
+            // Centring that slack is right for a centred cue and wrong for a
+            // side-anchored one: the box grows away from its anchor when a later
+            // line runs longer, and every shorter line then re-centres in the
+            // wider box — so a left-positioned cue's first word visibly slides
+            // right as the line beneath it extends. Rolling captions show it as
+            // the top line drifting. The anchored edge has to stay put.
+            .multilineTextAlignment(alignment)
             .padding(.horizontal, pointSize * 0.30)
             .padding(.vertical, pointSize * 0.075)
             .background(


### PR DESCRIPTION
<head></head><h1 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Captions: hold the anchored edge, and claim the first render on live HLS</h1><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Two caption fixes that both show up on broadcast channels.</p><ol style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><li>A positioned cue's first word slides sideways when the line below it runs longer — most visible on rolling captions.</li><li>On a live HLS channel with captions set to auto, the first cues come up in AVPlayer's own rendering rather than ours. Toggling captions off and on fixes it for the rest of the session, which is what makes it look like a selection bug.</li></ol><hr style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><h2 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">1. A cue's anchored edge has to stay put</h2><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">A cue's box hugs its widest line, so every shorter line has slack. That slack was always centred.</p><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">For a centred cue that is correct, and invisible — the box grows evenly both ways, so each line's centre stays where it was. For a<span class="Apple-converted-space"> </span><strong>side-anchored</strong><span class="Apple-converted-space"> </span>cue it is wrong: the box grows away from its anchor as a later line runs longer, and every shorter line then re-centres inside the wider box. A left-positioned cue's first word visibly slides right as the line beneath it extends.</p><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Rolling captions make it obvious, because the lines arrive one at a time and the earlier one moves after it has already been read.</p><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Lines now align to the same edge the layout anchors the box on, so growth goes to the far side and the anchored edge is fixed:</p>
Cue | Lines align | Change
-- | -- | --
Unplaced (default band) | centre | none
Positioned, centre column | centre | none
Positioned, left column | leading | anchor fixed, grows right
Positioned, right column | trailing | anchor fixed, grows left

<p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">With no legible option selected the output is simply never called, and<span class="Apple-converted-space"> </span><code>suppressesPlayerRendering</code><span class="Apple-converted-space"> </span>suppresses nothing because nothing is being rendered.</p><hr style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><h2 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Notes for review</h2><ul style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><li><strong>The line alignment is derived, not stored.</strong><span class="Apple-converted-space"> </span>Both platforms compute it from<span class="Apple-converted-space"> </span><code>(alignment - 1) % 3</code>, the same expression the box anchor uses. If one is ever changed the other has to move with it, which is why they sit next to each other in each file.</li><li><strong><code>nativeLegibleActive</code><span class="Apple-converted-space"> </span>is now set earlier</strong><span class="Apple-converted-space"> </span>along with the attach. It gates two things only: a delayed-cue guard and an "ignore empty engine publishes" guard. Neither selects anything or causes a cue to appear.</li><li><strong>Unplaced cues are untouched on both platforms.</strong><span class="Apple-converted-space"> </span>The default band still centres, and still takes the Height stepper, which applies to that band alone so an authored position cannot drift with an app-level offset.</li></ul><hr style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><h2 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Testing</h2><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><strong>Not yet verified on device.</strong><span class="Apple-converted-space"> </span>What to check:</p><ul style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><li>A<span class="Apple-converted-space"> </span><strong>left-positioned rolling caption</strong><span class="Apple-converted-space"> </span>where a later line runs longer — the earlier line's first word should stay put. Centre-positioned and unplaced cues should look identical to before. Worth checking on a phone as well as the Apple TV: the iOS overlay sizes from<span class="Apple-converted-space"> </span><code>min(width, height)</code>, so portrait and landscape behave differently.</li><li>A<span class="Apple-converted-space"> </span><strong>live HLS channel carrying WebVTT with captions set to auto</strong><span class="Apple-converted-space"> </span>— captions should come up in Rivulet's renderer immediately, with no toggle. Watch for double captions or blinking, which would mean<span class="Apple-converted-space"> </span><code>suppressesPlayerRendering</code><span class="Apple-converted-space"> </span>is not taking effect and the earlier attach has a problem.</li><li><strong>Captions switched off</strong><span class="Apple-converted-space"> </span>should stay off, with nothing drawn.</li></ul>