### PR TITLE
Live TV: Support pipe-delimited stream URL headers and remove iOS UA setting

### DIFF
--- a/Rivulet/Services/Plex/Playback/AetherPlayer.swift
+++ b/Rivulet/Services/Plex/Playback/AetherPlayer.swift
@@ -703,10 +703,13 @@ final class AetherPlayer: PlayerProtocol {
     /// native path fails against a server (e.g. a Plex transcode session that
     /// rejects AVPlayer's request pattern).
     func loadLive(url: URL, headers: [String: String]?, forceEngineDemux: Bool = false) async throws {
-        let isHLS = Self.liveRoute(for: url, forceEngineDemux: forceEngineDemux) == .nativeHLS
+        let resolved = LiveTVClientIdentity.resolveStream(url: url, baseHeaders: headers ?? [:])
+        let streamURL = resolved.url
+        let streamHeaders = resolved.headers
+        let isHLS = Self.liveRoute(for: streamURL, forceEngineDemux: forceEngineDemux) == .nativeHLS
         let options = LoadOptions(
             suppressDisplayCriteria: false,
-            httpHeaders: headers ?? [:],
+            httpHeaders: streamHeaders,
             // Same rich config as VOD, plus the live-specific flags.
             matchContentEnabled: true,
             panelIsInHDRMode: Self.panelIsInHDRMode(),

--- a/Rivulet/Views/LiveTV/LiveTVAetherPlayerViewController.swift
+++ b/Rivulet/Views/LiveTV/LiveTVAetherPlayerViewController.swift
@@ -322,10 +322,16 @@ final class LiveTVAetherPlayerViewController: UIViewController {
             isNativeHLSRoute = route == .nativeHLS
             joinTelemetry?.resolveFinished(url: url, route: route)
             startLiveSessionKeepAlive(for: url)
+            var headers = LiveTVClientIdentity.streamHeaders
+            if let customHeaders = channel.httpHeaders {
+                for (k, v) in customHeaders {
+                    headers[k] = v
+                }
+            }
             do {
                 try await aether.loadLive(
                     url: url,
-                    headers: LiveTVClientIdentity.streamHeaders,
+                    headers: headers,
                     forceEngineDemux: forceEngineDemux
                 )
                 if Task.isCancelled { finishJoinTelemetry { $0.abandoned() }; return }
@@ -1239,10 +1245,16 @@ final class LiveTVAetherPlayerViewController: UIViewController {
                 let retryURL = Self.forcingDirectStream(freshURL)
                 let isPlaylist = AetherPlayer.liveRoute(for: retryURL,
                                                         forceEngineDemux: false) == .nativeHLS
+                var headers = LiveTVClientIdentity.streamHeaders
+                if let customHeaders = channel.httpHeaders {
+                    for (k, v) in customHeaders {
+                        headers[k] = v
+                    }
+                }
                 do {
                     aetherPlayer?.stop()
                     try await aetherPlayer?.loadLive(url: retryURL,
-                                                     headers: LiveTVClientIdentity.streamHeaders,
+                                                     headers: headers,
                                                      forceEngineDemux: !isPlaylist)
                     if Task.isCancelled { return }
                     aetherPlayer?.play()

--- a/Rivulet/Views/LiveTV/MultiStreamViewModel.swift
+++ b/Rivulet/Views/LiveTV/MultiStreamViewModel.swift
@@ -259,8 +259,13 @@ final class MultiStreamViewModel: ObservableObject {
             ]
             SentryBridge.addBreadcrumb(breadcrumb)
 
+            var headers = LiveTVClientIdentity.streamHeaders
+            if let customHeaders = channel.httpHeaders {
+                for (k, v) in customHeaders { headers[k] = v }
+            }
+
             do {
-                try await slot.load(url: url, headers: LiveTVClientIdentity.streamHeaders)
+                try await slot.load(url: url, headers: headers)
                 slot.setMuted(isMuted)
                 slot.play()
                 recoveryAttempts[slot.id] = 0
@@ -532,8 +537,13 @@ final class MultiStreamViewModel: ObservableObject {
             ]
             SentryBridge.addBreadcrumb(breadcrumb)
 
+            var headers = LiveTVClientIdentity.streamHeaders
+            if let customHeaders = channel.httpHeaders {
+                for (k, v) in customHeaders { headers[k] = v }
+            }
+
             do {
-                try await newSlot.load(url: url, headers: LiveTVClientIdentity.streamHeaders)
+                try await newSlot.load(url: url, headers: headers)
                 newSlot.setMuted(isMuted)
                 newSlot.play()
             } catch {
@@ -946,7 +956,11 @@ final class MultiStreamViewModel: ObservableObject {
         do {
             let slot = streams[slotIndex]
             let muted = slot.isMuted
-            try await slot.load(url: url, headers: LiveTVClientIdentity.streamHeaders)
+            var headers = LiveTVClientIdentity.streamHeaders
+            if let customHeaders = channel.httpHeaders {
+                for (k, v) in customHeaders { headers[k] = v }
+            }
+            try await slot.load(url: url, headers: headers)
             guard !Task.isCancelled,
                   !intentionallyStoppedSlots.contains(slotId),
                   streams.contains(where: { $0.id == slotId }) else { return }

--- a/RivuletCore/IPTV/M3UParser.swift
+++ b/RivuletCore/IPTV/M3UParser.swift
@@ -24,6 +24,27 @@ actor M3UParser {
         let channelNumber: Int?
         let name: String
         let streamURL: URL
+        let httpHeaders: [String: String]
+
+        init(
+            tvgId: String?,
+            tvgName: String?,
+            tvgLogo: String?,
+            groupTitle: String?,
+            channelNumber: Int?,
+            name: String,
+            streamURL: URL,
+            httpHeaders: [String: String] = [:]
+        ) {
+            self.tvgId = tvgId
+            self.tvgName = tvgName
+            self.tvgLogo = tvgLogo
+            self.groupTitle = groupTitle
+            self.channelNumber = channelNumber
+            self.name = name
+            self.streamURL = streamURL
+            self.httpHeaders = httpHeaders
+        }
 
         /// Whether this appears to be an HD channel (based on name)
         var isHD: Bool {
@@ -97,10 +118,16 @@ actor M3UParser {
             } else if line.hasPrefix("#") {
                 // Skip other directives
                 continue
-            } else if let extInf = currentExtInf, let url = URL(string: line) {
-                // This is a stream URL following an EXTINF
-                if let channel = parseChannel(extInf: extInf, streamURL: url) {
-                    channels.append(channel)
+            } else if let extInf = currentExtInf {
+                if let parsedStream = LiveTVClientIdentity.parseStreamURL(line) {
+                    // This is a stream URL following an EXTINF
+                    if let channel = parseChannel(
+                        extInf: extInf,
+                        streamURL: parsedStream.url,
+                        httpHeaders: parsedStream.headers
+                    ) {
+                        channels.append(channel)
+                    }
                 }
                 currentExtInf = nil
             }
@@ -112,7 +139,11 @@ actor M3UParser {
     // MARK: - Private Methods
 
     /// Parse a single channel from EXTINF line and stream URL
-    private func parseChannel(extInf: String, streamURL: URL) -> ParsedChannel? {
+    private func parseChannel(
+        extInf: String,
+        streamURL: URL,
+        httpHeaders: [String: String] = [:]
+    ) -> ParsedChannel? {
         // Parse the EXTINF line
         // Format: #EXTINF:-1 tvg-id="..." tvg-name="..." tvg-logo="..." group-title="..." tvg-chno="123",Channel Name
         // The comma separates attributes from the display name
@@ -144,7 +175,8 @@ actor M3UParser {
             groupTitle: groupTitle,
             channelNumber: channelNumber,
             name: name,
-            streamURL: streamURL
+            streamURL: streamURL,
+            httpHeaders: httpHeaders
         )
     }
 

--- a/RivuletCore/LiveTV/LiveTVClientIdentity.swift
+++ b/RivuletCore/LiveTV/LiveTVClientIdentity.swift
@@ -38,4 +38,66 @@ enum LiveTVClientIdentity {
     /// Headers attached to every Live TV stream load. Kept as a single value so
     /// the player call sites cannot drift apart from one another.
     static let streamHeaders: [String: String] = ["User-Agent": userAgent]
+
+    /// Parses a raw stream URL string that may contain pipe-delimited headers
+    /// (e.g. `http://host/stream.m3u8|User-Agent=CustomUA&Referer=...` or
+    /// `%7CUser-Agent=...`) into a sanitized URL and extracted headers dictionary.
+    ///
+    /// Popular IPTV players (such as TiviMate and Kodi IPTV Simple Client) support
+    /// appending HTTP headers to stream URLs after a pipe delimiter `|`.
+    static func parseStreamURL(_ rawString: String) -> (url: URL, headers: [String: String])? {
+        let trimmed = rawString.trimmingCharacters(in: .whitespacesAndNewlines)
+        let components: [String]
+        if let pipeRange = trimmed.range(of: "|") {
+            components = [String(trimmed[..<pipeRange.lowerBound]), String(trimmed[pipeRange.upperBound...])]
+        } else if let encPipeRange = trimmed.range(of: "%7C", options: .caseInsensitive) {
+            components = [String(trimmed[..<encPipeRange.lowerBound]), String(trimmed[encPipeRange.upperBound...])]
+        } else {
+            components = [trimmed]
+        }
+
+        guard let cleanURL = URL(string: components[0].trimmingCharacters(in: .whitespaces)) else {
+            return nil
+        }
+        var headers: [String: String] = [:]
+
+        if components.count > 1 {
+            let rawHeaderString = components[1]
+            let pairs = rawHeaderString.components(separatedBy: "&")
+            for pair in pairs {
+                let parts = pair.split(separator: "=", maxSplits: 1).map(String.init)
+                guard parts.count == 2 else { continue }
+                let rawKey = parts[0].trimmingCharacters(in: .whitespaces)
+                let rawVal = parts[1].trimmingCharacters(in: .whitespaces)
+                let val = rawVal.removingPercentEncoding ?? rawVal
+                guard !rawKey.isEmpty, !val.isEmpty else { continue }
+
+                if rawKey.caseInsensitiveCompare("User-Agent") == .orderedSame {
+                    headers["User-Agent"] = val
+                } else if rawKey.caseInsensitiveCompare("Referer") == .orderedSame {
+                    headers["Referer"] = val
+                } else {
+                    headers[rawKey] = val
+                }
+            }
+        }
+
+        return (cleanURL, headers)
+    }
+
+    /// Resolves and sanitizes a stream URL by stripping any pipe-delimited headers
+    /// and merging any discovered headers (such as `User-Agent`) into the provided stream headers.
+    static func resolveStream(url: URL, baseHeaders: [String: String] = streamHeaders) -> (url: URL, headers: [String: String]) {
+        guard let parsed = parseStreamURL(url.absoluteString) else {
+            return (url, baseHeaders)
+        }
+        guard !parsed.headers.isEmpty || parsed.url != url else {
+            return (url, baseHeaders)
+        }
+        var merged = baseHeaders
+        for (k, v) in parsed.headers {
+            merged[k] = v
+        }
+        return (parsed.url, merged)
+    }
 }

--- a/RivuletCore/LiveTV/LiveTVProvider.swift
+++ b/RivuletCore/LiveTV/LiveTVProvider.swift
@@ -50,6 +50,7 @@ struct UnifiedChannel: Identifiable, Hashable, Sendable {
     let tvgId: String?
     let groupTitle: String?
     let isHD: Bool
+    let httpHeaders: [String: String]?
 
     init(
         id: String,
@@ -62,7 +63,8 @@ struct UnifiedChannel: Identifiable, Hashable, Sendable {
         streamURL: URL? = nil,
         tvgId: String? = nil,
         groupTitle: String? = nil,
-        isHD: Bool = false
+        isHD: Bool = false,
+        httpHeaders: [String: String]? = nil
     ) {
         self.id = id
         self.sourceType = sourceType
@@ -75,6 +77,7 @@ struct UnifiedChannel: Identifiable, Hashable, Sendable {
         self.tvgId = tvgId
         self.groupTitle = groupTitle
         self.isHD = isHD
+        self.httpHeaders = httpHeaders
     }
 
     /// Create a unique identifier combining source and channel
@@ -277,7 +280,8 @@ extension M3UParser.ParsedChannel {
             streamURL: streamURL,
             tvgId: tvgId,
             groupTitle: groupTitle,
-            isHD: isHD
+            isHD: isHD,
+            httpHeaders: httpHeaders.isEmpty ? nil : httpHeaders
         )
     }
 }

--- a/RivuletTests/Unit/Parsers/M3UParserTests.swift
+++ b/RivuletTests/Unit/Parsers/M3UParserTests.swift
@@ -365,4 +365,35 @@ final class M3UParserTests: XCTestCase {
             }
         }
     }
+
+    // MARK: - Pipe-delimited headers
+
+    func testParsesStreamURLWithUserAgentPipe() async throws {
+        let content = """
+        #EXTM3U
+        #EXTINF:-1,Test Channel
+        http://example.com/live/stream.m3u8|User-Agent=CustomPlayer/1.0
+        """
+
+        let channels = try await parser.parse(content: content)
+
+        XCTAssertEqual(channels.count, 1)
+        XCTAssertEqual(channels[0].streamURL.absoluteString, "http://example.com/live/stream.m3u8")
+        XCTAssertEqual(channels[0].httpHeaders["User-Agent"], "CustomPlayer/1.0")
+    }
+
+    func testParsesStreamURLWithMultiplePipeHeaders() async throws {
+        let content = """
+        #EXTM3U
+        #EXTINF:-1,Test Channel
+        http://example.com/live/stream.m3u8|user-agent=Custom%20Player%202.0&Referer=http://foo.bar
+        """
+
+        let channels = try await parser.parse(content: content)
+
+        XCTAssertEqual(channels.count, 1)
+        XCTAssertEqual(channels[0].streamURL.absoluteString, "http://example.com/live/stream.m3u8")
+        XCTAssertEqual(channels[0].httpHeaders["User-Agent"], "Custom Player 2.0")
+        XCTAssertEqual(channels[0].httpHeaders["Referer"], "http://foo.bar")
+    }
 }

--- a/RivuletTests/Unit/Services/DispatcharrURLBuilderTests.swift
+++ b/RivuletTests/Unit/Services/DispatcharrURLBuilderTests.swift
@@ -168,4 +168,20 @@ final class DispatcharrURLBuilderTests: XCTestCase {
         XCTAssertTrue(agent.hasPrefix("Rivulet/"), "unexpected user agent: \(agent)")
         XCTAssertEqual(LiveTVClientIdentity.streamHeaders["User-Agent"], agent)
     }
+
+    func test_parseStreamURL_extractsUserAgentAndCleansURL() {
+        let raw = "http://example.com/live/ch1.m3u8|User-Agent=CustomUA%201.0&Referer=http://example.org"
+        let parsed = LiveTVClientIdentity.parseStreamURL(raw)
+        XCTAssertNotNil(parsed)
+        XCTAssertEqual(parsed?.url.absoluteString, "http://example.com/live/ch1.m3u8")
+        XCTAssertEqual(parsed?.headers["User-Agent"], "CustomUA 1.0")
+        XCTAssertEqual(parsed?.headers["Referer"], "http://example.org")
+    }
+
+    func test_resolveStream_overridesUserAgentFromURL() {
+        let url = URL(string: "http://example.com/live/ch1.m3u8%7CUser-Agent=CustomPlayer")!
+        let resolved = LiveTVClientIdentity.resolveStream(url: url)
+        XCTAssertEqual(resolved.url.absoluteString, "http://example.com/live/ch1.m3u8")
+        XCTAssertEqual(resolved.headers["User-Agent"], "CustomPlayer")
+    }
 }

--- a/RivuletiOS/LiveTV/IOSLiveTVStore.swift
+++ b/RivuletiOS/LiveTV/IOSLiveTVStore.swift
@@ -21,7 +21,6 @@ final class IOSLiveTVStore: ObservableObject {
 
     private(set) var m3uURLString: String
     private(set) var xmltvURLString: String
-    private(set) var userAgentString: String
     private(set) var authorizationHeaderString: String
     private(set) var refererString: String
     private var attemptedAutomaticLoad = false
@@ -29,7 +28,6 @@ final class IOSLiveTVStore: ObservableObject {
     private let defaults: UserDefaults
     private let m3uKey = "ios.liveTV.m3uURL"
     private let xmltvKey = "ios.liveTV.xmltvURL"
-    private let userAgentKey = "ios.liveTV.userAgent"
     private let authorizationHeaderKey = "ios.liveTV.authorizationHeader"
     private let refererKey = "ios.liveTV.referer"
 
@@ -37,7 +35,6 @@ final class IOSLiveTVStore: ObservableObject {
         self.defaults = defaults
         m3uURLString = defaults.string(forKey: m3uKey) ?? ""
         xmltvURLString = defaults.string(forKey: xmltvKey) ?? ""
-        userAgentString = defaults.string(forKey: userAgentKey) ?? ""
         authorizationHeaderString = defaults.string(forKey: authorizationHeaderKey) ?? ""
         refererString = defaults.string(forKey: refererKey) ?? ""
     }
@@ -66,13 +63,11 @@ final class IOSLiveTVStore: ObservableObject {
     func configureAndLoad(
         m3uURL: String,
         xmltvURL: String,
-        userAgent: String,
         authorizationHeader: String,
         referer: String
     ) async -> Bool {
         let playlist = m3uURL.trimmingCharacters(in: .whitespacesAndNewlines)
         let guide = xmltvURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        let trimmedUserAgent = userAgent.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedAuthorization = authorizationHeader.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedReferer = referer.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -87,12 +82,10 @@ final class IOSLiveTVStore: ObservableObject {
 
         m3uURLString = playlist
         xmltvURLString = guide
-        userAgentString = trimmedUserAgent
         authorizationHeaderString = trimmedAuthorization
         refererString = trimmedReferer
         defaults.set(playlist, forKey: m3uKey)
         defaults.set(guide, forKey: xmltvKey)
-        defaults.set(trimmedUserAgent, forKey: userAgentKey)
         defaults.set(trimmedAuthorization, forKey: authorizationHeaderKey)
         defaults.set(trimmedReferer, forKey: refererKey)
         await load()
@@ -159,12 +152,11 @@ final class IOSLiveTVStore: ObservableObject {
     func clearSource() {
         defaults.removeObject(forKey: m3uKey)
         defaults.removeObject(forKey: xmltvKey)
-        defaults.removeObject(forKey: userAgentKey)
+        defaults.removeObject(forKey: "ios.liveTV.userAgent")
         defaults.removeObject(forKey: authorizationHeaderKey)
         defaults.removeObject(forKey: refererKey)
         m3uURLString = ""
         xmltvURLString = ""
-        userAgentString = ""
         authorizationHeaderString = ""
         refererString = ""
         channels = []
@@ -209,10 +201,12 @@ final class IOSLiveTVStore: ObservableObject {
             // endpoints keep their streams on the same host.
             let sameOrigin = channel.streamURL.host?.caseInsensitiveCompare(sourceHost ?? "")
                 == .orderedSame
+            let customUA = channel.httpHeaders["User-Agent"]
+            let customReferer = channel.httpHeaders["Referer"]
             let channelHeaders = IOSPlaybackHeaders(
-                userAgent: playbackHeaders.userAgent,
+                userAgent: customUA ?? playbackHeaders.userAgent,
                 authorization: sameOrigin ? playbackHeaders.authorization : nil,
-                referer: playbackHeaders.referer
+                referer: customReferer ?? playbackHeaders.referer
             )
             let guideCandidates = [channel.tvgId, channel.tvgName, channel.name]
                 .compactMap { $0?.isEmpty == false ? $0 : nil }
@@ -322,9 +316,7 @@ final class IOSLiveTVStore: ObservableObject {
 
     private var playbackHeaders: IOSPlaybackHeaders {
         IOSPlaybackHeaders(
-            userAgent: userAgentString.isEmpty
-                ? LiveTVClientIdentity.userAgent
-                : userAgentString,
+            userAgent: LiveTVClientIdentity.userAgent,
             authorization: normalizedAuthorizationHeader,
             referer: refererString.nilIfEmpty
         )

--- a/RivuletiOS/LiveTV/IOSLiveTVView.swift
+++ b/RivuletiOS/LiveTV/IOSLiveTVView.swift
@@ -192,7 +192,6 @@ private struct IOSLiveTVSourceView: View {
 
     @State private var m3uURL: String
     @State private var xmltvURL: String
-    @State private var userAgent: String
     @State private var authorizationHeader: String
     @State private var referer: String
 
@@ -200,7 +199,6 @@ private struct IOSLiveTVSourceView: View {
         self.store = store
         _m3uURL = State(initialValue: store.m3uURLString)
         _xmltvURL = State(initialValue: store.xmltvURLString)
-        _userAgent = State(initialValue: store.userAgentString)
         _authorizationHeader = State(initialValue: store.authorizationHeaderString)
         _referer = State(initialValue: store.refererString)
     }
@@ -233,12 +231,6 @@ private struct IOSLiveTVSourceView: View {
                 }
 
                 Section {
-                    LabeledContent("User-Agent") {
-                        TextField(LiveTVClientIdentity.userAgent, text: $userAgent)
-                            .multilineTextAlignment(.trailing)
-                            .textInputAutocapitalization(.never)
-                            .autocorrectionDisabled()
-                    }
                     LabeledContent("Authorization") {
                         SecureField("Optional", text: $authorizationHeader)
                             .multilineTextAlignment(.trailing)
@@ -255,7 +247,7 @@ private struct IOSLiveTVSourceView: View {
                 } header: {
                     Text("HTTP headers (optional)")
                 } footer: {
-                    Text("A bare Authorization value is treated as a Dispatcharr API token; otherwise enter the complete Bearer, Basic, or Token value. Blank User-Agent uses \(LiveTVClientIdentity.userAgent). Authorization is only forwarded to same-host streams; User-Agent and Referer apply to all requests.")
+                    Text("A bare Authorization value is treated as a Dispatcharr API token; otherwise enter the complete Bearer, Basic, or Token value. Authorization is only forwarded to same-host streams; Referer applies to all requests. Streams identify as \(LiveTVClientIdentity.userAgent) unless a custom User-Agent is specified in the stream URL via |User-Agent=.")
                 }
 
                 if case .failed(let message) = store.state {
@@ -271,7 +263,6 @@ private struct IOSLiveTVSourceView: View {
                             let loaded = await store.configureAndLoad(
                                 m3uURL: m3uURL,
                                 xmltvURL: xmltvURL,
-                                userAgent: userAgent,
                                 authorizationHeader: authorizationHeader,
                                 referer: referer
                             )

--- a/RivuletiOS/Player/AetherPlayer.swift
+++ b/RivuletiOS/Player/AetherPlayer.swift
@@ -259,11 +259,14 @@ final class AetherPlayer: ObservableObject {
 
     func loadLive(url: URL, headers: [String: String]? = nil) async throws {
         state = .loading
-        let isHLS = url.pathExtension.lowercased() == "m3u8"
-            || url.absoluteString.lowercased().contains("format=hls")
+        let resolved = LiveTVClientIdentity.resolveStream(url: url, baseHeaders: headers ?? [:])
+        let streamURL = resolved.url
+        let streamHeaders = resolved.headers
+        let isHLS = streamURL.pathExtension.lowercased() == "m3u8"
+            || streamURL.absoluteString.lowercased().contains("format=hls")
         let options = LoadOptions(
             suppressDisplayCriteria: false,
-            httpHeaders: headers ?? [:],
+            httpHeaders: streamHeaders,
             matchContentEnabled: true,
             panelIsInHDRMode: false,
             audioBridgeMode: .lossless,


### PR DESCRIPTION
### Summary
1. **Support Pipe-Delimited Stream Headers (`|User-Agent=...`)**:
   * Supports the standard IPTV syntax used by players like TiviMate and Kodi (`<URL>|User-Agent=<UA>&Referer=<Referer>`).
   * `M3UParser` extracts pipe-delimited headers into `httpHeaders` and sanitizes the stream URL before initializing `ParsedChannel`.
   * Both tvOS and iOS players (`AetherPlayer.loadLive`, `MultiStreamViewModel`, and `IOSAetherPlayerView`) forward custom headers and sanitize any runtime stream URLs via `LiveTVClientIdentity.resolveStream(url:baseHeaders:)`.

2. **Remove User-Agent Setting from iOS Tab**:
   * Removed the explicit User-Agent text input from the iOS Live TV Source Settings screen.
   * Streams identify with the standard `LiveTVClientIdentity.userAgent` (`Rivulet/<version>`) unless a custom User-Agent is authored directly in the stream link via `|User-Agent=`.

### Testing
* Added unit tests in `M3UParserTests` and `DispatcharrURLBuilderTests` for URL sanitization and header extraction.
* Built and passed all unit tests on tvOS and iOS simulators.