### PR TITLE
iOS: Add Jump-to-Now button to Live TV guide header

### DIFF
--- a/RivuletiOS/LiveTV/IOSGuideCollectionView.swift
+++ b/RivuletiOS/LiveTV/IOSGuideCollectionView.swift
@@ -132,7 +132,7 @@ struct IOSGuideCollectionView: UIViewRepresentable {
             self.parent = parent
             if parent.snapToken != lastSnapToken {
                 lastSnapToken = parent.snapToken
-                resetWindow()
+                snapToNow()
                 return
             }
 
@@ -140,6 +140,16 @@ struct IOSGuideCollectionView: UIViewRepresentable {
             guard signature != lastDataSignature else { return }
             lastDataSignature = signature
             rebuildData(reload: true)
+        }
+
+        func snapToNow() {
+            let anchor = Self.floorToHalfHour(Date())
+            let end = windowStart.addingTimeInterval(TimeInterval(totalMinutes * 60))
+            if anchor >= windowStart && anchor < end {
+                setLeftEdge(to: anchor, animated: true)
+            } else {
+                resetWindow()
+            }
         }
 
         func resetWindow() {

--- a/RivuletiOS/LiveTV/IOSGuideView.swift
+++ b/RivuletiOS/LiveTV/IOSGuideView.swift
@@ -7,16 +7,17 @@ import UIKit
 struct IOSGuideView: View {
     let channels: [IOSIPTVChannel]
     let programsByChannel: [String: [IOSEPGProgram]]
+    var snapToken: Int = 0
 
     @State private var selection: IOSGuideSelection?
     @State private var playbackRequest: IOSPlaybackRequest?
-    @State private var snapGeneration = 0
+    @State private var internalSnapToken = 0
 
     var body: some View {
         IOSGuideCollectionView(
             channels: channels,
             programsByChannel: programsByChannel,
-            snapToken: snapGeneration
+            snapToken: snapToken + internalSnapToken
         ) { channel, program in
             if let program {
                 selection = IOSGuideSelection(channel: channel, program: program)
@@ -36,7 +37,7 @@ struct IOSGuideView: View {
                 .presentationBackground(.clear)
         }
         .fullScreenCover(item: $playbackRequest, onDismiss: {
-            snapGeneration += 1
+            internalSnapToken += 1
         }) { request in
             IOSAetherPlayerView(
                 request: request,

--- a/RivuletiOS/LiveTV/IOSLiveTVView.swift
+++ b/RivuletiOS/LiveTV/IOSLiveTVView.swift
@@ -7,6 +7,7 @@ struct IOSLiveTVView: View {
     @StateObject private var store = IOSLiveTVStore()
     @State private var showingSourceEditor = false
     @State private var selectedGroup: String?
+    @State private var snapToNowToken = 0
     let showSettings: () -> Void
 
     init(showSettings: @escaping () -> Void = {}) {
@@ -62,6 +63,12 @@ struct IOSLiveTVView: View {
 
             HStack(spacing: 4) {
                 if !store.channels.isEmpty {
+                    Button("Jump to now", systemImage: "arrow.right.and.line.vertical.and.arrow.left") {
+                        snapToNowToken += 1
+                    }
+                    .labelStyle(.iconOnly)
+                    .frame(width: 42, height: 42)
+
                     Button("Refresh", systemImage: "arrow.clockwise") {
                         Task { await store.load() }
                     }
@@ -125,7 +132,8 @@ struct IOSLiveTVView: View {
 
             IOSGuideView(
                 channels: visibleChannels,
-                programsByChannel: store.programsByChannel
+                programsByChannel: store.programsByChannel,
+                snapToken: snapToNowToken
             )
         }
         .overlay {


### PR DESCRIPTION
### Summary
Adds a "Jump to Now" button next to the Refresh button in the iOS Live TV header:

* **SF Symbol**: Uses `arrow.right.and.line.vertical.and.arrow.left` (inward arrows to a vertical divider).
* **Behavior**:
  * Calculates `floorToHalfHour(Date())` and smoothly animates the horizontal timeline back to the current half-hour slot on air.
  * Preserves vertical scroll position (you stay on whatever channel row you were viewing).
  * If the user had scrolled outside the loaded window (>12h), it resets the timeline window anchored around now.

### Testing
* Built and verified on iOS Simulator.