### PR TITLE
iOS: size captions from measurement instead of a scaled tvOS guess

### DIFF
--- a/RivuletiOS/LiveTV/IOSAetherPlayerView.swift
+++ b/RivuletiOS/LiveTV/IOSAetherPlayerView.swift
@@ -560,10 +560,84 @@ struct IOSAetherSubtitleOverlay: View {
     let videoSize: CGSize
 
     private enum Metrics {
-        // iPhone captions need a smaller curve than the 10-foot tvOS UI.
-        // 0.039675 is a 25% reduction from tvOS's 0.0529, equivalent to
-        // reducing a 0.20 scale factor to 0.15.
-        static let fontHeightFraction: CGFloat = 0.039675
+        /// Caption line PITCH (baseline to baseline) as a fraction of the VIDEO
+        /// view height, for each size the system reports. MEASURED against
+        /// AVPlayerViewController on an iPhone 16 Pro, not derived.
+        ///
+        /// Method: full-screen captures of the same broadcast at each caption
+        /// size, landscape and portrait. The video rect was found by its
+        /// letterbox/pillarbox bounds (714.7x402.0pt landscape, 402.0x226.0pt
+        /// portrait, both exactly 16:9), and pitch by autocorrelating the
+        /// per-row ink profile of the caption glyphs — which is immune to the
+        /// band-splitting that catches a naive "find the text rows" pass at the
+        /// larger sizes.
+        ///
+        ///     setting    pitch px   pitch pt   /videoH    ratio
+        ///     small         53.97      17.99   0.04475    0.620
+        ///     default       87.01      29.00   0.07215    1.000
+        ///     large        135.44      45.15   0.11231    1.557
+        ///     xlarge       168.18      56.06   0.13945    1.933
+        ///
+        /// **The curve is not tvOS's.** There the same settings measure 1.69x
+        /// and 2.25x at the top two rungs against 1.557x and 1.933x here, so
+        /// the platform's ladder cannot be reused — an earlier guess that the
+        /// non-linearity was a shared MediaAccessibility behaviour was wrong.
+        ///
+        /// Captions scale with the VIDEO view, confirmed rather than assumed:
+        /// portrait/landscape video height is 226/402 = 0.5622, and the
+        /// portrait pitch matches that prediction to within 4%. Screen height
+        /// would make portrait captions LARGER, and screen width predicts a
+        /// pitch 21% too small; neither survives the measurement. This also
+        /// means the old `min(width, height)` basis was wrong in portrait,
+        /// where it silently switches from being the height to the width.
+        ///
+        /// Stored as PITCH rather than point size on purpose: the conversion
+        /// needs the font's leading multiple, and `pointSize(videoHeight:…)`
+        /// takes that from the font it is about to draw with, so no constant
+        /// has to be measured or guessed here.
+        /// The x-axis is MediaAccessibility's quantised buckets, confirmed on
+        /// device: iOS's four caption sizes report exactly 0.6, 1.0, 1.5 and
+        /// 2.0 — four of the five `CaptionAppearance.fontScale(forRelativeSize:)`
+        /// documents. There is no 0.35 rung on iOS.
+        ///
+        /// The y-axis is measured, not derived: each fraction is
+        /// AVPlayerViewController's own line pitch over the video height at
+        /// that setting. Do not "simplify" this to a multiplier — the system
+        /// is not linear in the reported value, which is the whole point of
+        /// #299.
+        static let pitchLadder: [(reported: CGFloat, pitchFraction: CGFloat)] = [
+            (0.60, 0.04475),
+            (1.00, 0.07215),
+            (1.50, 0.11231),
+            (2.00, 0.13945)
+        ]
+
+        /// Caption point size for a video height and the system's reported
+        /// relative character size.
+        ///
+        /// Interpolates between the measured rungs, so a value iOS does not
+        /// currently report still lands sensibly rather than falling back to a
+        /// wrong multiply.
+        static func pointSize(videoHeight: CGFloat, reported: CGFloat, font: UIFont) -> CGFloat {
+            let targetPitch = videoHeight * pitchFraction(forReported: reported)
+            // Leading multiple of the ACTUAL caption font. AVKit and this
+            // overlay draw the same face at the same size, so matching pitch
+            // matches apparent size without anyone having to measure a constant.
+            let leading = font.lineHeight / max(font.pointSize, 1)
+            return max(minimumPointSize, targetPitch / max(leading, 0.5))
+        }
+
+        static func pitchFraction(forReported reported: CGFloat) -> CGFloat {
+            guard let first = pitchLadder.first, let last = pitchLadder.last else { return 0 }
+            if reported <= first.reported { return first.pitchFraction }
+            if reported >= last.reported { return last.pitchFraction }
+            for (lo, hi) in zip(pitchLadder, pitchLadder.dropFirst()) where reported <= hi.reported {
+                let t = (reported - lo.reported) / (hi.reported - lo.reported)
+                return lo.pitchFraction + t * (hi.pitchFraction - lo.pitchFraction)
+            }
+            return last.pitchFraction
+        }
+
         static let minimumPointSize: CGFloat = 10
         static let positionedSafeFraction: CGFloat = 0.10
         static let unpositionedBottomFraction: CGFloat = 0.05
@@ -572,13 +646,18 @@ struct IOSAetherSubtitleOverlay: View {
     var body: some View {
         GeometryReader { proxy in
             let allCues = cues + nativeCues
-            let pointSize = max(
-                Metrics.minimumPointSize,
-                min(proxy.size.width, proxy.size.height)
-                    * Metrics.fontHeightFraction
-                    * style.fontScale
-            )
             let picture = pictureRect(in: proxy.size)
+            // Sized from the VIDEO height, not `min(width, height)` of the
+            // container: in portrait the container is tall and the video a short
+            // band, so min() silently became the WIDTH and captions came out
+            // sized off the wrong axis. `style.fontScale` is the raw value
+            // MediaAccessibility reports (fontScale(forRelativeSize:) is
+            // identity inside its clamp), which is what the ladder is keyed on.
+            let pointSize = Metrics.pointSize(
+                videoHeight: captionSizingHeight(in: proxy.size),
+                reported: style.fontScale,
+                font: style.font(ofSize: 100)   // reference size; only its leading ratio is read
+            )
             let osdBoundary = landscapeCaptionMaxY(
                 in: picture,
                 container: proxy.size
@@ -723,6 +802,23 @@ struct IOSAetherSubtitleOverlay: View {
             font = UIFont(descriptor: descriptor, size: size)
         }
         return font
+    }
+
+    /// Height the caption size is derived from.
+    ///
+    /// NOT `pictureRect(in:).height`. That falls back to the whole container
+    /// when `videoSize` is unknown, which is fine for positioning but ruinous
+    /// for sizing: in portrait the container is ~874pt tall against a ~226pt
+    /// video band, so captions come out nearly 4x too large. And unknown is not
+    /// a rare state — the software decode path publishes no `presentationSize`
+    /// at all, so it can persist for a whole session.
+    ///
+    /// Falls back to the tallest 16:9 picture the container could hold, which
+    /// is what broadcast actually is, rather than to the container itself.
+    private func captionSizingHeight(in container: CGSize) -> CGFloat {
+        let rect = pictureRect(in: container)
+        if videoSize.width > 0, videoSize.height > 0 { return rect.height }
+        return min(container.height, container.width * 9.0 / 16.0)
     }
 
     private func pictureRect(in container: CGSize) -> CGRect {


### PR DESCRIPTION
<head></head><h1 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">iOS captions: size from measurement, not from a scaled tvOS guess</h1><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">#299 measured tvOS's caption sizes against AVPlayer and replaced a wrong constant with a measured ladder. iOS still has the constant — and it is the<span class="Apple-converted-space"> </span><em>pre-#299 tvOS number</em>, scaled by eye. This does the same measurement for iOS.</p><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">The short version: iOS captions were<span class="Apple-converted-space"> </span><strong>25–35% too small</strong>, sized off the wrong axis in portrait, and scaled by a multiplier the system does not use.</p><hr style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><h2 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">What was there</h2><pre style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><code class="language-swift">static let fontHeightFraction: CGFloat = 0.039675   // "a 25% reduction from tvOS's 0.0529"
...
let pointSize = min(proxy.size.width, proxy.size.height)
              * Metrics.fontHeightFraction
              * style.fontScale
</code></pre><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Three separate faults, which is why this is a rewrite rather than a new number.</p><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><strong>1. The constant descends from the one #299 deleted.</strong><span class="Apple-converted-space"> </span>0.0529 is the tvOS value that PR measured as 24% oversized. Reducing it by 25% for iOS did not fix it, it inherited it — and the two errors happened to land near each other, which is what made it look plausible.</p><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><strong>2. It multiplies by the reported scale.</strong><span class="Apple-converted-space"> </span>That is precisely the mistake #299 exists to correct.<span class="Apple-converted-space"> </span><code>MACaptionAppearanceGetRelativeCharacterSize</code><span class="Apple-converted-space"> </span>returns quantised buckets and AVKit's rendered size is<span class="Apple-converted-space"> </span><strong>not linear in them</strong>. See<code>CaptionAppearance.fontScale(forRelativeSize:)</code>, which says so.</p><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><strong>3.<span class="Apple-converted-space"> </span><code>min(width, height)</code><span class="Apple-converted-space"> </span>is the wrong axis in portrait.</strong><span class="Apple-converted-space"> </span>It is the video height in landscape, and the container<span class="Apple-converted-space"> </span><strong>width</strong><span class="Apple-converted-space"> </span>in portrait — where the video is a short band in a tall view. Captions were sized off an unrelated dimension in one orientation.</p><h2 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">What replaced it</h2><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">A ladder measured against<span class="Apple-converted-space"> </span><code>AVPlayerViewController</code><span class="Apple-converted-space"> </span>on an iPhone at each of the four caption sizes, in both orientations:</p>
Setting | pitch px | pitch pt | ÷ videoH | ratio
-- | -- | -- | -- | --
Small | 53.97 | 17.99 | 0.04475 | 0.620
Default | 87.01 | 29.00 | 0.07215 | 1.000
Large | 135.44 | 45.15 | 0.11231 | 1.557
Extra large | 168.18 | 56.06 | 0.13945 | 1.933

<p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">iOS is 6–23% larger throughout,<span class="Apple-converted-space"> </span><strong>and the curves differ in shape</strong><span class="Apple-converted-space"> </span>— tvOS climbs to 2.25× at the top where iOS reaches 1.93×. No single factor converts one into the other, so neither platform's numbers can be derived from the other's. They have to be measured separately, and were.</p><h3 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Stored as pitch, so no font constant is needed</h3><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">The ladder holds<span class="Apple-converted-space"> </span><strong>line pitch</strong>, and point size is<span class="Apple-converted-space"> </span><code>targetPitch / leading</code><span class="Apple-converted-space"> </span>where<span class="Apple-converted-space"> </span><code>leading</code><span class="Apple-converted-space"> </span>is<span class="Apple-converted-space"> </span><code>font.lineHeight / font.pointSize</code><span class="Apple-converted-space"> </span>read at runtime. That removes the last hand-measured number: change the caption font and the sizing follows without re-measuring anything.</p><h3 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">The sizing height must not fall back to the container</h3><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><code>pictureRect(in:)</code><span class="Apple-converted-space"> </span>returns the whole container when<span class="Apple-converted-space"> </span><code>videoSize</code><span class="Apple-converted-space"> </span>is unknown. Harmless while it only drove positioning; ruinous once it drives sizing — in portrait that is ~874pt against a ~226pt video band, so captions come up nearly<span class="Apple-converted-space"> </span><strong>4× too large</strong>.</p><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">And unknown is not a brief startup state: the software decode path publishes no<span class="Apple-converted-space"> </span><code>presentationSize</code><span class="Apple-converted-space"> </span>at all, so it can persist for a whole session. Sizing now falls back to the tallest 16:9 picture the container could hold, which is what broadcast actually is.<span class="Apple-converted-space"> </span><code>pictureRect</code><span class="Apple-converted-space"> </span>itself is unchanged.</p><hr style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><h2 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Notes for review</h2><ul style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><li><strong>The<span class="Apple-converted-space"> </span><code>reported</code><span class="Apple-converted-space"> </span>column is not decorative.</strong><span class="Apple-converted-space"> </span>It is the API's actual output, read off the device. If a future iOS adds a fifth caption size, the ladder needs the new bucket — interpolation between existing rungs will be close but is not measured.</li><li><strong>Do not "simplify" the ladder to a multiplier.</strong><span class="Apple-converted-space"> </span>That is the #299 bug, and it is why the old code was wrong at three of the four settings.</li><li><strong>Nothing shared changed.</strong><span class="Apple-converted-space"> </span>The diff is one file under<span class="Apple-converted-space"> </span><code>RivuletiOS/</code>.<span class="Apple-converted-space"> </span><code>CaptionAppearance</code><span class="Apple-converted-space"> </span>is untouched, so tvOS cannot be affected by this.</li><li><strong>The measurement device is an iPhone, and the fractions are dimensionless.</strong><span class="Apple-converted-space"> </span>They are ratios of video height, so they carry to any screen size; nothing here is pinned to a particular handset.</li></ul><h2 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Testing</h2><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Measured from full-screen<span class="Apple-converted-space"> </span><code>AVPlayerViewController</code><span class="Apple-converted-space"> </span>screenshots at all four caption sizes, both orientations. The four<span class="Apple-converted-space"> </span><code>reported</code>values and the resulting point sizes were then read back from a device build and match the ladder.</p><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><strong>Not verified:</strong><span class="Apple-converted-space"> </span>a direct side-by-side against the system player at the same setting. The arithmetic says we now render AVKit's pitch, but "matches AVKit" has been checked numerically, not visually. That comparison is the one thing that would close this out, and is worth doing before merge if convenient.</p>